### PR TITLE
sc-10396: RadarLocationManager.updateTrackingFromMeta(:) now calls .updateTrackingFromInitialize()

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -786,7 +786,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -816,7 +816,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -367,7 +367,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
             [self removeAllRegions];
 
             // If updateTracking() was called from the RadarLocationManager
-            // intializer, don't tell the CLLocationManager to stop, because
+            // initializer, don't tell the CLLocationManager to stop, because
             // the location manager may be in use by other location-based
             // services. Currently, only the initializer passes in YES, and all
             // subsequent calls to updateTracking() get NO.
@@ -390,7 +390,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Removed remote tracking options | trackingOptions = %@", Radar.getTrackingOptions]];
         }
-        [self updateTracking];
+        [self updateTrackingFromInitialize];
     }
 }
 


### PR DESCRIPTION
[sc-10396: [iOS SDK] RadarLocationManager.updateTrackingFromMeta() should call .updateTrackingFromInitialize()](https://app.shortcut.com/radarlabs/story/10396/ios-sdk-radarlocationmanager-updatetrackingfrommeta-should-call-updatetrackingfrominitialize)

`RadarLocationManager.updateTrackingFromMeta(:)` now calls `.updateTrackingFromInitialize()` instead of `.updateTracking()`, because visits and significant location updates should not be stopped when remote tracking options are applied.

See also [sc-8335: Add guards against stopping CLVisits and SLCs from initializing Radar (SDK P1)](https://app.shortcut.com/radarlabs/story/8335/add-guards-against-stopping-clvisits-and-slcs-from-initializing-radar-sdk-p1), when we first addressed this.