### PR TITLE
Kennyhu/mob 64 ios log app kills

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -13,17 +13,6 @@ import RadarSDK
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate, RadarDelegate {
 
     let locationManager = CLLocationManager()
-    
-    func applicationWillResignActive(_ application: UIApplication) {
-        // This method is called when the app is about to move from active to inactive state.
-        // You can log the event here.
-        print("User is about to quit the application.")
-    }
-    
-    func applicationWillTerminate(_ application: UIApplication) {
-        Radar.writeLocalLog("another arb log entry.")
-        print("User is to quit the application.")
-    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { (_, _) in }
@@ -33,8 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.requestLocationPermissions()
 
         // Replace with a valid test publishable key
-        Radar.writeLocalLog("another arb log entry2.")
-        Radar.initialize(publishableKey: "prj_test_pk_dda829b0b0bc3621b754e42da53271d07b32992f")
+        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
         Radar.setDelegate(self)
 
         if UIApplication.shared.applicationState != .background {
@@ -46,131 +34,131 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 print("Track once: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
             }
         }
-//
-        let options = RadarTrackingOptions.presetEfficient
+
+        let options = RadarTrackingOptions.presetContinuous
         Radar.startTracking(trackingOptions: options)
-//
-//        Radar.getContext { (status, location, context) in
-//            print("Context: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); context?.geofences = \(String(describing: context?.geofences)); context?.place = \(String(describing: context?.place)); context?.country = \(String(describing: context?.country))")
-//        }
-//
-//        // In the Radar dashboard settings
-//        // (https://radar.com/dashboard/settings), add this to the chain
-//        // metadata: {"mcdonalds":{"orderActive":"true"}}.
-//        Radar.searchPlaces(
-//            radius: 1000,
-//            chains: ["mcdonalds"],
-//            chainMetadata: ["orderActive": "true"],
-//            categories: nil,
-//            groups: nil,
-//            limit: 10
-//        ) { (status, location, places) in
-//            print("Search places: status = \(Radar.stringForStatus(status)); places = \(String(describing: places))")
-//        }
-//
-//        Radar.searchGeofences(
-//            radius: 1000,
-//            tags: ["store"],
-//            metadata: nil,
-//            limit: 10
-//        ) { (status, location, geofences) in
-//            print("Search geofences: status = \(Radar.stringForStatus(status)); geofences = \(String(describing: geofences))")
-//        }
-//
-//        Radar.geocode(address: "20 jay st brooklyn") { (status, addresses) in
-//            print("Geocode: status = \(Radar.stringForStatus(status)); coordinate = \(String(describing: addresses?.first?.coordinate))")
-//        }
-//
-//        Radar.reverseGeocode { (status, addresses) in
-//            print("Reverse geocode: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-//        }
-//
-//        Radar.ipGeocode { (status, address, proxy) in
-//            print("IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy)")
-//        }
-//
-//        let origin = CLLocation(latitude: 40.78382, longitude: -73.97536)
-//        let destination = CLLocation(latitude: 40.70390, longitude: -73.98670)
-//
-//
-//        Radar.autocomplete(
-//            query: "brooklyn",
-//            near: origin,
-//            layers: ["locality"],
-//            limit: 10,
-//            country: "US",
-//            expandUnits:true
-//        ) { (status, addresses) in
-//            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-//
-//            if let address = addresses?.first {
-//                Radar.validateAddress(address: address) { (status, address, verificationStatus) in
-//                    print("Validate address: status = \(Radar.stringForStatus(status)); address = \(String(describing: address)); verificationStatus = \(Radar.stringForVerificationStatus(verificationStatus))")
-//                }
-//            }
-//        }
-//
-//        Radar.autocomplete(
-//            query: "brooklyn",
-//            near: origin,
-//            layers: ["locality"],
-//            limit: 10,
-//            country: "US"
-//        ) { (status, addresses) in
-//            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-//        }
-//
-//        Radar.getDistance(
-//            origin: origin,
-//            destination: destination,
-//            modes: [.foot, .car],
-//            units: .imperial
-//        ) { (status, routes) in
-//            print("Distance: status = \(Radar.stringForStatus(status)); routes.car.distance.value = \(String(describing: routes?.car?.distance.value)); routes.car.distance.text = \(String(describing: routes?.car?.distance.text)); routes.car.duration.value = \(String(describing: routes?.car?.duration.value)); routes.car.duration.text = \(String(describing: routes?.car?.duration.text))")
-//        }
-//
-//        let tripOptions = RadarTripOptions(externalId: "299", destinationGeofenceTag: "store", destinationGeofenceExternalId: "123")
-//        tripOptions.mode = .car
-//        tripOptions.approachingThreshold = 9
-//        Radar.startTrip(options: tripOptions)
-//
-//        var i = 0
-//        Radar.mockTracking(
-//            origin: origin,
-//            destination: destination,
-//            mode: .car,
-//            steps: 3,
-//            interval: 3
-//        ) { (status, location, events, user) in
-//            print("Mock track: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
-//
-//            if (i == 2) {
-//                Radar.completeTrip()
-//            }
-//
-//            i += 1
-//        }
-//
-//        let origins = [
-//            CLLocation(latitude: 40.78382, longitude: -73.97536),
-//            CLLocation(latitude: 40.70390, longitude: -73.98670)
-//        ]
-//        let destinations = [
-//            CLLocation(latitude: 40.64189, longitude: -73.78779),
-//            CLLocation(latitude: 35.99801, longitude: -78.94294)
-//        ]
-//
-//        Radar.getMatrix(origins: origins, destinations: destinations, mode: .car, units: .imperial) { (status, matrix) in
-//            print("Matrix: status = \(Radar.stringForStatus(status)); matrix[0][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 0)?.duration.text)); matrix[0][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 1)?.duration.text)); matrix[1][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 0)?.duration.text)); matrix[1][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 1)?.duration.text))")
-//        }
-//
-//        Radar.logConversion(name: "conversion_event", metadata: ["data": "test"]) { (status, event) in
-//            if let conversionEvent = event, conversionEvent.type == .conversion {
-//                print("Conversion name: \(conversionEvent.conversionName!)")
-//            }
-//
-//            print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
-//        }
+
+        Radar.getContext { (status, location, context) in
+            print("Context: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); context?.geofences = \(String(describing: context?.geofences)); context?.place = \(String(describing: context?.place)); context?.country = \(String(describing: context?.country))")
+        }
+        
+        // In the Radar dashboard settings
+        // (https://radar.com/dashboard/settings), add this to the chain
+        // metadata: {"mcdonalds":{"orderActive":"true"}}.
+        Radar.searchPlaces(
+            radius: 1000,
+            chains: ["mcdonalds"],
+            chainMetadata: ["orderActive": "true"],
+            categories: nil,
+            groups: nil,
+            limit: 10
+        ) { (status, location, places) in
+            print("Search places: status = \(Radar.stringForStatus(status)); places = \(String(describing: places))")
+        }
+
+        Radar.searchGeofences(
+            radius: 1000,
+            tags: ["store"],
+            metadata: nil,
+            limit: 10
+        ) { (status, location, geofences) in
+            print("Search geofences: status = \(Radar.stringForStatus(status)); geofences = \(String(describing: geofences))")
+        }
+
+        Radar.geocode(address: "20 jay st brooklyn") { (status, addresses) in
+            print("Geocode: status = \(Radar.stringForStatus(status)); coordinate = \(String(describing: addresses?.first?.coordinate))")
+        }
+
+        Radar.reverseGeocode { (status, addresses) in
+            print("Reverse geocode: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+        }
+
+        Radar.ipGeocode { (status, address, proxy) in
+            print("IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy)")
+        }
+
+        let origin = CLLocation(latitude: 40.78382, longitude: -73.97536)
+        let destination = CLLocation(latitude: 40.70390, longitude: -73.98670)
+
+
+        Radar.autocomplete(
+            query: "brooklyn",
+            near: origin,
+            layers: ["locality"],
+            limit: 10,
+            country: "US",
+            expandUnits:true
+        ) { (status, addresses) in
+            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+
+            if let address = addresses?.first {
+                Radar.validateAddress(address: address) { (status, address, verificationStatus) in
+                    print("Validate address: status = \(Radar.stringForStatus(status)); address = \(String(describing: address)); verificationStatus = \(Radar.stringForVerificationStatus(verificationStatus))")
+                }
+            }
+        }
+
+        Radar.autocomplete(
+            query: "brooklyn",
+            near: origin,
+            layers: ["locality"],
+            limit: 10,
+            country: "US"
+        ) { (status, addresses) in
+            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+        }
+
+        Radar.getDistance(
+            origin: origin,
+            destination: destination,
+            modes: [.foot, .car],
+            units: .imperial
+        ) { (status, routes) in
+            print("Distance: status = \(Radar.stringForStatus(status)); routes.car.distance.value = \(String(describing: routes?.car?.distance.value)); routes.car.distance.text = \(String(describing: routes?.car?.distance.text)); routes.car.duration.value = \(String(describing: routes?.car?.duration.value)); routes.car.duration.text = \(String(describing: routes?.car?.duration.text))")
+        }
+
+        let tripOptions = RadarTripOptions(externalId: "299", destinationGeofenceTag: "store", destinationGeofenceExternalId: "123")
+        tripOptions.mode = .car
+        tripOptions.approachingThreshold = 9
+        Radar.startTrip(options: tripOptions)
+
+        var i = 0
+        Radar.mockTracking(
+            origin: origin,
+            destination: destination,
+            mode: .car,
+            steps: 3,
+            interval: 3
+        ) { (status, location, events, user) in
+            print("Mock track: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
+
+            if (i == 2) {
+                Radar.completeTrip()
+            }
+
+            i += 1
+        }
+
+        let origins = [
+            CLLocation(latitude: 40.78382, longitude: -73.97536),
+            CLLocation(latitude: 40.70390, longitude: -73.98670)
+        ]
+        let destinations = [
+            CLLocation(latitude: 40.64189, longitude: -73.78779),
+            CLLocation(latitude: 35.99801, longitude: -78.94294)
+        ]
+
+        Radar.getMatrix(origins: origins, destinations: destinations, mode: .car, units: .imperial) { (status, matrix) in
+            print("Matrix: status = \(Radar.stringForStatus(status)); matrix[0][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 0)?.duration.text)); matrix[0][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 1)?.duration.text)); matrix[1][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 0)?.duration.text)); matrix[1][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 1)?.duration.text))")
+        }
+
+        Radar.logConversion(name: "conversion_event", metadata: ["data": "test"]) { (status, event) in
+            if let conversionEvent = event, conversionEvent.type == .conversion {
+                print("Conversion name: \(conversionEvent.conversionName!)")
+            }
+
+            print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
+        }
 
         return true
     }

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -13,6 +13,17 @@ import RadarSDK
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate, RadarDelegate {
 
     let locationManager = CLLocationManager()
+    
+    func applicationWillResignActive(_ application: UIApplication) {
+        // This method is called when the app is about to move from active to inactive state.
+        // You can log the event here.
+        print("User is about to quit the application.")
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        Radar.writeLocalLog("another arb log entry.")
+        print("User is to quit the application.")
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { (_, _) in }
@@ -22,7 +33,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.requestLocationPermissions()
 
         // Replace with a valid test publishable key
-        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
+        Radar.writeLocalLog("another arb log entry2.")
+        Radar.initialize(publishableKey: "prj_test_pk_dda829b0b0bc3621b754e42da53271d07b32992f")
         Radar.setDelegate(self)
 
         if UIApplication.shared.applicationState != .background {
@@ -34,131 +46,131 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 print("Track once: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
             }
         }
-
-        let options = RadarTrackingOptions.presetContinuous
+//
+        let options = RadarTrackingOptions.presetEfficient
         Radar.startTracking(trackingOptions: options)
-
-        Radar.getContext { (status, location, context) in
-            print("Context: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); context?.geofences = \(String(describing: context?.geofences)); context?.place = \(String(describing: context?.place)); context?.country = \(String(describing: context?.country))")
-        }
-        
-        // In the Radar dashboard settings
-        // (https://radar.com/dashboard/settings), add this to the chain
-        // metadata: {"mcdonalds":{"orderActive":"true"}}.
-        Radar.searchPlaces(
-            radius: 1000,
-            chains: ["mcdonalds"],
-            chainMetadata: ["orderActive": "true"],
-            categories: nil,
-            groups: nil,
-            limit: 10
-        ) { (status, location, places) in
-            print("Search places: status = \(Radar.stringForStatus(status)); places = \(String(describing: places))")
-        }
-
-        Radar.searchGeofences(
-            radius: 1000,
-            tags: ["store"],
-            metadata: nil,
-            limit: 10
-        ) { (status, location, geofences) in
-            print("Search geofences: status = \(Radar.stringForStatus(status)); geofences = \(String(describing: geofences))")
-        }
-
-        Radar.geocode(address: "20 jay st brooklyn") { (status, addresses) in
-            print("Geocode: status = \(Radar.stringForStatus(status)); coordinate = \(String(describing: addresses?.first?.coordinate))")
-        }
-
-        Radar.reverseGeocode { (status, addresses) in
-            print("Reverse geocode: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-        }
-
-        Radar.ipGeocode { (status, address, proxy) in
-            print("IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy)")
-        }
-
-        let origin = CLLocation(latitude: 40.78382, longitude: -73.97536)
-        let destination = CLLocation(latitude: 40.70390, longitude: -73.98670)
-
-
-        Radar.autocomplete(
-            query: "brooklyn",
-            near: origin,
-            layers: ["locality"],
-            limit: 10,
-            country: "US",
-            expandUnits:true
-        ) { (status, addresses) in
-            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-
-            if let address = addresses?.first {
-                Radar.validateAddress(address: address) { (status, address, verificationStatus) in
-                    print("Validate address: status = \(Radar.stringForStatus(status)); address = \(String(describing: address)); verificationStatus = \(Radar.stringForVerificationStatus(verificationStatus))")
-                }
-            }
-        }
-
-        Radar.autocomplete(
-            query: "brooklyn",
-            near: origin,
-            layers: ["locality"],
-            limit: 10,
-            country: "US"
-        ) { (status, addresses) in
-            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
-        }
-
-        Radar.getDistance(
-            origin: origin,
-            destination: destination,
-            modes: [.foot, .car],
-            units: .imperial
-        ) { (status, routes) in
-            print("Distance: status = \(Radar.stringForStatus(status)); routes.car.distance.value = \(String(describing: routes?.car?.distance.value)); routes.car.distance.text = \(String(describing: routes?.car?.distance.text)); routes.car.duration.value = \(String(describing: routes?.car?.duration.value)); routes.car.duration.text = \(String(describing: routes?.car?.duration.text))")
-        }
-
-        let tripOptions = RadarTripOptions(externalId: "299", destinationGeofenceTag: "store", destinationGeofenceExternalId: "123")
-        tripOptions.mode = .car
-        tripOptions.approachingThreshold = 9
-        Radar.startTrip(options: tripOptions)
-
-        var i = 0
-        Radar.mockTracking(
-            origin: origin,
-            destination: destination,
-            mode: .car,
-            steps: 3,
-            interval: 3
-        ) { (status, location, events, user) in
-            print("Mock track: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
-
-            if (i == 2) {
-                Radar.completeTrip()
-            }
-
-            i += 1
-        }
-
-        let origins = [
-            CLLocation(latitude: 40.78382, longitude: -73.97536),
-            CLLocation(latitude: 40.70390, longitude: -73.98670)
-        ]
-        let destinations = [
-            CLLocation(latitude: 40.64189, longitude: -73.78779),
-            CLLocation(latitude: 35.99801, longitude: -78.94294)
-        ]
-
-        Radar.getMatrix(origins: origins, destinations: destinations, mode: .car, units: .imperial) { (status, matrix) in
-            print("Matrix: status = \(Radar.stringForStatus(status)); matrix[0][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 0)?.duration.text)); matrix[0][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 1)?.duration.text)); matrix[1][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 0)?.duration.text)); matrix[1][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 1)?.duration.text))")
-        }
-
-        Radar.logConversion(name: "conversion_event", metadata: ["data": "test"]) { (status, event) in
-            if let conversionEvent = event, conversionEvent.type == .conversion {
-                print("Conversion name: \(conversionEvent.conversionName!)")
-            }
-
-            print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
-        }
+//
+//        Radar.getContext { (status, location, context) in
+//            print("Context: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); context?.geofences = \(String(describing: context?.geofences)); context?.place = \(String(describing: context?.place)); context?.country = \(String(describing: context?.country))")
+//        }
+//
+//        // In the Radar dashboard settings
+//        // (https://radar.com/dashboard/settings), add this to the chain
+//        // metadata: {"mcdonalds":{"orderActive":"true"}}.
+//        Radar.searchPlaces(
+//            radius: 1000,
+//            chains: ["mcdonalds"],
+//            chainMetadata: ["orderActive": "true"],
+//            categories: nil,
+//            groups: nil,
+//            limit: 10
+//        ) { (status, location, places) in
+//            print("Search places: status = \(Radar.stringForStatus(status)); places = \(String(describing: places))")
+//        }
+//
+//        Radar.searchGeofences(
+//            radius: 1000,
+//            tags: ["store"],
+//            metadata: nil,
+//            limit: 10
+//        ) { (status, location, geofences) in
+//            print("Search geofences: status = \(Radar.stringForStatus(status)); geofences = \(String(describing: geofences))")
+//        }
+//
+//        Radar.geocode(address: "20 jay st brooklyn") { (status, addresses) in
+//            print("Geocode: status = \(Radar.stringForStatus(status)); coordinate = \(String(describing: addresses?.first?.coordinate))")
+//        }
+//
+//        Radar.reverseGeocode { (status, addresses) in
+//            print("Reverse geocode: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+//        }
+//
+//        Radar.ipGeocode { (status, address, proxy) in
+//            print("IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy)")
+//        }
+//
+//        let origin = CLLocation(latitude: 40.78382, longitude: -73.97536)
+//        let destination = CLLocation(latitude: 40.70390, longitude: -73.98670)
+//
+//
+//        Radar.autocomplete(
+//            query: "brooklyn",
+//            near: origin,
+//            layers: ["locality"],
+//            limit: 10,
+//            country: "US",
+//            expandUnits:true
+//        ) { (status, addresses) in
+//            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+//
+//            if let address = addresses?.first {
+//                Radar.validateAddress(address: address) { (status, address, verificationStatus) in
+//                    print("Validate address: status = \(Radar.stringForStatus(status)); address = \(String(describing: address)); verificationStatus = \(Radar.stringForVerificationStatus(verificationStatus))")
+//                }
+//            }
+//        }
+//
+//        Radar.autocomplete(
+//            query: "brooklyn",
+//            near: origin,
+//            layers: ["locality"],
+//            limit: 10,
+//            country: "US"
+//        ) { (status, addresses) in
+//            print("Autocomplete: status = \(Radar.stringForStatus(status)); formattedAddress = \(String(describing: addresses?.first?.formattedAddress))")
+//        }
+//
+//        Radar.getDistance(
+//            origin: origin,
+//            destination: destination,
+//            modes: [.foot, .car],
+//            units: .imperial
+//        ) { (status, routes) in
+//            print("Distance: status = \(Radar.stringForStatus(status)); routes.car.distance.value = \(String(describing: routes?.car?.distance.value)); routes.car.distance.text = \(String(describing: routes?.car?.distance.text)); routes.car.duration.value = \(String(describing: routes?.car?.duration.value)); routes.car.duration.text = \(String(describing: routes?.car?.duration.text))")
+//        }
+//
+//        let tripOptions = RadarTripOptions(externalId: "299", destinationGeofenceTag: "store", destinationGeofenceExternalId: "123")
+//        tripOptions.mode = .car
+//        tripOptions.approachingThreshold = 9
+//        Radar.startTrip(options: tripOptions)
+//
+//        var i = 0
+//        Radar.mockTracking(
+//            origin: origin,
+//            destination: destination,
+//            mode: .car,
+//            steps: 3,
+//            interval: 3
+//        ) { (status, location, events, user) in
+//            print("Mock track: status = \(Radar.stringForStatus(status)); location = \(String(describing: location)); events = \(String(describing: events)); user = \(String(describing: user))")
+//
+//            if (i == 2) {
+//                Radar.completeTrip()
+//            }
+//
+//            i += 1
+//        }
+//
+//        let origins = [
+//            CLLocation(latitude: 40.78382, longitude: -73.97536),
+//            CLLocation(latitude: 40.70390, longitude: -73.98670)
+//        ]
+//        let destinations = [
+//            CLLocation(latitude: 40.64189, longitude: -73.78779),
+//            CLLocation(latitude: 35.99801, longitude: -78.94294)
+//        ]
+//
+//        Radar.getMatrix(origins: origins, destinations: destinations, mode: .car, units: .imperial) { (status, matrix) in
+//            print("Matrix: status = \(Radar.stringForStatus(status)); matrix[0][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 0)?.duration.text)); matrix[0][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 0, destinationIndex: 1)?.duration.text)); matrix[1][0].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 0)?.duration.text)); matrix[1][1].duration.text = \(String(describing: matrix?.routeBetween(originIndex: 1, destinationIndex: 1)?.duration.text))")
+//        }
+//
+//        Radar.logConversion(name: "conversion_event", metadata: ["data": "test"]) { (status, event) in
+//            if let conversionEvent = event, conversionEvent.type == .conversion {
+//                print("Conversion name: \(conversionEvent.conversionName!)")
+//            }
+//
+//            print("Log Conversion: status = \(Radar.stringForStatus(status)); event = \(String(describing: event))")
+//        }
 
         return true
     }

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		DD8E2F7A24018C37002D51AB /* CLLocationManagerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = DD8E2F7924018C37002D51AB /* CLLocationManagerMock.m */; };
 		DD8E2F7D24018C54002D51AB /* CLVisitMock.m in Sources */ = {isa = PBXBuildFile; fileRef = DD8E2F7C24018C54002D51AB /* CLVisitMock.m */; };
 		DE1E7644239724FD006F34A1 /* search_geofences.json in Resources */ = {isa = PBXBuildFile; fileRef = DE1E7643239724FD006F34A1 /* search_geofences.json */; };
+		E619D29D2B0BF4CE00C88578 /* RadarFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = E619D29C2B0BF4CE00C88578 /* RadarFileSystem.h */; };
+		E619D29F2B0BF50D00C88578 /* RadarFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = E619D29E2B0BF50D00C88578 /* RadarFileSystem.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -315,6 +317,8 @@
 		DDD7BD0325EC3015002473B3 /* RadarRouteMatrix.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarRouteMatrix.m; sourceTree = "<group>"; };
 		DDF1157C2524E18100D575C4 /* RadarTrip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarTrip.m; sourceTree = "<group>"; };
 		DE1E7643239724FD006F34A1 /* search_geofences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = search_geofences.json; sourceTree = "<group>"; };
+		E619D29C2B0BF4CE00C88578 /* RadarFileSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarFileSystem.h; sourceTree = "<group>"; };
+		E619D29E2B0BF50D00C88578 /* RadarFileSystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarFileSystem.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -447,6 +451,8 @@
 				58F950CF2407038300364B15 /* RadarCollectionAdditions.m */,
 				01F99CFA2965C182004E8CF3 /* RadarConfig.h */,
 				01F99CFC2965C1C4004E8CF3 /* RadarConfig.m */,
+				E619D29C2B0BF4CE00C88578 /* RadarFileSystem.h */,
+				E619D29E2B0BF50D00C88578 /* RadarFileSystem.m */,
 				96A5A11727ADA02E007B960B /* RadarDelegateHolder.h */,
 				DD4C104925D87E3E009C2E36 /* RadarDelegateHolder.m */,
 				DD236CF723088F8400EB88F9 /* RadarLocationManager.h */,
@@ -628,6 +634,7 @@
 				96A5A0C427AD9F41007B960B /* RadarCircleGeometry+Internal.h in Headers */,
 				0114F058284EFDB700ADA4E4 /* RadarRouteMode.h in Headers */,
 				96A5A0D527AD9F41007B960B /* RadarRouteDuration+Internal.h in Headers */,
+				E619D29D2B0BF4CE00C88578 /* RadarFileSystem.h in Headers */,
 				96A5A0CE27AD9F41007B960B /* RadarCoordinate+Internal.h in Headers */,
 				96A5A11927ADA02F007B960B /* RadarLog.h in Headers */,
 				96A5A10A27AD9F7F007B960B /* RadarAddress.h in Headers */,
@@ -785,6 +792,7 @@
 				0107AA9B26220153008AB52F /* RadarContext.m in Sources */,
 				015C53AE29B8E8BA004F53A6 /* (null) in Sources */,
 				0107AB23262201EC008AB52F /* RadarSettings.m in Sources */,
+				E619D29F2B0BF50D00C88578 /* RadarFileSystem.m in Sources */,
 				0107AAAA26220165008AB52F /* RadarGeofenceGeometry.m in Sources */,
 				0107AAEC262201A6008AB52F /* RadarTrip.m in Sources */,
 				9679F4A327CD8DE200800797 /* CLLocation+Radar.m in Sources */,

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1003,6 +1003,20 @@ logConversionWithNotification
  */
 + (void)setLogLevel:(RadarLogLevel)level;
 
+/**
+ Writes to local logs.
+
+ @param message The message to be logged.
+ */
++ (void)writeLocalLog:(NSString *_Nonnull)message;
+
+/**
+ Log user terminating application.
+
+ */
++ (void)logUserTermination;
+
+
 #pragma mark - Helpers
 
 /**

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1011,10 +1011,23 @@ logConversionWithNotification
 + (void)writeLocalLog:(NSString *_Nonnull)message;
 
 /**
- Log user terminating application.
+ Log application termination.
 
  */
 + (void)logTermination;
+
+/**
+ Log application entering background.
+
+ */
++ (void)logEnteringBackground;
+
+/**
+ Log application resigning active.
+
+ */
++ (void)logResignActive;
+
 
 
 #pragma mark - Helpers

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1014,7 +1014,7 @@ logConversionWithNotification
  Log user terminating application.
 
  */
-+ (void)logUserTermination;
++ (void)logTermination;
 
 
 #pragma mark - Helpers

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1039,7 +1039,7 @@
 }
 
 + (void)writeLocalLog:(NSString *)message {
-    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeAppLifecycleEvent message:message];
+    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeNone message:message];
 
 }
 
@@ -1048,7 +1048,7 @@
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
     NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
     NSString *message = [NSString stringWithFormat:@"User terminated app at %@", dateString];
-    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeAppLifecycleEvent message:message];
+    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeNone message:message];
 }
 
 #pragma mark - Helpers

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1043,13 +1043,18 @@
 
 }
 
