### PR TITLE
[sc-9788] Removed the RadarSettings.listenToServerTrackingOptions accessors

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -227,9 +227,8 @@
 
     // NOTE: this is sent up for measuring number of clients set on
     // remote tracking options
-    if ([RadarSettings listenToServerTrackingOptions]) {
-        params[@"listenToServer"] = @(YES);
-    }
+    BOOL usingRemoteTrackingOptions = RadarSettings.tracking && RadarSettings.remoteTrackingOptions;
+    params[@"usingRemoteTrackingOptions"] = @(usingRemoteTrackingOptions);
 
     NSString *host = [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -198,7 +198,6 @@ static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
 
 - (void)stopTracking {
     [RadarSettings setTracking:NO];
-    [RadarSettings setListenToServerTrackingOptions:NO];
     [self updateTracking];
 }
 
@@ -387,14 +386,12 @@ static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
     if (meta) {
         if ([meta trackingOptions]) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
-                                               message:@"Listening to server tracking options"];
-            [RadarSettings setListenToServerTrackingOptions:YES];
+                                               message:[NSString stringWithFormat:@"Setting remote tracking options | trackingOptions = %@", meta.trackingOptions]];
             [RadarSettings setRemoteTrackingOptions:[meta trackingOptions]];
         } else {
-            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
-                                               message:@"Not listening to server tracking options; reverting to fallback values"];
-            [RadarSettings setListenToServerTrackingOptions:NO];
             [RadarSettings removeRemoteTrackingOptions];
+            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                               message:[NSString stringWithFormat:@"Removed remote tracking options | trackingOptions = %@", Radar.getTrackingOptions]];
         }
         [self updateTracking];
     }

--- a/RadarSDK/RadarSettings.h
+++ b/RadarSDK/RadarSettings.h
@@ -32,8 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setAdIdEnabled:(BOOL)enabled;
 + (BOOL)tracking;
 + (void)setTracking:(BOOL)tracking;
-+ (BOOL)listenToServerTrackingOptions;
-+ (void)setListenToServerTrackingOptions:(BOOL)listenToServerTrackingOptions;
 + (RadarTrackingOptions *_Nullable)trackingOptions;
 + (void)setTrackingOptions:(RadarTrackingOptions *_Nonnull)options;
 + (RadarTrackingOptions *_Nullable)remoteTrackingOptions;

--- a/RadarSDK/RadarSettings.m
+++ b/RadarSDK/RadarSettings.m
@@ -23,7 +23,6 @@ static NSString *const kAdIdEnabled = @"radar-adIdEnabled";
 static NSString *const kTracking = @"radar-tracking";
 static NSString *const kTrackingOptions = @"radar-trackingOptions";
 static NSString *const kRemoteTrackingOptions = @"radar-remoteTrackingOptions";
-static NSString *const kListenToServerTrackingOptions = @"radar-listenToServerTrackingOptions";
 static NSString *const kTripOptions = @"radar-tripOptions";
 static NSString *const kLogLevel = @"radar-logLevel";
 static NSString *const kHost = @"radar-host";
@@ -113,14 +112,6 @@ static NSString *const kDefaultHost = @"https://api.radar.io";
 
 + (void)setTracking:(BOOL)tracking {
     [[NSUserDefaults standardUserDefaults] setBool:tracking forKey:kTracking];
-}
-
-+ (void)setListenToServerTrackingOptions:(BOOL)listenToServerTrackingOptions {
-    [[NSUserDefaults standardUserDefaults] setBool:listenToServerTrackingOptions forKey:kListenToServerTrackingOptions];
-}
-
-+(BOOL)listenToServerTrackingOptions {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:kListenToServerTrackingOptions];
 }
 
 + (RadarTrackingOptions *)trackingOptions {


### PR DESCRIPTION
[sc-9788: [iOS SDK] Rename listenToServer to usingRemoteTrackingOptions](https://app.shortcut.com/radarlabs/story/9788/ios-sdk-rename-listentoserver-to-usingremotetrackingoptions)

**This is the iOS counterpart to [the Android SDK PR 211](https://github.com/radarlabs/radar-sdk-android/pull/211).**