### PR TITLE
Geocode Custom IP

### DIFF
--- a/RadarSDK/Radar.h
+++ b/RadarSDK/Radar.h
@@ -403,6 +403,12 @@ typedef void(^ _Nonnull RadarIPGeocodeCompletionHandler)(RadarStatus status, Rad
 + (void)ipGeocode:(RadarIPGeocodeCompletionHandler)completionHandler;
 
 /**
+ Geocodes a provided IP address, returning a region.
+ */
++ (void)ipGeocode:(NSString * _Nonnull)ip
+completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler;
+
+/**
  Sets the log level for debug logs.
  
  @param level The log level.

--- a/RadarSDK/Radar.h
+++ b/RadarSDK/Radar.h
@@ -400,15 +400,15 @@ typedef void(^ _Nonnull RadarIPGeocodeCompletionHandler)(RadarStatus status, Rad
 
  @param completionHandler A completion handler.
  */
-+ (void)ipGeocode:(RadarIPGeocodeCompletionHandler)completionHandler;
++ (void)geocodeDeviceIP:(RadarIPGeocodeCompletionHandler)completionHandler;
 
 /**
  Geocodes a provided IP address, returning a region.
 
- @param ip The IP address to geocode.
+ @param IP The IP address to geocode.
  @param completionHandler A completion handler.
  */
-+ (void)ipGeocode:(NSString * _Nonnull)ip
++ (void)geocodeIP:(NSString * _Nonnull)IP
 completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler;
 
 /**

--- a/RadarSDK/Radar.h
+++ b/RadarSDK/Radar.h
@@ -404,6 +404,9 @@ typedef void(^ _Nonnull RadarIPGeocodeCompletionHandler)(RadarStatus status, Rad
 
 /**
  Geocodes a provided IP address, returning a region.
+
+ @param ip The IP address to geocode.
+ @param completionHandler A completion handler.
  */
 + (void)ipGeocode:(NSString * _Nonnull)ip
 completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler;

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -204,14 +204,14 @@
     }];
 }
 
-+ (void)ipGeocode:(RadarIPGeocodeCompletionHandler)completionHandler {
++ (void)geocodeDeviceIP:(RadarIPGeocodeCompletionHandler)completionHandler {
     [[RadarAPIClient sharedInstance] ipGeocode:nil completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
         completionHandler(status, country);
     }];
 }
 
-+ (void)ipGeocode:(NSString * _Nonnull)ip completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler {
-    [[RadarAPIClient sharedInstance] ipGeocode:ip completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
++ (void)geocodeIP:(NSString *)IP completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler {
+    [[RadarAPIClient sharedInstance] ipGeocode:IP completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
         completionHandler(status, country);
     }];
 }

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -205,7 +205,13 @@
 }
 
 + (void)ipGeocode:(RadarIPGeocodeCompletionHandler)completionHandler {
-    [[RadarAPIClient sharedInstance] ipGeocode:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
+    [[RadarAPIClient sharedInstance] ipGeocode:nil completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
+        completionHandler(status, country);
+    }];
+}
+
++ (void)ipGeocode:(NSString * _Nonnull)ip completionHandler:(RadarIPGeocodeCompletionHandler)completionHandler {
+    [[RadarAPIClient sharedInstance] ipGeocode:ip completionHandler:^(RadarStatus status, NSDictionary * _Nullable res, RadarRegion * _Nullable country) {
         completionHandler(status, country);
     }];
 }

--- a/RadarSDK/RadarAPIClient.h
+++ b/RadarSDK/RadarAPIClient.h
@@ -66,7 +66,8 @@ typedef void(^ _Nullable RadarIPGeocodeAPICompletionHandler)(RadarStatus status,
 - (void)reverseGeocode:(CLLocation * _Nonnull)location
      completionHandler:(RadarGeocodeAPICompletionHandler _Nullable)completionHandler;
 
-- (void)ipGeocode:(RadarIPGeocodeAPICompletionHandler _Nullable)completionHandler;
+- (void)ipGeocode:(NSString * _Nullable)ip
+completionHandler:(RadarIPGeocodeAPICompletionHandler _Nullable)completionHandler;
 
 @end
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -462,14 +462,24 @@
     }];
 }
 
