### PR TITLE
startTrackingVerified()

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -10,7 +10,7 @@ import UserNotifications
 import RadarSDK
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate, RadarDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate, RadarDelegate, RadarVerifiedDelegate {
 
     let locationManager = CLLocationManager()
 
@@ -22,9 +22,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.requestLocationPermissions()
 
         // Replace with a valid test publishable key
-        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
+        Radar.initialize(publishableKey: "org_test_pk_5857c63d9c1565175db8b00750808a66a002acb8")
         Radar.setDelegate(self)
+        Radar.setVerifiedDelegate(self)
+        
+        Radar.startTrackingVerified(token: true, interval: 60, beacons: true)
 
+        /*
         if UIApplication.shared.applicationState != .background {
             Radar.getLocation { (status, location, stopped) in
                 print("Location: status = \(Radar.stringForStatus(status)); location = \(String(describing: location))")
@@ -175,6 +179,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
         }
+         */
 
         return true
     }
@@ -248,4 +253,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.notify(message)
     }
 
+    func didUpdateToken(_ token: String) {
+        
+    }
+    
 }

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -22,13 +22,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.requestLocationPermissions()
 
         // Replace with a valid test publishable key
-        Radar.initialize(publishableKey: "org_test_pk_5857c63d9c1565175db8b00750808a66a002acb8")
+        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
         Radar.setDelegate(self)
         Radar.setVerifiedDelegate(self)
-        
-        Radar.startTrackingVerified(token: true, interval: 60, beacons: true)
 
-        /*
         if UIApplication.shared.applicationState != .background {
             Radar.getLocation { (status, location, stopped) in
                 print("Location: status = \(Radar.stringForStatus(status)); location = \(String(describing: location))")
@@ -179,7 +176,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
         }
-         */
 
         return true
     }

--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.9.2-beta.1'
+  s.version               = '3.9.4'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.8.9'
+  s.version               = '3.8.10'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.8.10'
+  s.version               = '3.8.10-beta.1'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -429,10 +429,6 @@
 		DD236C772308797B00EB88F9 /* RadarSDK */ = {
 			isa = PBXGroup;
 			children = (
-				82EEA9292A9E684C0048DCEC /* RadarFeatureSettings.h */,
-				82EEA92B2A9E685B0048DCEC /* RadarFeatureSettings.m */,
-				82F7FAEC2A65FE030055AA4B /* RadarVerificationManager.h */,
-				82F7FAED2A65FE030055AA4B /* RadarVerificationManager.m */,
 				96A5A0D827AD9F7F007B960B /* Include */,
 				DD236C792308797B00EB88F9 /* Info.plist */,
 				532FC303277A783900989279 /* Radar+Internal.h */,
@@ -449,6 +445,8 @@
 				01F99CFC2965C1C4004E8CF3 /* RadarConfig.m */,
 				96A5A11727ADA02E007B960B /* RadarDelegateHolder.h */,
 				DD4C104925D87E3E009C2E36 /* RadarDelegateHolder.m */,
+				82EEA9292A9E684C0048DCEC /* RadarFeatureSettings.h */,
+				82EEA92B2A9E685B0048DCEC /* RadarFeatureSettings.m */,
 				DD236CF723088F8400EB88F9 /* RadarLocationManager.h */,
 				DD236CF823088F8400EB88F9 /* RadarLocationManager.m */,
 				96A5A11527ADA02E007B960B /* RadarLog.h */,
@@ -475,6 +473,8 @@
 				DD8CCDF7246872360011690D /* RadarTripOptions.m */,
 				DD236D0323099B8400EB88F9 /* RadarUtils.h */,
 				DD236D0423099B8400EB88F9 /* RadarUtils.m */,
+				82F7FAEC2A65FE030055AA4B /* RadarVerificationManager.h */,
+				82F7FAED2A65FE030055AA4B /* RadarVerificationManager.m */,
 				DD27CB7D235D13F000299FEC /* Models */,
 				53CCD781275E576B00F79CC8 /* Util */,
 			);

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 /* Begin PBXFileReference section */
 		0107A9E82621FFB9008AB52F /* RadarSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RadarSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0113020D2AE1447600EFC377 /* RadarVerifiedDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarVerifiedDelegate.h; sourceTree = "<group>"; };
+		0113020E2AE1467800EFC377 /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/PrivateFrameworks/Network.framework; sourceTree = DEVELOPER_DIR; };
 		0114F057284EFDB700ADA4E4 /* RadarRouteMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarRouteMode.h; sourceTree = "<group>"; };
 		01DDC7C529FC387400C0D039 /* RadarNotificationHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarNotificationHelper.m; sourceTree = "<group>"; };
 		01DDC7C629FC387400C0D039 /* RadarNotificationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarNotificationHelper.h; sourceTree = "<group>"; };
@@ -557,6 +558,7 @@
 		DDC637F2238C7F9C00747FD4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0113020E2AE1467800EFC377 /* Network.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -862,7 +864,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.8;
+				MARKETING_VERSION = 3.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -892,7 +894,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.8;
+				MARKETING_VERSION = 3.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -975,7 +977,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.8.9;
+				MARKETING_VERSION = 3.8.10;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1033,7 +1035,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.8.9;
+				MARKETING_VERSION = 3.8.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = "-fembed-bitcode";

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -874,7 +874,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.2-beta.1;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -904,7 +904,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.2-beta.1;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -987,7 +987,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.9.2-beta.1;
+				MARKETING_VERSION = 3.9.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1045,7 +1045,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.9.2-beta.1;
+				MARKETING_VERSION = 3.9.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = "-fembed-bitcode";

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 
 /* Begin PBXFileReference section */
 		0107A9E82621FFB9008AB52F /* RadarSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RadarSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0113020D2AE1447600EFC377 /* RadarVerifiedDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarVerifiedDelegate.h; sourceTree = "<group>"; };
 		0114F057284EFDB700ADA4E4 /* RadarRouteMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarRouteMode.h; sourceTree = "<group>"; };
 		01DDC7C529FC387400C0D039 /* RadarNotificationHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarNotificationHelper.m; sourceTree = "<group>"; };
 		01DDC7C629FC387400C0D039 /* RadarNotificationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarNotificationHelper.h; sourceTree = "<group>"; };
@@ -357,6 +358,7 @@
 				96A5A0EC27AD9F7F007B960B /* RadarContext.h */,
 				96A5A0E327AD9F7F007B960B /* RadarCoordinate.h */,
 				96A5A0E727AD9F7F007B960B /* RadarDelegate.h */,
+				0113020D2AE1447600EFC377 /* RadarVerifiedDelegate.h */,
 				96A5A0DA27AD9F7F007B960B /* RadarEvent.h */,
 				96A5A0E927AD9F7F007B960B /* RadarFraud.h */,
 				96A5A0E627AD9F7F007B960B /* RadarGeofence.h */,

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		0114F058284EFDB700ADA4E4 /* RadarRouteMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0114F057284EFDB700ADA4E4 /* RadarRouteMode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		015C53AD29B8E8BA004F53A6 /* (null) in Headers */ = {isa = PBXBuildFile; };
 		015C53AE29B8E8BA004F53A6 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		01F810702AF0119800BD7088 /* RadarVerifiedDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 01F8106F2AF0119800BD7088 /* RadarVerifiedDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01F99CFB2965C182004E8CF3 /* RadarConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 01F99CFA2965C182004E8CF3 /* RadarConfig.h */; };
 		01F99CFD2965C1C4004E8CF3 /* RadarConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F99CFC2965C1C4004E8CF3 /* RadarConfig.m */; };
 		532FC304277A790600989279 /* Radar+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 532FC303277A783900989279 /* Radar+Internal.h */; };
