### PR TITLE
sc-9378: Clarified the RadarGeofence.geometry comment

### DIFF
--- a/RadarSDK/Include/RadarGeofence.h
+++ b/RadarSDK/Include/RadarGeofence.h
@@ -41,7 +41,7 @@
 @property (nullable, copy, nonatomic, readonly) NSDictionary *metadata;
 
 /**
- The geometry of the geofence.
+ The geometry of the geofence, which can be cast to either `RadarCircleGeometry` or `RadarPolygonGeometry`.
  */
 @property (nonnull, strong, nonatomic, readonly) RadarGeofenceGeometry *geometry;
 


### PR DESCRIPTION
[sc-9378: [iOS SDK] Improve the docs for RadarGeofence.geometry](https://app.shortcut.com/radarlabs/story/9378/ios-sdk-improve-the-docs-for-radargeofence-geometry)


Now it points out that this will be an instance of one of the `RadarGeofenceGeometry` subclasses. I wanted to add some sample code for casting a `geometry` object, but Objective-C comments don't support the ``` Markdown syntax for code snippets.