### PR TITLE
[9522] More downstream version bump changes

### DIFF
--- a/.github/workflows/downstream-version-bump.yml
+++ b/.github/workflows/downstream-version-bump.yml
@@ -10,13 +10,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  notify:
-    runs-on: macos-latest
+  dispatch:
+    strategy:
+      matrix:
+        repo: [
+          'radarlabs/react-native-radar',
+          'radarlabs/capacitor-radar',
+          'radarlabs/flutter-radar',
+          'radarlabs/radar-sdk-xamarin',
+          'radarlabs/cordova-plugin-radar',
+        ]
+    runs-on: -latest
     steps:
-      - name:
+      - name: Dispatch to downtream SDKs
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.RADAR_CIRCLECI_PAT }}
-          repository: radarlabs/react-native-radar
+          repository: ${{ matrix.repo }}
           event-type: ios-sdk-release
           client-payload: '{"release": "${{ github.event.release.tag_name }}"}'

--- a/.github/workflows/downstream-version-bump.yml
+++ b/.github/workflows/downstream-version-bump.yml
@@ -20,7 +20,7 @@ jobs:
           'radarlabs/radar-sdk-xamarin',
           'radarlabs/cordova-plugin-radar',
         ]
-    runs-on: -latest
+    runs-on: macos-latest
     steps:
       - name: Dispatch to downtream SDKs
         uses: peter-evans/repository-dispatch@v2
@@ -28,4 +28,4 @@ jobs:
           token: ${{ secrets.RADAR_CIRCLECI_PAT }}
           repository: ${{ matrix.repo }}
           event-type: ios-sdk-release
-          client-payload: '{"release": "${{ github.event.release.tag_name }}"}'
+          client-payload: '{"release": "${{ github.event.release.tag_name }}", "platform": "ios"}'


### PR DESCRIPTION
## Summary
- Dispatch events to all downstream SDKs
- Add `platform: iOS` to client payload