@@ -163,11 +164,11 @@
 
 /* Begin PBXFileReference section */
 		0107A9E82621FFB9008AB52F /* RadarSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RadarSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0113020D2AE1447600EFC377 /* RadarVerifiedDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarVerifiedDelegate.h; sourceTree = "<group>"; };
 		0113020E2AE1467800EFC377 /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/PrivateFrameworks/Network.framework; sourceTree = DEVELOPER_DIR; };
 		0114F057284EFDB700ADA4E4 /* RadarRouteMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarRouteMode.h; sourceTree = "<group>"; };
 		01DDC7C529FC387400C0D039 /* RadarNotificationHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarNotificationHelper.m; sourceTree = "<group>"; };
 		01DDC7C629FC387400C0D039 /* RadarNotificationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarNotificationHelper.h; sourceTree = "<group>"; };
+		01F8106F2AF0119800BD7088 /* RadarVerifiedDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarVerifiedDelegate.h; sourceTree = "<group>"; };
 		01F99CFA2965C182004E8CF3 /* RadarConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarConfig.h; sourceTree = "<group>"; };
 		01F99CFC2965C1C4004E8CF3 /* RadarConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarConfig.m; sourceTree = "<group>"; };
 		532FC303277A783900989279 /* Radar+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Radar+Internal.h"; sourceTree = "<group>"; };
@@ -359,7 +360,6 @@
 				96A5A0EC27AD9F7F007B960B /* RadarContext.h */,
 				96A5A0E327AD9F7F007B960B /* RadarCoordinate.h */,
 				96A5A0E727AD9F7F007B960B /* RadarDelegate.h */,
-				0113020D2AE1447600EFC377 /* RadarVerifiedDelegate.h */,
 				96A5A0DA27AD9F7F007B960B /* RadarEvent.h */,
 				96A5A0E927AD9F7F007B960B /* RadarFraud.h */,
 				96A5A0E627AD9F7F007B960B /* RadarGeofence.h */,
@@ -379,6 +379,7 @@
 				96A5A0E127AD9F7F007B960B /* RadarTrip.h */,
 				96A5A0EE27AD9F7F007B960B /* RadarTripOptions.h */,
 				96A5A0E027AD9F7F007B960B /* RadarUser.h */,
+				01F8106F2AF0119800BD7088 /* RadarVerifiedDelegate.h */,
 			);
 			path = Include;
 			sourceTree = "<group>";
@@ -602,6 +603,7 @@
 				96A5A0C827AD9F41007B960B /* RadarBeacon+Internal.h in Headers */,
 				96A5A0C927AD9F41007B960B /* RadarPlace+Internal.h in Headers */,
 				96A5A10427AD9F7F007B960B /* RadarDelegate.h in Headers */,
