### PR TITLE
[sc-8770] Update the version number to 3.3.1(-beta.1)

### DIFF
--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.3.1'
+  s.version               = '3.3.1-beta.1'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.3.1";
+    return @"3.3.1-beta.1";
 }
 
 + (NSString *)adId {


### PR DESCRIPTION
[[sc-8770] [project] Update the version number to 3.3.1(-beta.1)](https://app.shortcut.com/radarlabs/story/8770/ios-sdk-3-3-1-sdk-release)

This is a tiny due-diligence PR to assign a beta version number for `develop`.

**Merge this before #153.**