-+ (void) logUserTermination {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
-    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
-    NSString *message = [NSString stringWithFormat:@"App terminated at %@", dateString];
-    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:message];
++ (void) logTermination {
+    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:@"App terminated" includeDate:YES includeBattery:YES];
 }
+
++ (void) logEnteringBackground {
+    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:@"App entering background" includeDate:YES includeBattery:YES];
+}
+
++ (void) logResignActive {
+    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:@"App resigning active" includeDate:YES includeBattery:YES];
+}
+
 
 #pragma mark - Helpers
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1039,7 +1039,7 @@
 }
 
 + (void)writeLocalLog:(NSString *)message {
-    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeNone message:message];
+    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:message];
 
 }
 
@@ -1047,8 +1047,8 @@
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
     NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
-    NSString *message = [NSString stringWithFormat:@"User terminated app at %@", dateString];
-    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeNone message:message];
+    NSString *message = [NSString stringWithFormat:@"App terminated at %@", dateString];
+    [[RadarLogger sharedInstance] logWithLevelToFileSystem:RadarLogLevelInfo type:RadarLogTypeNone message:message];
 }
 
 #pragma mark - Helpers

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1046,7 +1046,7 @@
 + (void) logUserTermination {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
-    NSString *dateString =  [dateFormatter stringFromDate:[NSDate date]];
+    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
     NSString *message = [NSString stringWithFormat:@"User terminated app at %@", dateString];
     [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeAppLifecycleEvent message:message];
 }

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -43,6 +43,8 @@
 
 + (void)initializeWithPublishableKey:(NSString *)publishableKey {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"initialize()"];