+				01F810702AF0119800BD7088 /* RadarVerifiedDelegate.h in Headers */,
 				96A5A0CA27AD9F41007B960B /* RadarTrip+Internal.h in Headers */,
 				96A5A0FF27AD9F7F007B960B /* RadarGeofenceGeometry.h in Headers */,
 				96A5A0CB27AD9F41007B960B /* RadarRoute+Internal.h in Headers */,

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -469,7 +469,7 @@ typedef void (^_Nonnull RadarLogConversionCompletionHandler)(RadarStatus status,
  
  @warning Note that you must configure SSL pinning before calling this method.
  */
-+ (void)startTrackingVerified:(BOOL *)token NS_SWIFT_NAME(startTrackingVerified(token:));
++ (void)startTrackingVerified:(BOOL)token NS_SWIFT_NAME(startTrackingVerified(token:));
 
 /**
  Starts tracking the user's location in the background with configurable tracking options.

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -464,6 +464,13 @@ typedef void (^_Nonnull RadarLogConversionCompletionHandler)(RadarStatus status,
 + (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerifiedToken(completionHandler:));
 
 /**
+ Starts tracking the user's location with device integrity information for location verification use cases.
+ 
+ @warning Note that you must configure SSL pinning before calling this method.
+ */
++ (void)startTrackingVerified:(BOOL *)token NS_SWIFT_NAME(startTrackingVerified(token:));
+
+/**
  Starts tracking the user's location in the background with configurable tracking options.
 
  @param options Configurable tracking options.

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -23,6 +23,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RadarDelegate;
+@protocol RadarVerifiedDelegate;
 @class RadarTripOptions;
 
 #pragma mark - Enums
@@ -541,6 +542,15 @@ typedef void (^_Nonnull RadarLogConversionCompletionHandler)(RadarStatus status,
  @see https://radar.com/documentation/sdk/ios#listening-for-events-with-a-delegate
  */
 + (void)setDelegate:(nullable id<RadarDelegate>)delegate;
+
+/**
+ Sets a delegate for client-side delivery of verified location tokens.
+
+ @param verifiedDelegate A delegate for client-side delivery of verified location tokens. If `nil`, the previous delegate will be cleared.
+
+ @see https://radar.com/documentation/fraud
+ */
++ (void)setVerifiedDelegate:(nullable id<RadarVerifiedDelegate>)verifiedDelegate;
 
 #pragma mark - Events
 

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -454,6 +454,18 @@ typedef void (^_Nonnull RadarLogConversionCompletionHandler)(RadarStatus status,
 + (void)trackVerifiedWithCompletionHandler:(RadarTrackCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerified(completionHandler:));
 
 /**
+ Tracks the user's location with device integrity information for location verification use cases.
+
+ @warning Note that you must configure SSL pinning before calling this method.
+
+ @param beacons A boolean indicating whether to range beacons.
+ @param completionHandler An optional completion handler.
+
+ @see https://radar.com/documentation/fraud
+ */
++ (void)trackVerifiedWithBeacons:(BOOL)beacons completionHandler:(RadarTrackCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerified(beacons:completionHandler:));
+
+/**
  Tracks the user's location with device integrity information for location verification use cases. Returns a JSON Web Token (JWT). Verify the JWT server-side using your secret key.
 
  @warning Note that you must configure SSL pinning before calling this method.
@@ -465,11 +477,27 @@ typedef void (^_Nonnull RadarLogConversionCompletionHandler)(RadarStatus status,
 + (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerifiedToken(completionHandler:));
 
 /**
+ Tracks the user's location with device integrity information for location verification use cases. Returns a JSON Web Token (JWT). Verify the JWT server-side using your secret key.
+
+ @warning Note that you must configure SSL pinning before calling this method.
+
+ @param beacons A boolean indicating whether to range beacons.
+ @param completionHandler An optional completion handler.
+
+ @see https://radar.com/documentation/fraud
+ */
++ (void)trackVerifiedTokenWithBeacons:(BOOL)beacons completionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerifiedToken(beacons:completionHandler:));
+
+/**
  Starts tracking the user's location with device integrity information for location verification use cases.
+ 
+ @param token A boolean indicating whether to return a JSON Web Token (JWT). If `true`, tokens are delivered to your `RadarVerifiedDelegate`. If `false`, location updates are delivered to your `RadarDelegate`.
+ @param beacons A boolean indicating whether to range beacons.
+ @param interval The interval in seconds between each location update. A number between 1 and 60.
  
  @warning Note that you must configure SSL pinning before calling this method.
  */
-+ (void)startTrackingVerified:(BOOL)token NS_SWIFT_NAME(startTrackingVerified(token:));
++ (void)startTrackingVerified:(BOOL)token interval:(NSTimeInterval)interval beacons:(BOOL)beacons NS_SWIFT_NAME(startTrackingVerified(token:interval:beacons:));
 
 /**
  Starts tracking the user's location in the background with configurable tracking options.

--- a/RadarSDK/Include/RadarVerifiedDelegate.h
+++ b/RadarSDK/Include/RadarVerifiedDelegate.h
@@ -1,0 +1,30 @@
+//
+//  RadarVerifiedDelegate.h
+//  RadarSDK
+//
+//  Copyright © 2023 Radar Labs, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Radar.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A delegate for client-side delivery of verified location tokens. For more information, see https://radar.com/documentation/fraud
+
+ @see https://radar.com/documentation/fraud
+ */
+@protocol RadarVerifiedDelegate<NSObject>
+
+/**
+ Tells the delegate that the current user's verified location was updated. Receives a JSON Web Token (JWT). Verify the JWT server-side using your secret key.
+
+ @param token The token.
+ */
+- (void)didUpdateToken:(NSString *_Nonnull)token NS_SWIFT_NAME(didUpdateToken(_:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -247,12 +247,20 @@
     [[RadarVerificationManager sharedInstance] trackVerifiedWithCompletionHandler:completionHandler];
 }
 
++ (void)trackVerifiedWithBeacons:(BOOL)beacons completionHandler:(RadarTrackCompletionHandler)completionHandler {
+    [[RadarVerificationManager sharedInstance] trackVerifiedWithBeacons:(BOOL)beacons completionHandler:completionHandler];
+}
+
 + (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler)completionHandler {
     [[RadarVerificationManager sharedInstance] trackVerifiedTokenWithCompletionHandler:completionHandler];
 }
 
-+ (void)startTrackingVerified:(BOOL)token {
-    [[RadarVerificationManager sharedInstance] startTrackingVerified:token];
++ (void)trackVerifiedTokenWithBeacons:(BOOL)beacons completionHandler:(RadarTrackTokenCompletionHandler)completionHandler {
+    [[RadarVerificationManager sharedInstance] trackVerifiedTokenWithBeacons:(BOOL)beacons completionHandler:completionHandler];
+}
+
++ (void)startTrackingVerified:(BOOL)token interval:(NSTimeInterval)interval beacons:(BOOL)beacons {
+    [[RadarVerificationManager sharedInstance] startTrackingVerified:token interval:interval beacons:beacons];
 }
 
 + (void)startTrackingWithOptions:(RadarTrackingOptions *)options {

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -251,7 +251,7 @@
     [[RadarVerificationManager sharedInstance] trackVerifiedTokenWithCompletionHandler:completionHandler];
 }
 
-+ (void)startTrackingVerified:(BOOL *)token {
++ (void)startTrackingVerified:(BOOL)token {
     [[RadarVerificationManager sharedInstance] startTrackingVerified:token];
 }
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -368,6 +368,10 @@
     [RadarDelegateHolder sharedInstance].delegate = delegate;
 }
 
++ (void)setVerifiedDelegate:(id<RadarVerifiedDelegate>)verifiedDelegate {
+    [RadarDelegateHolder sharedInstance].verifiedDelegate = verifiedDelegate;
+}
+
 #pragma mark - Events
 
 + (void)acceptEventId:(NSString *)eventId verifiedPlaceId:(NSString *)verifiedPlaceId {

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -244,101 +244,15 @@
 }
 
 + (void)trackVerifiedWithCompletionHandler:(RadarTrackCompletionHandler)completionHandler {
-    [[RadarAPIClient sharedInstance]
-     getConfigForUsage:@"verify" verified:YES
-            completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
-                [[RadarLocationManager sharedInstance]
-                    getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
-                                 completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
-                                     if (status != RadarStatusSuccess) {
-                                         if (completionHandler) {
-                                             [RadarUtils runOnMainThread:^{
-                                                 completionHandler(status, nil, nil, nil);
-                                             }];
-                                         }
-
-                                         return;
-                                     }
-
-                                     [[RadarVerificationManager sharedInstance]
-                                         getAttestationWithNonce:config.nonce
-                                               completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
-                                                   [[RadarAPIClient sharedInstance]
-                                                       trackWithLocation:location
-                                                                 stopped:RadarState.stopped
-                                                              foreground:[RadarUtils foreground]
-                                                                  source:RadarLocationSourceForegroundLocation
-                                                                replayed:NO
-                                                                 beacons:nil
-                                                                verified:YES
-                                                       attestationString:attestationString
-                                                                    keyId:keyId
-                                                        attestationError:attestationError
-                                                               encrypted:NO
-                                                       completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
-                                                                           RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
-                                                                           RadarConfig *_Nullable config, NSString *_Nullable token) {
-                                                            if (status == RadarStatusSuccess && config != nil) { 
-                                                                [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
-                                                            }
-                                                           if (completionHandler) {
-                                                               [RadarUtils runOnMainThread:^{
-                                                                   completionHandler(status, location, events, user);
-                                                               }];
-                                                           }
-                                                       }];
-                                               }];
-                                 }];
-            }];
+    [[RadarVerificationManager sharedInstance] trackVerifiedWithCompletionHandler:completionHandler];
 }
 
 + (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler)completionHandler {
-    [[RadarAPIClient sharedInstance]
-     getConfigForUsage:@"verify" verified:YES
-            completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
-                [[RadarLocationManager sharedInstance]
-                    getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
-                                 completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
-                                     if (status != RadarStatusSuccess) {
-                                         if (completionHandler) {
-                                             [RadarUtils runOnMainThread:^{
-                                                 completionHandler(status, nil);
-                                             }];
-                                         }
+    [[RadarVerificationManager sharedInstance] trackVerifiedTokenWithCompletionHandler:completionHandler];
+}
 
-                                         return;
-                                     }
-
-                                     [[RadarVerificationManager sharedInstance]
-                                         getAttestationWithNonce:config.nonce
-                                               completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
-                                                   [[RadarAPIClient sharedInstance]
-                                                       trackWithLocation:location
-                                                                 stopped:RadarState.stopped
-                                                              foreground:[RadarUtils foreground]
-                                                                  source:RadarLocationSourceForegroundLocation
-                                                                replayed:NO
-                                                                 beacons:nil
-                                                                verified:YES
-                                                       attestationString:attestationString
-                                                                    keyId:keyId
-                                                        attestationError:attestationError
-                                                               encrypted:YES
-                                                       completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
-                                                                           RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
-                                                                           RadarConfig *_Nullable config, NSString *_Nullable token) {
-                                                            if (status == RadarStatusSuccess && config != nil) { 
-                                                                [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
-                                                            }
-                                                           if (completionHandler) {
-                                                               [RadarUtils runOnMainThread:^{
-                                                                   completionHandler(status, token);
-                                                               }];
-                                                           }
-                                                       }];
-                                               }];
-                                 }];
-            }];
++ (void)startTrackingVerified:(BOOL *)token {
+    [[RadarVerificationManager sharedInstance] startTrackingVerified:token];
 }
 
 + (void)startTrackingWithOptions:(RadarTrackingOptions *)options {

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -385,7 +385,7 @@
 
                                 NSString *token = (NSString *)tokenObj;
                                 
-                                if (location) {
+                                if (token) {
                                     [[RadarDelegateHolder sharedInstance] didUpdateToken:token];
                                 }
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -384,6 +384,10 @@
                                 }
 
                                 NSString *token = (NSString *)tokenObj;
+                                
+                                if (location) {
+                                    [[RadarDelegateHolder sharedInstance] didUpdateToken:token];
+                                }
 
                                 return completionHandler(status, nil, nil, nil, nil, nil, token);
                             }

