### PR TITLE
sc-10569: Add RadarTripOptions.scheduledArrivalAt & RadarEventTypeUserDwelledInGeofence

### DIFF
--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.4.3'
+  s.version               = '3.4.4'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -790,7 +790,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.3;
+				MARKETING_VERSION = 3.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -820,7 +820,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.3;
+				MARKETING_VERSION = 3.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/RadarSDK/Include/RadarEvent.h
+++ b/RadarSDK/Include/RadarEvent.h
@@ -61,7 +61,9 @@ typedef NS_ENUM(NSInteger, RadarEventType) {
     /// `user.entered_region_postal_code`
     RadarEventTypeUserEnteredRegionPostalCode NS_SWIFT_NAME(userEnteredRegionPostalCode),
     /// `user.exited_region_postal_code`
-    RadarEventTypeUserExitedRegionPostalCode NS_SWIFT_NAME(userExitedRegionPostalCode)
+    RadarEventTypeUserExitedRegionPostalCode NS_SWIFT_NAME(userExitedRegionPostalCode),
+    /// `user.dwelled_in_geofence`
+    RadarEventTypeUserDwelledInGeofence NS_SWIFT_NAME(userDwelledInGeofence)
 };
 
 /**

--- a/RadarSDK/Include/RadarTripOptions.h
+++ b/RadarSDK/Include/RadarTripOptions.h
@@ -22,6 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
             destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
      destinationGeofenceExternalId:(NSString *_Nullable)destinationGeofenceExternalId;
 
+- (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
+            destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
+     destinationGeofenceExternalId:(NSString *_Nullable)destinationGeofenceExternalId
+                scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt;
+
 /**
  A stable unique ID for the trip.
  */
@@ -41,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
  For trips with a destination, the external ID of the destination geofence.
  */
 @property (nullable, nonatomic, copy) NSString *destinationGeofenceExternalId;
+
+/**
+ * The scheduled arrival time for the trip.
+ */
+@property (nullable, nonatomic, copy) NSDate *scheduledArrivalAt;
 
 /**
  For trips with a destination, the travel mode.

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -344,7 +344,9 @@
         params[@"destinationGeofenceExternalId"] = options.destinationGeofenceExternalId;
     }
     params[@"mode"] = [Radar stringForMode:options.mode];
-
+    if (options.scheduledArrivalAt) {
+        params[@"scheduledArrivalAt"] = [[RadarUtils isoDateFormatter] stringFromDate:options.scheduledArrivalAt];
+    }
     NSString *host = [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/trips/%@", host, options.externalId];
     url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];

--- a/RadarSDK/RadarEvent.m
+++ b/RadarSDK/RadarEvent.m
@@ -340,6 +340,8 @@
         return @"user.entered_region_postal_code";
     case RadarEventTypeUserExitedRegionPostalCode:
         return @"user.exited_region_postal_code";
+    case RadarEventTypeUserDwelledInGeofence:
+        return @"user.dwelled_in_geofence";
     default:
         return @"unknown";
     }

--- a/RadarSDK/RadarTripOptions.m
+++ b/RadarSDK/RadarTripOptions.m
@@ -14,6 +14,7 @@ static NSString *const kMetadata = @"metadata";
 static NSString *const kDestinationGeofenceTag = @"destinationGeofenceTag";
 static NSString *const kDestinationGeofenceExternalId = @"destinationGeofenceExternalId";
 static NSString *const kMode = @"mode";
+static NSString *const kScheduledArrivalAt = @"scheduledArrivalAt";
 
 - (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
             destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
@@ -28,6 +29,21 @@ static NSString *const kMode = @"mode";
     return self;
 }
 
+- (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
+            destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
+     destinationGeofenceExternalId:(NSString *_Nullable)destinationGeofenceExternalId
+                scheduledArrivalAt:(NSDate * _Nullable)scheduledArrivalAt {
+    self = [self initWithExternalId:externalId
+             destinationGeofenceTag:destinationGeofenceTag
+      destinationGeofenceExternalId:destinationGeofenceExternalId];
+
+    if (self) {
+        _scheduledArrivalAt = scheduledArrivalAt;
+    }
+
+    return self;
+}
+
 + (RadarTripOptions *)tripOptionsFromDictionary:(NSDictionary *)dict {
     if (!dict) {
         return nil;
@@ -35,7 +51,8 @@ static NSString *const kMode = @"mode";
 
     RadarTripOptions *options = [[RadarTripOptions alloc] initWithExternalId:dict[kExternalId]
                                                       destinationGeofenceTag:dict[kDestinationGeofenceTag]
-                                               destinationGeofenceExternalId:dict[kDestinationGeofenceExternalId]];
+                                               destinationGeofenceExternalId:dict[kDestinationGeofenceExternalId]
+                                                          scheduledArrivalAt:dict[kScheduledArrivalAt]];
     options.metadata = dict[kMetadata];
     NSString *modeStr = dict[kMode];
     if ([modeStr isEqualToString:@"foot"]) {
@@ -59,6 +76,7 @@ static NSString *const kMode = @"mode";
     dict[kDestinationGeofenceTag] = self.destinationGeofenceTag;
     dict[kDestinationGeofenceExternalId] = self.destinationGeofenceExternalId;
     dict[kMode] = [Radar stringForMode:self.mode];
+    dict[kScheduledArrivalAt] = self.scheduledArrivalAt;
     return dict;
 }
 
@@ -84,6 +102,9 @@ static NSString *const kMode = @"mode";
            ((!self.destinationGeofenceExternalId && !options.destinationGeofenceExternalId) ||
             (self.destinationGeofenceExternalId != nil && options.destinationGeofenceExternalId != nil &&
              [self.destinationGeofenceExternalId isEqualToString:options.destinationGeofenceExternalId])) &&
+           ((!self.scheduledArrivalAt && !options.scheduledArrivalAt) ||
+            (self.scheduledArrivalAt != nil && options.scheduledArrivalAt != nil &&
+            [self.scheduledArrivalAt isEqualToDate:options.scheduledArrivalAt])) &&
            self.mode == options.mode;
 }
 

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.4.3";
+    return @"3.4.4";
 }
 
 + (NSString *)adId {


### PR DESCRIPTION
[sc-10569: [iOS SDK] Add scheduledArrivalAt parameter to RadarTripOptions](https://app.shortcut.com/radarlabs/story/10569/ios-sdk-add-scheduledarrivalat-parameter-to-radartripoptions)

* Added `RadarTripOptions.scheduledArrivalAt` and `RadarEventTypeUserDwelledInGeofence`.

@nickpatrick's corresponding PR for Android is [#221](https://github.com/radarlabs/radar-sdk-android/pull/221/files#).