+    
+    [[RadarLogger sharedInstance] flushLocalLogs];
 
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
                                              selector:@selector(applicationWillEnterForeground)
@@ -1034,6 +1036,19 @@
 
 + (void)setLogLevel:(RadarLogLevel)level {
     [RadarSettings setLogLevel:level];
+}
+
++ (void)writeLocalLog:(NSString *)message {
+    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeAppLifecycleEvent message:message];
+
+}
+
++ (void) logUserTermination {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+    NSString *dateString =  [dateFormatter stringFromDate:[NSDate date]];
+    NSString *message = [NSString stringWithFormat:@"User terminated app at %@", dateString];
+    [[RadarLogger sharedInstance] logWithLevelLocal:RadarLogLevelInfo type:RadarLogTypeAppLifecycleEvent message:message];
 }
 
 #pragma mark - Helpers

--- a/RadarSDK/RadarFileSystem.h
+++ b/RadarSDK/RadarFileSystem.h
@@ -12,5 +12,6 @@
 
 - (NSData *)readFileAtPath:(NSString *)filePath;
 - (void)writeData:(NSData *)data toFileAtPath:(NSString *)filePath;
+- (void)deleteFileAtPath:(NSString *)filePath;
 
 @end

--- a/RadarSDK/RadarFileSystem.h
+++ b/RadarSDK/RadarFileSystem.h
@@ -1,3 +1,11 @@
+//
+//  RadarFileSystem.h
+//  RadarSDK
+//
+//  Created by Kenny Hu on 11/20/23.
+//  Copyright © 2023 Radar Labs, Inc. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 
 @interface RadarFileSystem : NSObject

