### PR TITLE
Always clear last location if successful track

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -307,12 +307,10 @@ completionHandler:(RadarConfigAPICompletionHandler _Nonnull)completionHandler {
         }
 
         if (options.replay == RadarTrackingOptionsReplayAll) {
-            // clear buffer
             [[RadarReplayBuffer sharedInstance] clearBuffer];
-        } else {
-            [RadarState setLastFailedStoppedLocation:nil];
         }
-        
+
+        [RadarState setLastFailedStoppedLocation:nil];
         [Radar flushLogs];
         
         RadarMeta *_Nullable meta = [RadarAPIClient parseMeta:res];

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -306,10 +306,7 @@ completionHandler:(RadarConfigAPICompletionHandler _Nonnull)completionHandler {
             return completionHandler(status, nil, nil, nil, nil, nil);
         }
 
-        if (options.replay == RadarTrackingOptionsReplayAll) {
-            [[RadarReplayBuffer sharedInstance] clearBuffer];
-        }
-
+        [[RadarReplayBuffer sharedInstance] clearBuffer];
         [RadarState setLastFailedStoppedLocation:nil];
         [Radar flushLogs];
         


### PR DESCRIPTION
There was a bug that reared it's head only if you were tracking with `replayed: stops`, failed a track call, and then changed to `replay: all` where the last call before changing to `all` would be sent up after clearing the replay buffer in the next successful `/track/replay`.