--- a/RadarSDK/RadarDelegateHolder.h
+++ b/RadarSDK/RadarDelegateHolder.h
@@ -9,12 +9,14 @@
 
 #import "Radar.h"
 #import "RadarDelegate.h"
+#import "RadarVerifiedDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RadarDelegateHolder : NSObject<RadarDelegate>
+@interface RadarDelegateHolder : NSObject<RadarDelegate, RadarVerifiedDelegate>
 
 @property (nullable, weak, nonatomic) id<RadarDelegate> delegate;
+@property (nullable, weak, nonatomic) id<RadarVerifiedDelegate> verifiedDelegate;
 
 + (instancetype)sharedInstance;
 - (void)didFailWithStatus:(RadarStatus)status;

--- a/RadarSDK/RadarDelegateHolder.m
+++ b/RadarSDK/RadarDelegateHolder.m
@@ -79,8 +79,8 @@
 }
 
 - (void)didUpdateToken:(NSString *)token {
-    if (self.delegate) {
-        // add to delegate
+    if (self.verifiedDelegate) {
+        [self.verifiedDelegate didUpdateToken:token];
     }
 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"📍 Radar token updated | token = %@", token]];

--- a/RadarSDK/RadarDelegateHolder.m
+++ b/RadarSDK/RadarDelegateHolder.m
@@ -78,4 +78,12 @@
     }
 }
 