--- a/RadarSDK/RadarFileSystem.h
+++ b/RadarSDK/RadarFileSystem.h
@@ -11,7 +11,9 @@
 @interface RadarFileSystem : NSObject
 
 - (NSData *)readFileAtPath:(NSString *)filePath;
+
 - (void)writeData:(NSData *)data toFileAtPath:(NSString *)filePath;
+
 - (void)deleteFileAtPath:(NSString *)filePath;
 
 @end

--- a/RadarSDK/RadarFileSystem.h
+++ b/RadarSDK/RadarFileSystem.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface RadarFileSystem : NSObject
+
+- (NSData *)readFileAtPath:(NSString *)filePath;
+- (void)writeData:(NSData *)data toFileAtPath:(NSString *)filePath;
+
+@end

--- a/RadarSDK/RadarFileSystem.m
+++ b/RadarSDK/RadarFileSystem.m
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+#import "RadarFileSystem.h"
+
+@implementation RadarFileSystem
+
+- (NSData *)readFileAtPath:(NSString *)filePath {
+    __block NSData *fileData = nil;
+
+    NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
+    [fileCoordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:filePath] options:0 error:nil byAccessor:^(NSURL *newURL) {
+        fileData = [NSData dataWithContentsOfURL:newURL];
+    }];
+
+    return fileData;
+}
+
+- (void)writeData:(NSData *)data toFileAtPath:(NSString *)filePath {
+    NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
+    [fileCoordinator coordinateWritingItemAtURL:[NSURL fileURLWithPath:filePath] options:NSFileCoordinatorWritingForReplacing error:nil byAccessor:^(NSURL *newURL) {
+        [data writeToURL:newURL atomically:YES];
+    }];
+}
+
+@end

