### PR TITLE
Add json map for Carthage binary support

### DIFF
--- a/RadarSDK.json
+++ b/RadarSDK.json
@@ -10,5 +10,5 @@
   "2.1.0": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.0/RadarSDK.framework.zip",
   "2.1.1": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.1/RadarSDK.framework.zip",
   "2.1.2": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.2/RadarSDK.framework.zip",
-  "2.1.3": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.3/RadarSDK.framework.zip",
+  "2.1.3": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.3/RadarSDK.framework.zip"
 }

--- a/RadarSDK.json
+++ b/RadarSDK.json
@@ -1,0 +1,14 @@
+{
+  "2.0.0": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.0/RadarSDK.framework.zip",
+  "2.0.1": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.1/RadarSDK.framework.zip",
+  "2.0.2": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.2/RadarSDK.framework.zip",
+  "2.0.3": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.3/RadarSDK.framework.zip",
+  "2.0.4": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.4/RadarSDK.framework.zip",
+  "2.0.5": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.5/RadarSDK.framework.zip",
+  "2.0.6": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.6/RadarSDK.framework.zip",
+  "2.0.7": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.0.7/RadarSDK.framework.zip",
+  "2.1.0": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.0/RadarSDK.framework.zip",
+  "2.1.1": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.1/RadarSDK.framework.zip",
+  "2.1.2": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.2/RadarSDK.framework.zip",
+  "2.1.3": "https://github.com/radarlabs/radar-sdk-ios/releases/download/2.1.3/RadarSDK.framework.zip",
+}


### PR DESCRIPTION
This lets Carthage users to grab our binary directly in their Cartfile with:
```
binary "https://raw.githubusercontent.com/radarlabs/radar-sdk-ios/master/RadarSDK.json"
```