-- (void)ipGeocode:(RadarIPGeocodeAPICompletionHandler)completionHandler {
+- (void)ipGeocode:(NSString *)ip completionHandler:(RadarIPGeocodeAPICompletionHandler)completionHandler {
     NSString *publishableKey = [RadarSettings publishableKey];
     if (!publishableKey) {
         return completionHandler(RadarStatusErrorPublishableKey, nil, nil);
     }
 
     NSString *host = [RadarSettings host];
-    NSString *url = [NSString stringWithFormat:@"%@/v1/geocode/ip", host];
+
+    NSString *url;
+    if (ip && ip.length > 0) {
+        NSMutableString *qs = [NSMutableString new];
+        [qs appendFormat:@"ip=%@", ip];
+
+        url = [NSString stringWithFormat:@"%@/v1/geocode/ip?%@", host, qs];
+    } else {
+        url = [NSString stringWithFormat:@"%@/v1/geocode/ip", host];
+    }
+
     url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
 
     NSDictionary *headers = @{

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -799,6 +799,47 @@ static NSString * const kPublishableKey = @"prj_test_pk_000000000000000000000000
     }];
 }
 
+- (void)test_Radar_ipGeocodeIP_error {
+    self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
+    self.apiHelperMock.mockStatus = RadarStatusErrorServer;
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+
+    [Radar ipGeocode:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
+        XCTAssertEqual(status, RadarStatusErrorServer);
+        XCTAssertNil(country);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError * _Nullable error) {
+        if (error) {
+            XCTFail();
+        }
+    }];
+}
+
+- (void)test_Radar_ipGeocodeIP_success {
+    self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
+    self.apiHelperMock.mockStatus = RadarStatusSuccess;
+    self.apiHelperMock.mockResponse = [RadarSDKTestUtils jsonDictionaryFromResource:@"ipGeocode"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+
+    [Radar ipGeocode:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
+        XCTAssertEqual(status, RadarStatusSuccess);
+        XCTAssertNotNil(country);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError * _Nullable error) {
+        if (error) {
+            XCTFail();
+        }
+    }];
+}
+
 - (void)test_RadarTrackingOptions_isEqual {
     RadarTrackingOptions *options = RadarTrackingOptions.efficient;
     XCTAssertNotEqualObjects(options, nil);

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -758,13 +758,13 @@ static NSString * const kPublishableKey = @"prj_test_pk_000000000000000000000000
     }];
 }
 
-- (void)test_Radar_ipGeocode_error {
+- (void)test_Radar_geocodeDeviceIP_error {
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusErrorServer;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocode:^(RadarStatus status, RadarRegion * _Nullable country) {
+    [Radar geocodeDeviceIP:^(RadarStatus status, RadarRegion * _Nullable country) {
         XCTAssertEqual(status, RadarStatusErrorServer);
         XCTAssertNil(country);
 
@@ -778,14 +778,14 @@ static NSString * const kPublishableKey = @"prj_test_pk_000000000000000000000000
     }];
 }
 
-- (void)test_Radar_ipGeocode_success {
+- (void)test_Radar_geocodeDeviceIP_success {
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusSuccess;
     self.apiHelperMock.mockResponse = [RadarSDKTestUtils jsonDictionaryFromResource:@"ipGeocode"];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocode:^(RadarStatus status, RadarRegion * _Nullable country) {
+    [Radar geocodeDeviceIP:^(RadarStatus status, RadarRegion * _Nullable country) {
         XCTAssertEqual(status, RadarStatusSuccess);
         XCTAssertNotNil(country);
 
@@ -799,13 +799,13 @@ static NSString * const kPublishableKey = @"prj_test_pk_000000000000000000000000
     }];
 }
 
-- (void)test_Radar_ipGeocodeIP_error {
+- (void)test_Radar_geocodeIP_error {
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusErrorServer;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocode:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
+    [Radar geocodeIP:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
         XCTAssertEqual(status, RadarStatusErrorServer);
         XCTAssertNil(country);
 
@@ -819,14 +819,14 @@ static NSString * const kPublishableKey = @"prj_test_pk_000000000000000000000000
     }];
 }
 
-- (void)test_Radar_ipGeocodeIP_success {
+- (void)test_Radar_geocodeIP_success {
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusSuccess;
     self.apiHelperMock.mockResponse = [RadarSDKTestUtils jsonDictionaryFromResource:@"ipGeocode"];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocode:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
+    [Radar geocodeIP:@"192.0.2.28" completionHandler:^(RadarStatus status, RadarRegion * _Nullable country) {
         XCTAssertEqual(status, RadarStatusSuccess);
         XCTAssertNotNil(country);
 


### PR DESCRIPTION
The previous PR (#41) only had support for geocoding the IP address of the user's device.

This PR adds the ability to geocode a *custom / provided* IP address.