--- a/RadarSDK/RadarFileSystem.m
+++ b/RadarSDK/RadarFileSystem.m
@@ -1,3 +1,11 @@
+//
+//  RadarFileSystem.m
+//  RadarSDK
+//
+//  Created by Kenny Hu on 11/20/23.
+//  Copyright © 2023 Radar Labs, Inc. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 #import "RadarFileSystem.h"
 
@@ -22,3 +30,4 @@
 }
 
 @end
+

--- a/RadarSDK/RadarFileSystem.m
+++ b/RadarSDK/RadarFileSystem.m
@@ -29,7 +29,6 @@
     }];
 }
 
-//method to delte file at path
 - (void)deleteFileAtPath:(NSString *)filePath {
     NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
     [fileCoordinator coordinateWritingItemAtURL:[NSURL fileURLWithPath:filePath] options:NSFileCoordinatorWritingForDeleting error:nil byAccessor:^(NSURL *newURL) {

--- a/RadarSDK/RadarFileSystem.m
+++ b/RadarSDK/RadarFileSystem.m
@@ -29,5 +29,13 @@
     }];
 }
 
+//method to delte file at path
+- (void)deleteFileAtPath:(NSString *)filePath {
+    NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
+    [fileCoordinator coordinateWritingItemAtURL:[NSURL fileURLWithPath:filePath] options:NSFileCoordinatorWritingForDeleting error:nil byAccessor:^(NSURL *newURL) {
+        [[NSFileManager defaultManager] removeItemAtURL:newURL error:nil];
+    }];
+}
+
 @end
 

