### PR TITLE
dont trust CLVisits as stops

### DIFF
--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -518,7 +518,7 @@ static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
             if (duration == 0) {
                 duration = -[location.timestamp timeIntervalSinceNow];
             }
-            stopped = (distance <= options.stopDistance && duration >= options.stopDuration) || source == RadarLocationSourceVisitArrival;
+            stopped = distance <= options.stopDistance && duration >= options.stopDuration;
 
             [[RadarLogger sharedInstance]
                 logWithLevel:RadarLogLevelDebug
@@ -534,7 +534,7 @@ static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
             }
         }
     } else {
-        stopped = (force || source == RadarLocationSourceVisitArrival);
+        stopped = force;
     }
     BOOL justStopped = stopped && !wasStopped;
     [RadarState setStopped:stopped];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -534,7 +534,7 @@ static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
             }
         }
     } else {
-        stopped = force;
+        stopped = (force || source == RadarLocationSourceVisitArrival);
     }
     BOOL justStopped = stopped && !wasStopped;
     [RadarState setStopped:stopped];


### PR DESCRIPTION
@nickpatrick and I were observing that quite often `CLVisit`s don't represent actual stops.  Useful as a location, but not a great signal for a real stop