### PR TITLE
Fix misspecified function header

### DIFF
--- a/RadarSDK/Include/RadarAddress.h
+++ b/RadarSDK/Include/RadarAddress.h
@@ -133,11 +133,6 @@ The plus4 value for the zip of the address.
 @property (nullable, copy, nonatomic, readonly) NSString *plus4;
 
 /**
-The property type of the address.
-*/
-@property (nullable, copy, nonatomic, readonly) NSString *propertyType;
-
-/**
 The metadata of the address.
 */
 @property (nullable, copy, nonatomic, readonly) NSDictionary *metadata;

--- a/RadarSDK/RadarAddress+Internal.h
+++ b/RadarSDK/RadarAddress+Internal.h
@@ -39,7 +39,7 @@
                                   placeLabel:(NSString *_Nullable)placeLabel
                                         unit:(NSString *_Nullable)unit
                                        plus4:(NSString *_Nullable)plus4
-                                propertyType:(NSString *_Nullable)propertyType
+                                    metadata:(NSDictionary *_Nullable)metadata
                                   confidence:(RadarAddressConfidence)confidence;
 
 @end


### PR DESCRIPTION
This change remained in my local editor but failed to make it up in https://github.com/radarlabs/radar-sdk-ios/pull/248. Don't think it breaks things, but Xcode shows a warning without this.