### PR TITLE
[7855] Clean up some warnings

### DIFF
--- a/RadarSDK/RadarBeaconManager.m
+++ b/RadarSDK/RadarBeaconManager.m
@@ -120,7 +120,9 @@
 
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Beacon ranging not available"];
 
-        completionHandler(RadarStatusErrorBluetooth, nil);
+        if (completionHandler) {
+            completionHandler(RadarStatusErrorBluetooth, nil);
+        }
 
         return;
     }

--- a/RadarSDK/RadarLog.h
+++ b/RadarSDK/RadarLog.h
@@ -41,6 +41,6 @@
 
  @return A display string for the log level.
  */
-+ (NSString *)stringForLogLevel:(RadarLogLevel)level NS_SWIFT_NAME(stringForLogLevel(_:));
++ (NSString *_Nonnull)stringForLogLevel:(RadarLogLevel)level NS_SWIFT_NAME(stringForLogLevel(_:));
 
 @end


### PR DESCRIPTION
This is a very small PR that cleans up a warning in the new logging code, as well as a static analysis warning about calling a potentially nil completion handler.