### PR TITLE
sc-11505: Add RadarTripOptions.approachingThreshold

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -101,6 +101,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let tripOptions = RadarTripOptions(externalId: "299", destinationGeofenceTag: "store", destinationGeofenceExternalId: "123")
         tripOptions.mode = .car
+        tripOptions.approachingThreshold = 9
         Radar.startTrip(options: tripOptions)
 
         var i = 0

--- a/RadarSDK/Include/RadarTripOptions.h
+++ b/RadarSDK/Include/RadarTripOptions.h
@@ -57,6 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) RadarRouteMode mode;
 
+@property (nonatomic, assign) UInt8 approachingThreshold;
+
 + (RadarTripOptions *)tripOptionsFromDictionary:(NSDictionary *)dict;
 - (NSDictionary *)dictionaryValue;
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -347,6 +347,9 @@
     if (options.scheduledArrivalAt) {
         params[@"scheduledArrivalAt"] = [[RadarUtils isoDateFormatter] stringFromDate:options.scheduledArrivalAt];
     }
+    if (options.approachingThreshold > 0) {
+        params[@"approachingThreshold"] = [NSString stringWithFormat:@"%d", options.approachingThreshold];
+    }
     NSString *host = [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/trips/%@", host, options.externalId];
     url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];


### PR DESCRIPTION
[sc-11505: [iOS SDK] Add approachingThreshold to Radar.startTrip() and .updateTrip()](https://app.shortcut.com/radarlabs/story/11505)

* Adds `RadarTripOptions.approachingThreshold`, which is passed as an `approachingThreshold` parameter when starting & updating trip calls.