### PR TITLE
Circleci update resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Build example
           command: make build-example-pretty
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
+    resource_class: macos.m1.large.gen1
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Build example
           command: make build-example-pretty
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.x86.medium.gen2
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: 13.4.1
+      xcode: 14.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
       - run:
           name: Build example
           command: make build-example-pretty
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large
 workflows:
   version: 2
   build_and_test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 14"
 PROJECT := RadarSDK
 PROJECT_EXAMPLE := Example/Example
 SCHEME := XCFramework


### PR DESCRIPTION
Our current `medium` builds are being deprecated: https://discuss.circleci.com/t/macos-resource-deprecation-update/46891

This sets our `resource_class: macos.x86.medium.gen2` and bumps the Xcode version.