### PR TITLE
Add 'flag' to RadarRegion

### DIFF
--- a/RadarSDK/RadarRegion+Internal.h
+++ b/RadarSDK/RadarRegion+Internal.h
@@ -9,7 +9,12 @@
 
 @interface RadarRegion ()
 
-- (nonnull instancetype)initWithId:(nonnull NSString *)_id name:(nonnull NSString *)name code:(nonnull NSString *)code type:(nonnull NSString *)type;
+- (nonnull instancetype)initWithId:(nonnull NSString *)_id
+                              name:(nonnull NSString *)name
+                              code:(nonnull NSString *)code
+                              type:(nonnull NSString *)type
+                              flag:(nullable NSString *)flag;
+
 - (nullable instancetype)initWithObject:(nullable id)object;
 
 @end

--- a/RadarSDK/RadarRegion.h
+++ b/RadarSDK/RadarRegion.h
@@ -36,6 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonnull, copy, nonatomic, readonly) NSString *type;
 
+/**
+ The (optional) flag of the region.
+ */
+@property (nullable, copy, nonatomic, readonly) NSString *flag;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarRegion.m
+++ b/RadarSDK/RadarRegion.m
@@ -9,13 +9,18 @@
 
 @implementation RadarRegion
 
-- (instancetype)initWithId:(nonnull NSString *)_id name:(nonnull NSString *)name code:(nonnull NSString *)code type:(nonnull NSString *)type {
+- (instancetype)initWithId:(nonnull NSString *)_id
+                      name:(nonnull NSString *)name
+                      code:(nonnull NSString *)code
+                      type:(nonnull NSString *)type
+                      flag:(nullable NSString *)flag {
     self = [super init];
     if (self) {
         __id = _id;
         _name = name;
         _code = code;
         _type = type;
+        _flag = flag;
     }
     return self;
 }
@@ -31,6 +36,7 @@
     NSString *name = @"";
     NSString *code = @"";
     NSString *type = @"";
+    NSString *flag = @"";
     
     id eventIdObj = regionDict[@"_id"];
     if ([eventIdObj isKindOfClass:[NSString class]]) {
@@ -51,8 +57,13 @@
     if ([eventTypeObj isKindOfClass:[NSString class]]) {
         type = (NSString *)eventTypeObj;
     }
+
+    id flagObj = regionDict[@"flag"];
+    if (flagObj && [flagObj isKindOfClass:[NSString class]]) {
+        flag = (NSString *)flagObj;
+    }
     
-    return [[RadarRegion alloc] initWithId:_id name:name code:code type:type];
+    return [[RadarRegion alloc] initWithId:_id name:name code:code type:type flag:flag];
 }
 
 @end


### PR DESCRIPTION
From the API spec, 'flag' is new for `RadarRegion` -- https://docs.google.com/document/d/1HQtkbe4A7TaIjTgH1BH4zYkD5xYhUyMAJt3zqVWZ1W0
```
RadarRegion: {
  flag: String? // new
}
```