--- a/RadarSDK/RadarLog.h
+++ b/RadarSDK/RadarLog.h
@@ -36,7 +36,7 @@
 
 - (NSDictionary *_Nonnull)dictionaryValue;
 
-- (instancetype)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
+- (instancetype _Nullable)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
 
 + (NSArray<NSDictionary *> *_Nullable)arrayForLogs:(NSArray<RadarLog *> *_Nullable)logs;
 

--- a/RadarSDK/RadarLog.h
+++ b/RadarSDK/RadarLog.h
@@ -36,6 +36,8 @@
 
 - (NSDictionary *_Nonnull)dictionaryValue;
 
+- (instancetype)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
+
 + (NSArray<NSDictionary *> *_Nullable)arrayForLogs:(NSArray<RadarLog *> *_Nullable)logs;
 
 /**

--- a/RadarSDK/RadarLog.m
+++ b/RadarSDK/RadarLog.m
@@ -68,6 +68,29 @@
     return str;
 }
 
++ (RadarLogLevel)logLevelForString:(NSString *)string {
+    NSDictionary<NSString *, NSNumber *> *logLevelMap = @{
+        @"none" : @(RadarLogLevelNone),
+        @"error" : @(RadarLogLevelError),
+        @"warning" : @(RadarLogLevelWarning),
+        @"info" : @(RadarLogLevelInfo),
+        @"debug" : @(RadarLogLevelDebug)
+    };
+    return logLevelMap[string].integerValue;
+}
+
++ (RadarLogType)logTypeForString:(NSString *)string {
+    NSDictionary<NSString *, NSNumber *> *logTypeMap = @{
+        @"NONE" : @(RadarLogTypeNone),
+        @"SDK_CALL" : @(RadarLogTypeSDKCall),
+        @"SDK_ERROR" : @(RadarLogTypeSDKError),
+        @"SDK_EXCEPTION" : @(RadarLogTypeSDKException),
+        @"APP_LIFECYCLE_EVENT" : @(RadarLogTypeAppLifecycleEvent),
+        @"PERMISSION_EVENT" : @(RadarLogTypePermissionEvent)
+    };
+    return logTypeMap[string].integerValue;
+}
+
 - (NSDictionary *)dictionaryValue {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[@"level"] = [RadarLog stringForLogLevel:self.level];
@@ -79,6 +102,17 @@
     dict[@"createdAt"] = createdAtString;
 
     return dict;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary {
+    self = [super init];
+    if (self) {
+        _level = [RadarLog logLevelForString:dictionary[@"level"]];
+        _type = [RadarLog logTypeForString:dictionary[@"type"]];
+        _message = dictionary[@"message"];
+        _createdAt = dictionary[@"createdAt"];
+    }
+    return self;
 }
 
 + (NSArray<NSDictionary *> *)arrayForLogs:(NSArray<RadarLog *> *)logs {

--- a/RadarSDK/RadarLogger.h
+++ b/RadarSDK/RadarLogger.h
@@ -16,6 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message;
 - (void)logWithLevel:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
+- (void)logWithLevelLocal:(RadarLogLevel)level message:(NSString *)message;
+- (void)logWithLevelLocal:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
+- (void)flushLocalLogs;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarLogger.h
+++ b/RadarSDK/RadarLogger.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RadarLogger : NSObject
 
+@property  (assign) NSString *logFilePath;
+
 + (instancetype)sharedInstance;
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message;
 - (void)logWithLevel:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;

--- a/RadarSDK/RadarLogger.h
+++ b/RadarSDK/RadarLogger.h
@@ -8,12 +8,14 @@
 #import <Foundation/Foundation.h>
 
 #import "RadarDelegate.h"
+#import "RadarFileSystem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RadarLogger : NSObject
 
-@property  (assign) NSString *logFilePath;
+@property (strong, nonatomic) NSString *logFilePath;
+@property (strong, nonatomic) RadarFileSystem *fileHandler;
 
 + (instancetype)sharedInstance;
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message;

--- a/RadarSDK/RadarLogger.h
+++ b/RadarSDK/RadarLogger.h
@@ -20,8 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message;
 - (void)logWithLevel:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
-- (void)logWithLevelLocal:(RadarLogLevel)level message:(NSString *)message;
-- (void)logWithLevelLocal:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
+- (void)logWithLevelToFileSystem:(RadarLogLevel)level message:(NSString *)message;
+- (void)logWithLevelToFileSystem:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
 - (void)flushLocalLogs;
 @end
 

--- a/RadarSDK/RadarLogger.h
+++ b/RadarSDK/RadarLogger.h
@@ -16,12 +16,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSString *logFilePath;
 @property (strong, nonatomic) RadarFileSystem *fileHandler;
+@property (strong, nonatomic) NSDateFormatter *dateFormatter;
+@property (strong, nonatomic) UIDevice *device;
 
 + (instancetype)sharedInstance;
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message;
 - (void)logWithLevel:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
 - (void)logWithLevelToFileSystem:(RadarLogLevel)level message:(NSString *)message;
+- (void)logWithLevelToFileSystem:(RadarLogLevel)level message:(NSString *)message includeDate:(BOOL)includeDate includeBattery:(BOOL)includeBattery;
 - (void)logWithLevelToFileSystem:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message;
+- (void)logWithLevelToFileSystem:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message includeDate:(BOOL)includeDate includeBattery:(BOOL)includeBattery;
 - (void)flushLocalLogs;
 @end
 

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -32,6 +32,7 @@
         NSString *documentsDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
         NSString *logFileName = @"RadarLogs.txt";
         self.logFilePath = [documentsDirectory stringByAppendingPathComponent:logFileName];
+        self.fileHandler = [[RadarFileSystem alloc] init];
     }
     return self;
 }
@@ -61,22 +62,19 @@
 
 - (void) logWithLevelLocal:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message {
     RadarLog *radarLog = [[RadarLog alloc] initWithLevel:level type:type message:message];
-    NSString *documentsDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
-    NSString *logFileName = @"RadarLogs.txt";
-    NSString *logFilePath = [documentsDirectory stringByAppendingPathComponent:logFileName];
+
     NSData *logData = [NSJSONSerialization dataWithJSONObject:[radarLog dictionaryValue] options:0 error:nil];
-    RadarFileSystem *fileHandler = [[RadarFileSystem alloc] init];
-    [fileHandler writeData:logData toFileAtPath:logFilePath];
+    
+    [self.fileHandler writeData:logData toFileAtPath:self.logFilePath];
 }
 
 - (void)flushLocalLogs {
-    RadarFileSystem *fileHandler = [[RadarFileSystem alloc] init]; 
-    NSData *fileData = [fileHandler readFileAtPath:self.logFilePath];
+    NSData *fileData = [self.fileHandler readFileAtPath:self.logFilePath];
     if (fileData) {
         NSDictionary *jsonDict = [NSJSONSerialization JSONObjectWithData:fileData options:0 error:nil];
         RadarLog *retrievedLog = [[RadarLog alloc] initWithDictionary:jsonDict];
         NSLog(@"retrieved log: %@", retrievedLog.message);
-        [fileHandler deleteFileAtPath:self.logFilePath];
+        [self.fileHandler deleteFileAtPath:self.logFilePath];
         if ([retrievedLog isKindOfClass:[RadarLog class]]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -75,7 +75,6 @@
 - (void) logWithLevelToFileSystem:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message includeDate:(BOOL)includeDate includeBattery:(BOOL)includeBattery{
     NSString *dateString = [self.dateFormatter stringFromDate:[NSDate date]];
     float batteryLevel = [self.device batteryLevel];
-    //append date and battery level to message if requested
     if (includeDate && includeBattery) {
         message = [NSString stringWithFormat:@"%@ |  at %@ | with %2.f%% battery", message, dateString, batteryLevel*100];
     } else if (includeDate) {

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -23,6 +23,17 @@
     return sharedInstance;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        // Set the default log file path
+        NSString *documentsDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+        NSString *logFileName = @"RadarLogs.txt";
+        self.logFilePath = [documentsDirectory stringByAppendingPathComponent:logFileName];
+    }
+    return self;
+}
+
 - (void)logWithLevel:(RadarLogLevel)level message:(NSString *)message {
     [self logWithLevel:level type:RadarLogTypeNone message:message];
 }
@@ -40,6 +51,61 @@
             [[RadarDelegateHolder sharedInstance] didLogMessage:log];
         }
     });
+}
+
+- (void) logWithLevelLocal:(RadarLogLevel)level message:(NSString *)message {
+    [self logWithLevelLocal:level type:RadarLogTypeNone message:message];
+}
+
+- (void) logWithLevelLocal:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message {
+     RadarLog *radarLog = [[RadarLog alloc] initWithLevel:level type:type message:message];
+
+     if (self.logFilePath) {
+        NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:self.logFilePath];
+        if (!fileHandle) {
+            [[NSFileManager defaultManager] createFileAtPath:self.logFilePath contents:nil attributes:nil];
+            fileHandle = [NSFileHandle fileHandleForWritingAtPath:self.logFilePath];
+        }
+        
+        if (fileHandle) {
+            [fileHandle seekToEndOfFile];
+            NSData *log = [NSKeyedArchiver archivedDataWithRootObject:radarLog requiringSecureCoding:NO error:nil];
+            [fileHandle writeData:[log dataUsingEncoding:NSUTF8StringEncoding]];
+            [fileHandle closeFile];
+        }
+    }    
+}
+
+- (void)flushlocalLogs {
+    // read logs from file
+    NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingAtPath:self.logFilePath];
+    if (fileHandle) {
+        NSData *data = [fileHandle readDataToEndOfFile];
+        [fileHandle closeFile];
+        
+        // delete file
+        [[NSFileManager defaultManager] removeItemAtPath:self.logFilePath error:nil];
+        
+        // send logs
+        NSString *logString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        NSArray<RadarLog *> *localLogs = [RadarLog parseLogs:logString];
+        for (RadarLog *localLog in localLogs) {
+ 
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [Radar sendLog:localLog.level type:localLog.type message:localLog.message];
+
+                RadarLogLevel logLevel = [RadarSettings logLevel];
+                if (logLevel >= localLog.level) {
+                    NSString *log = [NSString stringWithFormat:@"%@ | backgroundTimeRemaining = %g", localLog.message, [RadarUtils backgroundTimeRemaining]];
+
+                    os_log(OS_LOG_DEFAULT, "%@", log);
+
+                    [[RadarDelegateHolder sharedInstance] didLogMessage:log];
+                }
+            });
+        }
+    }
+   
 }
 
 @end

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -56,11 +56,11 @@
     });
 }
 
-- (void) logWithLevelLocal:(RadarLogLevel)level message:(NSString *)message {
+- (void) logWithLevelToFileSystem:(RadarLogLevel)level message:(NSString *)message {
     [self logWithLevelLocal:level type:RadarLogTypeNone message:message];
 }
 
-- (void) logWithLevelLocal:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message {
+- (void) logWithLevelToFileSystem:(RadarLogLevel)level type:(RadarLogType)type message:(NSString *)message {
     RadarLog *radarLog = [[RadarLog alloc] initWithLevel:level type:type message:message];
 
     NSData *fileData = [self.fileHandler readFileAtPath:self.logFilePath];

--- a/RadarSDK/RadarLogger.m
+++ b/RadarSDK/RadarLogger.m
@@ -116,7 +116,6 @@
         }
 
         for (RadarLog *retrievedLog in existingLogs) {
-            NSLog(@"retrieved log: %@", retrievedLog.message);
 
             dispatch_async(dispatch_get_main_queue(), ^{
                 [Radar sendLog:retrievedLog.level type:retrievedLog.type message:retrievedLog.message];


### PR DESCRIPTION
- Implemented a simple file system that performs atomic read and writes to a file location
- Extended `RadarLogger` to be able to write some logs into disk and to flush all logs on disk to dashboard.
- Implemented function to write local logs and to log user termination. 

QA:

This code chunk is added to the `app delegate`: 
**swift**
```
   func applicationWillTerminate(_ application: UIApplication) {
            Radar.logUserTermination()
    }
    func applicationWillResignActive(_ application: UIApplication) {
        Radar.logResignActive()
    }
    func applicationDidEnterBackground(_ application: UIApplication) {
        Radar.logEnteringBackground()
    }
```
**objC**
```
- (void)applicationWillTerminate:(UIApplication *)application {
  [Radar logTermination];   
}

- (void)applicationWillResignActive:(UIApplication *)application {
    [Radar logResignActive];    
}

- (void)applicationDidEnterBackground:(UIApplication *)application {
    [Radar logEnteringBackground];    
}
```
  and we are able to observe this from dashboard.

<img width="1669" alt="image" src="https://github.com/radarlabs/radar-sdk-ios/assets/139801512/f2b6700e-50c7-43c4-8953-644663658aa7">


waypoint build: https://expo.dev/accounts/radarlabs/projects/waypoint/builds/b2f6ceb5-5908-47a9-8e5d-f81acb78c6de


