### PR TITLE
support anonymous tracking

### DIFF
--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -313,6 +313,14 @@ typedef void(^_Nonnull RadarSendEventCompletionHandler)(RadarStatus status, CLLo
 + (NSDictionary *_Nullable)getMetadata;
 
 /**
+ Enables anonymous tracking for privacy reasons. Avoids creating user records on the server and avoids sending any stable device IDs, user IDs, and user metadata
+ to the server when calling `trackOnce()` or `startTracking()`. Disabled by default.
+
+ @param enabled A boolean indicating whether anonymous tracking should be enabled.
+ */
++ (void)setAnonymousTrackingEnabled:(BOOL)enabled;
+
+/**
  Enables `adId` (IDFA) collection. Disabled by default.
 
  @param enabled A boolean indicating whether `adId` should be collected.

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -94,6 +94,10 @@
     [RadarSettings setAdIdEnabled:enabled];
 }
 
++ (void)setAnonymousTrackingEnabled:(BOOL)enabled {
+    [RadarSettings setAnonymousTrackingEnabled:enabled];
+}
+
 #pragma mark - Get Location
 
 + (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -132,7 +132,12 @@
     NSMutableDictionary *params = [NSMutableDictionary new];
     BOOL anonymous = [RadarSettings anonymousTrackingEnabled];
     params[@"anonymous"] = @(anonymous);
-    if (!anonymous) {
+    if (anonymous) {
+        params[@"geofenceIds"] = [RadarState geofenceIds];
+        params[@"placeId"] = [RadarState placeId];
+        params[@"regionIds"] = [RadarState regionIds];
+        params[@"beaconIds"] = [RadarState beaconIds];
+    } else {
         params[@"id"] = [RadarSettings _id];
         params[@"installId"] = [RadarSettings installId];
         params[@"userId"] = [RadarSettings userId];
@@ -269,9 +274,56 @@
                         NSArray<RadarEvent *> *events = [RadarEvent eventsFromObject:eventsObj];
                         RadarUser *user = [[RadarUser alloc] initWithObject:userObj];
                         NSArray<RadarGeofence *> *nearbyGeofences = [RadarGeofence geofencesFromObject:nearbyGeofencesObj];
+        
+                        if (user) {
+                            BOOL inGeofences = user.geofences && user.geofences.count;
+                            BOOL atPlace = user.place != nil;
+                            BOOL canExit = inGeofences || atPlace;
+                            [RadarState setCanExit:canExit];
+                            
+                            NSMutableArray *geofenceIds = [NSMutableArray new];
+                            if (user.geofences) {
+                                for (RadarGeofence *geofence in user.geofences) {
+                                    [geofenceIds addObject:geofence._id];
+                                }
+                                
+                            }
+                            [RadarState setGeofenceIds:geofenceIds];
+                            
+                            NSString *placeId = nil;
+                            if (user.place) {
+                                placeId = user.place._id;
+                            }
+                            [RadarState setPlaceId:placeId];
+                            
+                            NSMutableArray *regionIds = [NSMutableArray new];
+                            if (user.country) {
+                                [regionIds addObject:user.country._id];
+                            }
+                            if (user.state) {
+                                [regionIds addObject:user.state._id];
+                            }
+                            if (user.dma) {
+                                [regionIds addObject:user.dma._id];
+                            }
+                            if (user.postalCode) {
+                                [regionIds addObject:user.postalCode._id];
+                            }
+                            [RadarState setRegionIds:regionIds];
+                            
+                            NSMutableArray *beaconIds = [NSMutableArray new];
+                            if (user.beacons) {
+                                for (RadarBeacon *beacon in user.beacons) {
+                                    [beaconIds addObject:beacon._id];
+                                }
+                                
+                            }
+                            [RadarState setBeaconIds:beaconIds];
+                        }
+        
                         if (events && user) {
                             [RadarSettings setId:user._id];
-
+                            
                             if (!user.trip) {
                                 [RadarSettings setTripOptions:nil];
                             }

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -130,15 +130,23 @@
     }
 
     NSMutableDictionary *params = [NSMutableDictionary new];
-    params[@"id"] = [RadarSettings _id];
-    params[@"installId"] = [RadarSettings installId];
-    params[@"userId"] = [RadarSettings userId];
-    params[@"deviceId"] = [RadarUtils deviceId];
-    params[@"description"] = [RadarSettings __description];
-    params[@"metadata"] = [RadarSettings metadata];
-    NSString *adId = [RadarUtils adId];
-    if (adId && [RadarSettings adIdEnabled]) {
-        params[@"adId"] = adId;
+    BOOL anonymous = [RadarSettings anonymousTrackingEnabled];
+    params[@"anonymous"] = @(anonymous);
+    if (!anonymous) {
+        params[@"id"] = [RadarSettings _id];
+        params[@"installId"] = [RadarSettings installId];
+        params[@"userId"] = [RadarSettings userId];
+        params[@"deviceId"] = [RadarUtils deviceId];
+        params[@"description"] = [RadarSettings __description];
+        params[@"metadata"] = [RadarSettings metadata];
+        NSString *adId = [RadarUtils adId];
+        if (adId && [RadarSettings adIdEnabled]) {
+            params[@"adId"] = adId;
+        }
+        NSString *sessionId = [RadarSettings sessionId];
+        if (sessionId) {
+            params[@"sessionId"] = sessionId;
+        }
     }
     params[@"latitude"] = @(location.coordinate.latitude);
     params[@"longitude"] = @(location.coordinate.longitude);
@@ -207,10 +215,6 @@
     }
     if (beacons) {
         params[@"beacons"] = [RadarBeacon arrayForBeacons:beacons];
-    }
-    NSString *sessionId = [RadarSettings sessionId];
-    if (sessionId) {
-        params[@"sessionId"] = sessionId;
     }
     NSString *locationAuthorization = [RadarUtils locationAuthorization];
     if (locationAuthorization) {

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -133,6 +133,7 @@
     BOOL anonymous = [RadarSettings anonymousTrackingEnabled];
     params[@"anonymous"] = @(anonymous);
     if (anonymous) {
+        params[@"deviceId"] = @"anonymous";
         params[@"geofenceIds"] = [RadarState geofenceIds];
         params[@"placeId"] = [RadarState placeId];
         params[@"regionIds"] = [RadarState regionIds];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -760,13 +760,6 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
                                                beacons:beacons
                                      completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events, RadarUser *_Nullable user,
                                                          NSArray<RadarGeofence *> *_Nullable nearbyGeofences, RadarMeta *_Nullable meta) {
-                                         if (user) {
-                                             BOOL inGeofences = user.geofences && user.geofences.count;
-                                             BOOL atPlace = user.place != nil;
-                                             BOOL canExit = inGeofences || atPlace;
-                                             [RadarState setCanExit:canExit];
-                                         }
-
                                          self.sending = NO;
 
                                          [self updateTrackingFromMeta:meta];

--- a/RadarSDK/RadarSettings.h
+++ b/RadarSDK/RadarSettings.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setDescription:(NSString *_Nullable)description;
 + (NSDictionary *_Nullable)metadata;
 + (void)setMetadata:(NSDictionary *_Nullable)metadata;
++ (BOOL)anonymousTrackingEnabled;
++ (void)setAnonymousTrackingEnabled:(BOOL)enabled;
 + (BOOL)adIdEnabled;
 + (void)setAdIdEnabled:(BOOL)enabled;
 + (BOOL)tracking;

--- a/RadarSDK/RadarSettings.m
+++ b/RadarSDK/RadarSettings.m
@@ -19,6 +19,7 @@ static NSString *const kId = @"radar-_id";
 static NSString *const kUserId = @"radar-userId";
 static NSString *const kDescription = @"radar-description";
 static NSString *const kMetadata = @"radar-metadata";
+static NSString *const kAnonymous = @"radar-anonymous";
 static NSString *const kAdIdEnabled = @"radar-adIdEnabled";
 static NSString *const kTracking = @"radar-tracking";
 static NSString *const kTrackingOptions = @"radar-trackingOptions";
@@ -97,6 +98,14 @@ static NSString *const kDefaultHost = @"https://api.radar.io";
 
 + (void)setMetadata:(NSString *)metadata {
     [[NSUserDefaults standardUserDefaults] setObject:metadata forKey:kMetadata];
+}
+
++ (BOOL)anonymousTrackingEnabled {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kAdIdEnabled];
+}
+
++ (void)setAnonymousTrackingEnabled:(BOOL)enabled {
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kAnonymous];
 }
 
 + (BOOL)adIdEnabled {

--- a/RadarSDK/RadarSettings.m
+++ b/RadarSDK/RadarSettings.m
@@ -101,7 +101,7 @@ static NSString *const kDefaultHost = @"https://api.radar.io";
 }
 
 + (BOOL)anonymousTrackingEnabled {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:kAdIdEnabled];
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kAnonymous];
 }
 
 + (void)setAnonymousTrackingEnabled:(BOOL)enabled {

--- a/RadarSDK/RadarState.h
+++ b/RadarSDK/RadarState.h
@@ -26,6 +26,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setCanExit:(BOOL)canExit;
 + (CLLocation *)lastFailedStoppedLocation;
 + (void)setLastFailedStoppedLocation:(CLLocation *_Nullable)lastFailedStoppedLocation;
++ (NSArray<NSString *> *)geofenceIds;
++ (void)setGeofenceIds:(NSArray<NSString *> *_Nullable)geofenceIds;
++ (NSArray<NSString *> *)placeId;
++ (void)setPlaceId:(NSString *_Nullable)placeId;
++ (NSArray<NSString *> *)regionIds;
++ (void)setRegionIds:(NSArray<NSString *> *_Nullable)regionIds;
++ (NSArray<NSString *> *)beaconIds;
++ (void)setBeaconIds:(NSArray<NSString *> *_Nullable)beaconIds;
 
 @end
 

--- a/RadarSDK/RadarState.m
+++ b/RadarSDK/RadarState.m
@@ -18,6 +18,10 @@ static NSString *const kStopped = @"radar-stopped";
 static NSString *const kLastSentAt = @"radar-lastSentAt";
 static NSString *const kCanExit = @"radar-canExit";
 static NSString *const kLastFailedStoppedLocation = @"radar-lastFailedStoppedLocation";
+static NSString *const kGeofenceIds = @"radar-geofenceIds";
+static NSString *const kPlaceId = @"radar-placeId";
+static NSString *const kRegionIds = @"radar-regionIds";
+static NSString *const kBeaconIds = @"radar-beaconIds";
 
 + (CLLocation *)lastLocation {
     NSDictionary *dict = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kLastLocation];
@@ -81,7 +85,7 @@ static NSString *const kLastFailedStoppedLocation = @"radar-lastFailedStoppedLoc
 }
 
 + (NSDate *)lastSentAt {
-    return [[NSUserDefaults standardUserDefaults] valueForKey:kLastSentAt];
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kLastSentAt];
 }
 
 + (BOOL)canExit {
@@ -112,6 +116,38 @@ static NSString *const kLastFailedStoppedLocation = @"radar-lastFailedStoppedLoc
 
     NSDictionary *dict = [RadarUtils dictionaryForLocation:lastFailedStoppedLocation];
     [[NSUserDefaults standardUserDefaults] setObject:dict forKey:kLastFailedStoppedLocation];
+}
+
++ (NSArray<NSString *> *)geofenceIds {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kGeofenceIds];
+}
+
++ (void)setGeofenceIds:(NSArray<NSString *> *)geofenceIds {
+    [[NSUserDefaults standardUserDefaults] setObject:geofenceIds forKey:kGeofenceIds];
+}
+
++ (NSString *)placeId {
+    return [[NSUserDefaults standardUserDefaults] stringForKey:kPlaceId];
+}
+
++ (void)setPlaceId:(NSString *)placeId {
+    [[NSUserDefaults standardUserDefaults] setObject:placeId forKey:kPlaceId];
+}
+
++ (NSArray<NSString *> *)regionIds {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kRegionIds];
+}
+
++ (void)setRegionIds:(NSArray<NSString *> *)regionIds {
+    [[NSUserDefaults standardUserDefaults] setObject:regionIds forKey:kRegionIds];
+}
+
++ (NSArray<NSString *> *)beaconIds {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kBeaconIds];
+}
+
++ (void)setBeaconIds:(NSArray<NSString *> *)beaconIds {
+    [[NSUserDefaults standardUserDefaults] setObject:beaconIds forKey:kBeaconIds];
 }
 
 @end

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.5.2";
+    return @"3.5.4";
 }
 
 + (NSString *)adId {


### PR DESCRIPTION
- Exposes `Radar.setAnonymousTrackingEnabled()`. When enabled, avoids sending any stable device IDs, user IDs, or user metadata to `POST /track`
- TODO: Send current `geofenceIds`, `placeId`, and `regionIds` to avoid duplicate events