### PR TITLE
sc-11337: Add metadata checks for custom events

### DIFF
--- a/RadarSDK/RadarEvent.m
+++ b/RadarSDK/RadarEvent.m
@@ -291,11 +291,11 @@
                                              verticalAccuracy:-1
                                                     timestamp:(createdAt ? createdAt : [NSDate date])];
         }
+    }
 
-        id metadataObj = dict[@"metadata"];
-        if (metadataObj && [metadataObj isKindOfClass:[NSDictionary class]]) {
-            metadata = (NSDictionary *)metadataObj;
-        }
+    id metadataObj = dict[@"metadata"];
+    if (metadataObj && [metadataObj isKindOfClass:[NSDictionary class]]) {
+        metadata = (NSDictionary *)metadataObj;
     }
 
     if (_id && createdAt) {
@@ -368,6 +368,8 @@
         return @"user.approaching_trip_destination";
     case RadarEventTypeUserArrivedAtTripDestination:
         return @"user.arrived_at_trip_destination";
+    case RadarEventTypeCustom:
+        return @"custom";
     default:
         return @"unknown";
     }

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -620,10 +620,16 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     XCTestExpectation *exp = [self expectationWithDescription:@"sendEvent"];
 
     [Radar sendEvent:@"customEvent4"
-        withMetadata:nil
+        withMetadata:@{@"foo": @"bar"}
    completionHandler:^(RadarStatus status, CLLocation *_Nullable location, NSArray<RadarEvent *> *_Nullable events, RadarUser *_Nullable user) {
         XCTAssertEqual(status, RadarStatusSuccess);
         XCTAssertNotNil(events);
+
+        RadarEvent *customEvent = events[0];
+        XCTAssertNotNil(customEvent);
+        NSDictionary *metadata = customEvent.metadata;
+        XCTAssertNotNil(metadata);
+        XCTAssertTrue([metadata[@"foo"] isEqual:@"bar"]);
         [exp fulfill];
     }
     ];
@@ -675,10 +681,17 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
     [Radar sendEvent:@"customEvent4"
         withLocation:mockLocation
-            metadata:@{@"foo": @"bar", @"baz": @YES, @"qux": @1}
+            metadata:@{@"foo": @"bar"}
     completionHandler:^(RadarStatus status, CLLocation *_Nullable location, NSArray<RadarEvent *> *_Nullable events, RadarUser *_Nullable user) {
         XCTAssertEqual(status, RadarStatusSuccess);
         XCTAssertNotNil(events);
+
+        RadarEvent *customEvent = events[0];
+        XCTAssertNotNil(customEvent);
+        NSDictionary *metadata = customEvent.metadata;
+        XCTAssertNotNil(metadata);
+        XCTAssertTrue([metadata[@"foo"] isEqual:@"bar"]);
+
         [exp fulfill];
     }
     ];

--- a/RadarSDKTests/Resources/custom_event.json
+++ b/RadarSDKTests/Resources/custom_event.json
@@ -16,6 +16,9 @@
         "live": 0,
         "locationAccuracyAuthorization": "FULL",
         "locationAuthorization": "GRANTED_BACKGROUND",
+        "metadata": {
+            "foo": "bar"
+        },
         "sdkVersion": "3.5.1",
         "stopped": 1,
         "type": "settings_opened",


### PR DESCRIPTION
[sc-11337: [iOS SDK] Add metadata checks for Radar.sendEvent() unit tests](https://app.shortcut.com/radarlabs/story/11337/ios-sdk-add-metadata-checks-for-radar-sendevent-unit-tests)

* Added unit tests and Example app checks for `RadarEvent.metadata` parsing, now that the server is sending back metadata as JSON data, not a string.
