### PR TITLE
sc-10985: Don't sync logs if RadarSettings._id is nil

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -938,6 +938,14 @@
         return completionHandler(RadarStatusErrorPublishableKey);
     }
 
+    NSString *radarId = [RadarSettings _id];
+    if (!radarId) {
+        // Either [Radar initializeWithPublishableKey] hasn't been called yet,
+        // or [RadarAPIClient trackWithLocation:stopped:foreground:source:replayed:beacons:completionHandler:]
+        // hasn't been called, or hasn't succeeded.
+        return completionHandler(RadarStatusErrorBadRequest);
+    }
+
     NSString *host = [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/logs", host];
 


### PR DESCRIPTION
[sc-10985: [iOS SDK] Cache logs if the Radar id hasn't been set yet](https://app.shortcut.com/radarlabs/story/10985/ios-sdk-cache-logs-if-the-radar-id-hasn-t-been-set-yet)

We're seeing increased server-side errors when attempting to sync logs when the ID is `nil`. This fixes `RadarAPIClient.syncLogs()` to fail when `RadarSettings._id` is `nil`, which will persist the log message until the next sync is attempted.

Slack discussion: https://radarlabs.slack.com/archives/C02MF6PAWBH/p1657844165516349