### PR TITLE
[sc-8770] 3.3.1 SDK release

### DIFF
--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.3.1-beta.1'
+  s.version               = '3.3.1'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.3.1-beta.1";
+    return @"3.3.1";
 }
 
 + (NSString *)adId {


### PR DESCRIPTION
[[sc-8770] [iOS SDK] 3.3.1 SDK release](https://app.shortcut.com/radarlabs/story/8770)

* Drop the `-beta.1` from the version number.