### PR TITLE
[Automation] Bump Versions on Released instead of Published 

### DIFF
--- a/.github/workflows/downstream-version-bump.yml
+++ b/.github/workflows/downstream-version-bump.yml
@@ -4,7 +4,7 @@ name: Downstream version bump
 on:
   # Triggered when a new release is tagged in GitHub.
   release:
-    types: [ published ]
+    types: [ released ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Bump downstream SDK versions on `released` instead of `published`. See [these docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) for more context.