### PR TITLE
Fix client side rate limiting

### DIFF
--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -24,7 +24,7 @@
     self = [super init];
     if (self) {
         _queue = dispatch_queue_create("io.radar.api", DISPATCH_QUEUE_SERIAL);
-        _semaphore = dispatch_semaphore_create(0);
+        _semaphore = dispatch_semaphore_create(1);
         _wait = NO;
     }
     return self;
@@ -39,8 +39,10 @@
           extendedTimeout:(BOOL)extendedTimeout
         completionHandler:(RadarAPICompletionHandler)completionHandler {
     dispatch_async(self.queue, ^{
+        BOOL didWait = NO;
         if (self.wait) {
             dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER);
+            didWait = YES;
         }
 
         self.wait = YES;
@@ -86,7 +88,9 @@
                     });
 
                     self.wait = NO;
-                    dispatch_semaphore_signal(self.semaphore);
+                    if (didWait) {
+                        dispatch_semaphore_signal(self.semaphore);
+                    }
 
                     return;
                 }
@@ -99,7 +103,9 @@
                     });
 
                     self.wait = NO;
-                    dispatch_semaphore_signal(self.semaphore);
+                    if (didWait) {
+                        dispatch_semaphore_signal(self.semaphore);
+                    }
 
                     return;
                 }
@@ -143,7 +149,9 @@
                 }
 
                 self.wait = NO;
-                dispatch_semaphore_signal(self.semaphore);
+                if (didWait) {
+                    dispatch_semaphore_signal(self.semaphore);
+                }
             };
 
             NSURLSessionDataTask *task = [[NSURLSession sessionWithConfiguration:configuration] dataTaskWithRequest:req completionHandler:dataTaskCompletionHandler];

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -25,7 +25,6 @@
     if (self) {
         _queue = dispatch_queue_create("io.radar.api", DISPATCH_QUEUE_SERIAL);
         _semaphore = dispatch_semaphore_create(1);
-        _wait = NO;
     }
     return self;
 }
@@ -39,13 +38,10 @@
           extendedTimeout:(BOOL)extendedTimeout
         completionHandler:(RadarAPICompletionHandler)completionHandler {
     dispatch_async(self.queue, ^{
-        BOOL didWait = NO;
-        if (self.wait) {
+        if (sleep) {
             dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER);
-            didWait = YES;
         }
 
-        self.wait = YES;
 
         NSMutableURLRequest *req = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
         req.HTTPMethod = method;
@@ -87,8 +83,7 @@
                         completionHandler(RadarStatusErrorNetwork, nil);
                     });
 
-                    self.wait = NO;
-                    if (didWait) {
+                    if (sleep) {
                         dispatch_semaphore_signal(self.semaphore);
                     }
 
@@ -102,8 +97,7 @@
                         completionHandler(RadarStatusErrorServer, nil);
                     });
 
-                    self.wait = NO;
-                    if (didWait) {
+                    if (sleep) {
                         dispatch_semaphore_signal(self.semaphore);
                     }
 
@@ -146,10 +140,6 @@
 
                 if (sleep) {
                     [NSThread sleepForTimeInterval:1];
-                }
-
-                self.wait = NO;
-                if (didWait) {
                     dispatch_semaphore_signal(self.semaphore);
                 }
             };

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -84,6 +84,7 @@
                     });
 
                     if (sleep) {
+                        [NSThread sleepForTimeInterval:1];
                         dispatch_semaphore_signal(self.semaphore);
                     }
 
@@ -98,6 +99,7 @@
                     });
 
                     if (sleep) {
+                        [NSThread sleepForTimeInterval:1];
                         dispatch_semaphore_signal(self.semaphore);
                     }
 


### PR DESCRIPTION
There was a bug in the previous implementation. We were incrementing the semaphore `dispatch_semaphore_signal(self.semaphore);` every time we called `requestWithMethod` though we were decrementing the semaphore only when we ran into the iVar `self.wait`. This meant that the semaphore grew rapidly as more often than not, we'd not run into `self.wait == true`, increasing the amount of concurrent `trackLocation`s we'd allow.

This PR changes the logic to check the semaphore (now initialized `dispatch_semaphore_create(1)`) only if `SLEEP: true`, which is only true for `trackWithLocation` where we have the perSecondRateLimit.