+- (void)didUpdateToken:(NSString *)token {
+    if (self.delegate) {
+        // add to delegate
+    }
+
+    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"📍 Radar token updated | token = %@", token]];
+}
+
 @end

--- a/RadarSDK/RadarSDK.h
+++ b/RadarSDK/RadarSDK.h
@@ -35,3 +35,4 @@ FOUNDATION_EXPORT const unsigned char RadarSDKVersionString[];
 #import "RadarTrip.h"
 #import "RadarTripOptions.h"
 #import "RadarUser.h"
+#import "RadarVerifiedDelegate.h"

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.8.9";
+    return @"3.8.10";
 }
 
 + (NSString *)deviceId {

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.8.10";
+    return @"3.8.10-beta.1";
 }
 
 + (NSString *)deviceId {

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.9.2-beta.1";
+    return @"3.9.4";
 }
 
 + (NSString *)deviceId {

--- a/RadarSDK/RadarVerificationManager.h
+++ b/RadarSDK/RadarVerificationManager.h
@@ -16,8 +16,10 @@ typedef void (^_Nullable RadarVerificationCompletionHandler)(NSString *_Nullable
 
 + (instancetype)sharedInstance;
 - (void)trackVerifiedWithCompletionHandler:(RadarTrackCompletionHandler _Nullable)completionHandler;
+- (void)trackVerifiedWithBeacons:(BOOL)beacons completionHandler:(RadarTrackCompletionHandler _Nullable)completionHandler;
 - (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler;
-- (void)startTrackingVerified:(BOOL)token;
+- (void)trackVerifiedTokenWithBeacons:(BOOL)beacons completionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler;
+- (void)startTrackingVerified:(BOOL)token interval:(NSTimeInterval)interval beacons:(BOOL)beacons;
 - (void)getAttestationWithNonce:(NSString *)nonce completionHandler:(RadarVerificationCompletionHandler)completionHandler;
 
 @end

--- a/RadarSDK/RadarVerificationManager.h
+++ b/RadarSDK/RadarVerificationManager.h
@@ -6,6 +6,8 @@
 //  Copyright © 2023 Radar Labs, Inc. All rights reserved.
 //
 
+#import "Radar.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RadarVerificationManager : NSObject
@@ -13,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^_Nullable RadarVerificationCompletionHandler)(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError);
 
 + (instancetype)sharedInstance;
+- (void)trackVerifiedWithCompletionHandler:(RadarTrackCompletionHandler _Nullable)completionHandler;
+- (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler _Nullable)completionHandler;
+- (void)startTrackingVerified:(BOOL)token;
 - (void)getAttestationWithNonce:(NSString *)nonce completionHandler:(RadarVerificationCompletionHandler)completionHandler;
 
 @end

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -254,9 +254,9 @@
                     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Network connected"];
 
                     if (token) {
-                        [self trackVerifiedTokenWithCompletionHandler:nil];
+                        [self trackVerifiedTokenWithBeacons:beacons completionHandler:nil];
                     } else {
-                        [self trackVerifiedWithCompletionHandler:nil];
+                        [self trackVerifiedWithBeacons:beacons completionHandler:nil];
                     }
                 } else {
                     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Network disconnected"];
@@ -274,9 +274,9 @@
                                                            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Timer fired"];
 
                                                            if (token) {
-                                                               [self trackVerifiedTokenWithCompletionHandler:nil];
+                                                               [self trackVerifiedTokenWithBeacons:beacons completionHandler:nil];
                                                            } else {
-                                                               [self trackVerifiedWithCompletionHandler:nil];
+                                                               [self trackVerifiedWithBeacons:beacons completionHandler:nil];
                                                            }
                                                        }];
     }

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -284,6 +284,12 @@
                                                            }
                                                        }];
     }
