### PR TITLE
Skip logging of replay payloads

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -255,8 +255,10 @@
     [bufferParams removeObjectForKey:@"updatedAtMsDiff"];
     
     NSMutableDictionary *requestsParams = [NSMutableDictionary new];
+
+    BOOL replaying = options.replay == RadarTrackingOptionsReplayAll && replayCount > 0;
     
-    if (options.replay == RadarTrackingOptionsReplayAll && replayCount > 0) {
+    if (replaying) {
         NSMutableArray *replaysArray = [RadarReplay arrayForReplays:replays];
         [replaysArray addObject:params];
         
@@ -277,7 +279,7 @@
                               headers:headers
                                params:requestsParams
                                 sleep:YES
-                           logPayload:YES
+                           logPayload:!replaying
                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
         if (status != RadarStatusSuccess || !res) {
             if (options.replay == RadarTrackingOptionsReplayAll) {
@@ -292,7 +294,6 @@
             return completionHandler(status, nil, nil, nil, nil, nil);
         }
 
-        [Radar flushLogs];
         if (options.replay == RadarTrackingOptionsReplayAll) {
             // clear buffer
             [[RadarReplayBuffer sharedInstance] clearBuffer];
@@ -300,6 +301,7 @@
             [RadarState setLastFailedStoppedLocation:nil];
         }
         
+        [Radar flushLogs];
         
         RadarMeta *_Nullable meta = [RadarAPIClient parseMeta:res];
         


### PR DESCRIPTION
@tjulien as discussed, this is the immediate fix for the 413s. Testing so far has been promising, I'm going to try & break things as much as I can over the next 24h. I suggest cutting an Orange tomorrow.

In a separate branch I've begun improving the robustness of our API Client. Preventing 413s in the first place, splitting up log calls, and the like. I'm prioritizing only what's essential for offline replay, but hope to fast follow with that work as well.