### PR TITLE
Reverse geocode current location

### DIFF
--- a/RadarSDK/Radar.h
+++ b/RadarSDK/Radar.h
@@ -381,13 +381,19 @@ typedef void(^ _Nonnull RadarIPGeocodeCompletionHandler)(RadarStatus status, Rad
         completionHandler:(RadarGeocodeCompletionHandler)completionHandler;
 
 /**
+ Gets the device's current location, then geocodes that location, returning an array of addresses.
+ @param completionHandler A completion handler.
+ */
++(void)reverseGeocode:(RadarGeocodeCompletionHandler)completionHandler;
+
+/**
  Geocodes a given location [(lat, lng) pair], returning an array of addresses.
 
  @param location The location to geocode.
  @param completionHandler A completion handler.
  */
-+ (void)reverseGeocode:(CLLocation * _Nonnull)location
-     completionHandler:(RadarGeocodeCompletionHandler)completionHandler;
++ (void)reverseGeocodeLocation:(CLLocation * _Nonnull)location
+             completionHandler:(RadarGeocodeCompletionHandler)completionHandler;
 
 /**
  Geocodes the device's IP address, returning a region.

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -185,7 +185,20 @@
     }];
 }
 
-+ (void)reverseGeocode:(CLLocation *)location completionHandler:(RadarGeocodeCompletionHandler)completionHandler {
++ (void)reverseGeocode:(RadarGeocodeCompletionHandler)completionHandler {
+    [[RadarLocationManager sharedInstance] getLocationWithCompletionHandler:^(RadarStatus status, CLLocation * _Nullable location, BOOL stopped) {
+        if (status != RadarStatusSuccess) {
+            return completionHandler(status, nil);
+        }
+
+        [[RadarAPIClient sharedInstance] reverseGeocode:location completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, NSArray<RadarAddress *> * _Nullable addresses) {
+            completionHandler(status, addresses);
+        }];
+    }];
+}
+
++ (void)reverseGeocodeLocation:(CLLocation *)location
+             completionHandler:(RadarGeocodeCompletionHandler)completionHandler {
     [[RadarAPIClient sharedInstance] reverseGeocode:location completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, NSArray<RadarAddress *> * _Nullable addresses) {
         completionHandler(status, addresses);
     }];


### PR DESCRIPTION
The previous PR (https://github.com/radarlabs/radar-sdk-ios/pull/41) only had support for sending an explicit location to be reverse geocoded.

This PR adds the ability to reverse geocode the user's current location using `RadarLocationManager`, as we have for search endpoints -- https://github.com/radarlabs/radar-sdk-ios/blob/v3/RadarSDK/Radar.h#L313-L341

Once there's confirmation about the method signatures, I can do the same for the Android SDK