### PR TITLE
Updates logger to os_log

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -27,6 +27,7 @@
 #import "RadarTripOptions.h"
 #import "RadarUser+Internal.h"
 #import "RadarUtils.h"
+#import <os/log.h>
 
 @implementation RadarAPIClient
 
@@ -902,7 +903,7 @@
     }
     [queryString appendFormat:@"&units=%@", unitsStr];
 
-    NSLog(@"%@", queryString);
+    os_log(OS_LOG_DEFAULT, "%@", queryString);
 
     NSString *host = [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/route/matrix?%@", host, queryString];

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -10,6 +10,7 @@
 #import "RadarDelegateHolder.h"
 #import "RadarSettings.h"
 #import "RadarUtils.h"
+#import <os/log.h>
 
 @implementation RadarLogger
 
@@ -30,7 +31,7 @@
         if (logLevel >= level) {
             NSString *log = [NSString stringWithFormat:@"%@ | backgroundTimeRemaining = %g", message, [RadarUtils backgroundTimeRemaining]];
 
-            NSLog(@"%@", log);
+            os_log(OS_LOG_DEFAULT, "%@", log);
 
             [[RadarDelegateHolder sharedInstance] didLogMessage:log];
         }


### PR DESCRIPTION
Small suggestion to use the newer os_log method.

Tested by pointing our podfile to the fork locally. All log messages appear to be present as expected.