### PR TITLE
Include approachingThreshold in tripOptions

### DIFF
--- a/RadarSDK/Include/RadarTripOptions.h
+++ b/RadarSDK/Include/RadarTripOptions.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) RadarRouteMode mode;
 
-@property (nonatomic, assign) UInt8 approachingThreshold;
+@property (nonatomic, assign) UInt16 approachingThreshold;
 
 + (RadarTripOptions *_Nullable)tripOptionsFromDictionary:(NSDictionary *)dict;
 - (NSDictionary *)dictionaryValue;

--- a/RadarSDK/RadarTripOptions.m
+++ b/RadarSDK/RadarTripOptions.m
@@ -79,7 +79,9 @@ static NSString *const kApproachingThreshold = @"approachingThreshold";
     dict[kDestinationGeofenceExternalId] = self.destinationGeofenceExternalId;
     dict[kMode] = [Radar stringForMode:self.mode];
     dict[kScheduledArrivalAt] = self.scheduledArrivalAt;
-    dict[kApproachingThreshold] = @(self.approachingThreshold);
+    if (self.approachingThreshold && self.approachingThreshold > 0) {
+        dict[kApproachingThreshold] = @(self.approachingThreshold);
+    }
     return dict;
 }
 
@@ -109,7 +111,8 @@ static NSString *const kApproachingThreshold = @"approachingThreshold";
             (self.scheduledArrivalAt != nil && options.scheduledArrivalAt != nil &&
             [self.scheduledArrivalAt isEqualToDate:options.scheduledArrivalAt])) &&
            self.mode == options.mode &&
-              self.approachingThreshold == options.approachingThreshold;
+            ((!self.approachingThreshold && !options.approachingThreshold) ||
+              (self.approachingThreshold == options.approachingThreshold));
 }
 
 @end

--- a/RadarSDK/RadarTripOptions.m
+++ b/RadarSDK/RadarTripOptions.m
@@ -108,7 +108,8 @@ static NSString *const kApproachingThreshold = @"approachingThreshold";
            ((!self.scheduledArrivalAt && !options.scheduledArrivalAt) ||
             (self.scheduledArrivalAt != nil && options.scheduledArrivalAt != nil &&
             [self.scheduledArrivalAt isEqualToDate:options.scheduledArrivalAt])) &&
-           self.mode == options.mode;
+           self.mode == options.mode &&
+              self.approachingThreshold == options.approachingThreshold;
 }
 
 @end

--- a/RadarSDK/RadarTripOptions.m
+++ b/RadarSDK/RadarTripOptions.m
@@ -15,6 +15,7 @@ static NSString *const kDestinationGeofenceTag = @"destinationGeofenceTag";
 static NSString *const kDestinationGeofenceExternalId = @"destinationGeofenceExternalId";
 static NSString *const kMode = @"mode";
 static NSString *const kScheduledArrivalAt = @"scheduledArrivalAt";
+static NSString *const kApproachingThreshold = @"approachingThreshold";
 
 - (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
             destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
@@ -66,6 +67,7 @@ static NSString *const kScheduledArrivalAt = @"scheduledArrivalAt";
     } else {
         options.mode = RadarRouteModeCar;
     }
+    options.approachingThreshold = [dict[kApproachingThreshold] intValue];
     return options;
 }
 
@@ -77,6 +79,7 @@ static NSString *const kScheduledArrivalAt = @"scheduledArrivalAt";
     dict[kDestinationGeofenceExternalId] = self.destinationGeofenceExternalId;
     dict[kMode] = [Radar stringForMode:self.mode];
     dict[kScheduledArrivalAt] = self.scheduledArrivalAt;
+    dict[kApproachingThreshold] = @(self.approachingThreshold);
     return dict;
 }
 


### PR DESCRIPTION
Part of the work for React Native parity https://linear.app/radarlabs/issue/MOB-56/include-trip-approaching-threshold-in-radartripoptions-helper

New to native iOS dev, but I think this is the meat of it? Existing tests pass as well. Will poke around a bit more tomorrow before opening this up