+    
+    if (token) {
+        [self trackVerifiedTokenWithBeacons:beacons completionHandler:nil];
+    } else {
+        [self trackVerifiedWithBeacons:beacons completionHandler:nil];
+    }
 }
 
 - (void)getAttestationWithNonce:(NSString *)nonce completionHandler:(RadarVerificationCompletionHandler)completionHandler {

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -152,7 +152,7 @@
             
             nw_path_monitor_set_update_handler(_monitor, ^(nw_path_t path) {
                 if (nw_path_get_status(path) == nw_path_status_satisfied) {
-                    NSLog(@"Network connected");
+                    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Network connected"];
                     
                     if (token) {
                         [self trackVerifiedTokenWithCompletionHandler:nil];

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -77,7 +77,7 @@
                                                                 foreground:[RadarUtils foreground]
                                                                     source:RadarLocationSourceForegroundLocation
                                                                   replayed:NO
-                                                                   beacons:nil
+                                                                   beacons:beacons
                                                                   verified:YES
                                                          attestationString:attestationString
                                                                      keyId:keyId
@@ -175,7 +175,7 @@
                                                                 foreground:[RadarUtils foreground]
                                                                     source:RadarLocationSourceForegroundLocation
                                                                   replayed:NO
-                                                                   beacons:nil
+                                                                   beacons:beacons
                                                                   verified:YES
                                                          attestationString:attestationString
                                                                      keyId:keyId

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -51,99 +51,97 @@
 }
 
 - (void)trackVerifiedWithBeacons:(BOOL)beacons completionHandler:(RadarTrackCompletionHandler)completionHandler {
-    @synchronized(self) {
-        [[RadarAPIClient sharedInstance]
-         getConfigForUsage:@"verify"
-         verified:YES
-         completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
-            [[RadarLocationManager sharedInstance]
-             getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
-             completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
-                if (status != RadarStatusSuccess) {
-                    if (completionHandler) {
-                        [RadarUtils runOnMainThread:^{
-                            completionHandler(status, nil, nil, nil);
-                        }];
-                    }
-                    
-                    return;
+    [[RadarAPIClient sharedInstance]
+     getConfigForUsage:@"verify"
+     verified:YES
+     completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
+        [[RadarLocationManager sharedInstance]
+         getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
+         completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
+            if (status != RadarStatusSuccess) {
+                if (completionHandler) {
+                    [RadarUtils runOnMainThread:^{
+                        completionHandler(status, nil, nil, nil);
+                    }];
                 }
                 
-                [self getAttestationWithNonce:config.nonce
-                            completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
-                    void (^callTrackAPI)(NSArray<RadarBeacon *> *_Nullable) = ^(NSArray<RadarBeacon *> *_Nullable beacons) {
-                        [[RadarAPIClient sharedInstance]
-                         trackWithLocation:location
-                         stopped:RadarState.stopped
-                         foreground:[RadarUtils foreground]
-                         source:RadarLocationSourceForegroundLocation
-                         replayed:NO
-                         beacons:beacons
-                         verified:YES
-                         attestationString:attestationString
-                         keyId:keyId
-                         attestationError:attestationError
-                         encrypted:NO
-                         completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
-                                             RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
-                                             RadarConfig *_Nullable config, NSString *_Nullable token) {
-                            if (status == RadarStatusSuccess && config != nil) {
-                                [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
-                            }
-                            if (completionHandler) {
-                                [RadarUtils runOnMainThread:^{
-                                    completionHandler(status, location, events, user);
-                                }];
-                            }
-                        }];
-                    };
-                    
-                    if (beacons) {
-                        [[RadarAPIClient sharedInstance]
-                         searchBeaconsNear:location
-                         radius:1000
-                         limit:10
-                         completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons,
-                                             NSArray<NSString *> *_Nullable beaconUUIDs) {
-                            if (beaconUUIDs && beaconUUIDs.count) {
-                                [RadarUtils runOnMainThread:^{
-                                    [[RadarBeaconManager sharedInstance]
-                                     rangeBeaconUUIDs:beaconUUIDs
-                                     completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
-                                        if (status != RadarStatusSuccess || !beacons) {
-                                            callTrackAPI(nil);
-                                            
-                                            return;
-                                        }
+                return;
+            }
+            
+            [self getAttestationWithNonce:config.nonce
+                        completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
+                void (^callTrackAPI)(NSArray<RadarBeacon *> *_Nullable) = ^(NSArray<RadarBeacon *> *_Nullable beacons) {
+                    [[RadarAPIClient sharedInstance]
+                     trackWithLocation:location
+                     stopped:RadarState.stopped
+                     foreground:[RadarUtils foreground]
+                     source:RadarLocationSourceForegroundLocation
+                     replayed:NO
+                     beacons:beacons
+                     verified:YES
+                     attestationString:attestationString
+                     keyId:keyId
+                     attestationError:attestationError
+                     encrypted:NO
+                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
+                                         RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
+                                         RadarConfig *_Nullable config, NSString *_Nullable token) {
+                        if (status == RadarStatusSuccess && config != nil) {
+                            [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
+                        }
+                        if (completionHandler) {
+                            [RadarUtils runOnMainThread:^{
+                                completionHandler(status, location, events, user);
+                            }];
+                        }
+                    }];
+                };
+                
+                if (beacons) {
+                    [[RadarAPIClient sharedInstance]
+                     searchBeaconsNear:location
+                     radius:1000
+                     limit:10
+                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons,
+                                         NSArray<NSString *> *_Nullable beaconUUIDs) {
+                        if (beaconUUIDs && beaconUUIDs.count) {
+                            [RadarUtils runOnMainThread:^{
+                                [[RadarBeaconManager sharedInstance]
+                                 rangeBeaconUUIDs:beaconUUIDs
+                                 completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
+                                    if (status != RadarStatusSuccess || !beacons) {
+                                        callTrackAPI(nil);
                                         
-                                        callTrackAPI(beacons);
-                                    }];
+                                        return;
+                                    }
+                                    
+                                    callTrackAPI(beacons);
                                 }];
-                            } else if (beacons && beacons.count) {
-                                [RadarUtils runOnMainThread:^{
-                                    [[RadarBeaconManager sharedInstance]
-                                     rangeBeacons:beacons
-                                     completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
-                                        if (status != RadarStatusSuccess || !beacons) {
-                                            callTrackAPI(nil);
-                                            
-                                            return;
-                                        }
+                            }];
+                        } else if (beacons && beacons.count) {
+                            [RadarUtils runOnMainThread:^{
+                                [[RadarBeaconManager sharedInstance]
+                                 rangeBeacons:beacons
+                                 completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
+                                    if (status != RadarStatusSuccess || !beacons) {
+                                        callTrackAPI(nil);
                                         
-                                        callTrackAPI(beacons);
-                                    }];
+                                        return;
+                                    }
+                                    
+                                    callTrackAPI(beacons);
                                 }];
-                            } else {
-                                callTrackAPI(nil);
-                            }
-                        }];
-                    } else {
-                        callTrackAPI(nil);
-                    }
-                }];
+                            }];
+                        } else {
+                            callTrackAPI(nil);
+                        }
+                    }];
+                } else {
+                    callTrackAPI(nil);
+                }
             }];
         }];
-    }
+    }];
 }
 
 - (void)trackVerifiedTokenWithCompletionHandler:(RadarTrackTokenCompletionHandler)completionHandler {
@@ -151,99 +149,97 @@
 }
 
 - (void)trackVerifiedTokenWithBeacons:(BOOL)beacons completionHandler:(RadarTrackTokenCompletionHandler)completionHandler {
-    @synchronized(self) {
-        [[RadarAPIClient sharedInstance]
-         getConfigForUsage:@"verify"
-         verified:YES
-         completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
-            [[RadarLocationManager sharedInstance]
-             getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
-             completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
-                if (status != RadarStatusSuccess) {
-                    if (completionHandler) {
-                        [RadarUtils runOnMainThread:^{
-                            completionHandler(status, nil);
-                        }];
-                    }
-                    
-                    return;
+    [[RadarAPIClient sharedInstance]
+     getConfigForUsage:@"verify"
+     verified:YES
+     completionHandler:^(RadarStatus status, RadarConfig *_Nullable config) {
+        [[RadarLocationManager sharedInstance]
+         getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyHigh
+         completionHandler:^(RadarStatus status, CLLocation *_Nullable location, BOOL stopped) {
+            if (status != RadarStatusSuccess) {
+                if (completionHandler) {
+                    [RadarUtils runOnMainThread:^{
+                        completionHandler(status, nil);
+                    }];
                 }
                 
-                [self getAttestationWithNonce:config.nonce
-                            completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
-                    void (^callTrackAPI)(NSArray<RadarBeacon *> *_Nullable) = ^(NSArray<RadarBeacon *> *_Nullable beacons) {
-                        [[RadarAPIClient sharedInstance]
-                         trackWithLocation:location
-                         stopped:RadarState.stopped
-                         foreground:[RadarUtils foreground]
-                         source:RadarLocationSourceForegroundLocation
-                         replayed:NO
-                         beacons:beacons
-                         verified:YES
-                         attestationString:attestationString
-                         keyId:keyId
-                         attestationError:attestationError
-                         encrypted:YES
-                         completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
-                                             RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
-                                             RadarConfig *_Nullable config, NSString *_Nullable token) {
-                            if (status == RadarStatusSuccess && config != nil) {
-                                [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
-                            }
-                            if (completionHandler) {
-                                [RadarUtils runOnMainThread:^{
-                                    completionHandler(status, token);
-                                }];
-                            }
-                        }];
-                    };
-                    
-                    if (beacons) {
-                        [[RadarAPIClient sharedInstance]
-                         searchBeaconsNear:location
-                         radius:1000
-                         limit:10
-                         completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons,
-                                             NSArray<NSString *> *_Nullable beaconUUIDs) {
-                            if (beaconUUIDs && beaconUUIDs.count) {
-                                [RadarUtils runOnMainThread:^{
-                                    [[RadarBeaconManager sharedInstance]
-                                     rangeBeaconUUIDs:beaconUUIDs
-                                     completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
-                                        if (status != RadarStatusSuccess || !beacons) {
-                                            callTrackAPI(nil);
-                                            
-                                            return;
-                                        }
+                return;
+            }
+            
+            [self getAttestationWithNonce:config.nonce
+                        completionHandler:^(NSString *_Nullable attestationString, NSString *_Nullable keyId, NSString *_Nullable attestationError) {
+                void (^callTrackAPI)(NSArray<RadarBeacon *> *_Nullable) = ^(NSArray<RadarBeacon *> *_Nullable beacons) {
+                    [[RadarAPIClient sharedInstance]
+                     trackWithLocation:location
+                     stopped:RadarState.stopped
+                     foreground:[RadarUtils foreground]
+                     source:RadarLocationSourceForegroundLocation
+                     replayed:NO
+                     beacons:beacons
+                     verified:YES
+                     attestationString:attestationString
+                     keyId:keyId
+                     attestationError:attestationError
+                     encrypted:YES
+                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarEvent *> *_Nullable events,
+                                         RadarUser *_Nullable user, NSArray<RadarGeofence *> *_Nullable nearbyGeofences,
+                                         RadarConfig *_Nullable config, NSString *_Nullable token) {
+                        if (status == RadarStatusSuccess && config != nil) {
+                            [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
+                        }
+                        if (completionHandler) {
+                            [RadarUtils runOnMainThread:^{
+                                completionHandler(status, token);
+                            }];
+                        }
+                    }];
+                };
+                
+                if (beacons) {
+                    [[RadarAPIClient sharedInstance]
+                     searchBeaconsNear:location
+                     radius:1000
+                     limit:10
+                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons,
+                                         NSArray<NSString *> *_Nullable beaconUUIDs) {
+                        if (beaconUUIDs && beaconUUIDs.count) {
+                            [RadarUtils runOnMainThread:^{
+                                [[RadarBeaconManager sharedInstance]
+                                 rangeBeaconUUIDs:beaconUUIDs
+                                 completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
+                                    if (status != RadarStatusSuccess || !beacons) {
+                                        callTrackAPI(nil);
                                         
-                                        callTrackAPI(beacons);
-                                    }];
+                                        return;
+                                    }
+                                    
+                                    callTrackAPI(beacons);
                                 }];
-                            } else if (beacons && beacons.count) {
-                                [RadarUtils runOnMainThread:^{
-                                    [[RadarBeaconManager sharedInstance]
-                                     rangeBeacons:beacons
-                                     completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
-                                        if (status != RadarStatusSuccess || !beacons) {
-                                            callTrackAPI(nil);
-                                            
-                                            return;
-                                        }
+                            }];
+                        } else if (beacons && beacons.count) {
+                            [RadarUtils runOnMainThread:^{
+                                [[RadarBeaconManager sharedInstance]
+                                 rangeBeacons:beacons
+                                 completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
+                                    if (status != RadarStatusSuccess || !beacons) {
+                                        callTrackAPI(nil);
                                         
-                                        callTrackAPI(beacons);
-                                    }];
+                                        return;
+                                    }
+                                    
+                                    callTrackAPI(beacons);
                                 }];
-                            } else {
-                                callTrackAPI(nil);
-                            }
-                        }];
-                    } else {
-                        callTrackAPI(nil);
-                    }
-                }];
+                            }];
+                        } else {
+                            callTrackAPI(nil);
+                        }
+                    }];
+                } else {
+                    callTrackAPI(nil);
+                }
             }];
         }];
-    }
+    }];
 }
 
 - (void)startTrackingVerified:(BOOL)token interval:(NSTimeInterval)interval beacons:(BOOL)beacons {

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -144,7 +144,7 @@
 }
 
 - (void)startTrackingVerified:(BOOL)token {
-    if (@available(iOS 14.0, *)) {
+    if (@available(iOS 12.0, *)) {
         if (!_monitor) {
             _monitor = nw_path_monitor_create();
             

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -160,7 +160,7 @@
                         [self trackVerifiedWithCompletionHandler:nil];
                     }
                 } else {
-                    NSLog(@"Network disconnected");
+                    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Network disconnected"];
                 }
             });
             
@@ -169,7 +169,7 @@
     }
     
     if (!self.timer) {
-        self.timer = [NSTimer scheduledTimerWithTimeInterval:30
+        self.timer = [NSTimer scheduledTimerWithTimeInterval:300
                                                      repeats:YES
                                                        block:^(NSTimer *_Nonnull timer) {
                                                            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Timer fired"];


### PR DESCRIPTION
- adds `startTrackingVerified(token:interval:beacons:)` which calls `trackVerified()` or `trackVerifiedToken()` on an `interval` or on network change (e.g., new IP address, connect to different wi-fi network) and delivers updates to a delegate
- refactors `trackVerified()` and `trackVerifiedToken()` logic into `RadarVerificationManager`
- adds `RadarVerifiedDelegate` with `didUpdateToken()` callback (modifying `RadarDelegate` would be a breaking change and potentially disruptive to non-Fraud users)