### PR TITLE
Add buffer to sync interval

### DIFF
--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -779,7 +779,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         }
 
         // We add the 0.1 second buffer to account for the fact that the timer may fire slightly before the desired interval
-        if (lastSyncInterval < options.desiredSyncInterval + 0.1) {
+        if (lastSyncInterval + 0.1 < options.desiredSyncInterval) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Skipping sync: desired sync interval | desiredSyncInterval = %d; lastSyncInterval = %f",
                                                                                   options.desiredSyncInterval, lastSyncInterval]];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -778,7 +778,8 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
             return;
         }
 
-        if (lastSyncInterval < options.desiredSyncInterval) {
+        // We add the 0.1 second buffer to account for the fact that the timer may fire slightly before the desired interval
+        if (lastSyncInterval < options.desiredSyncInterval + 0.1) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Skipping sync: desired sync interval | desiredSyncInterval = %d; lastSyncInterval = %f",
                                                                                   options.desiredSyncInterval, lastSyncInterval]];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -782,7 +782,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         if (lastSyncInterval + 0.1 < options.desiredSyncInterval) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Skipping sync: desired sync interval | desiredSyncInterval = %d; lastSyncInterval = %f",
-                                                                                  options.desiredSyncInterval, lastSyncInterval]];
+                                                                                  options.desiredSyncInterval, lastSyncInterval + 0.1]];
 
             return;
         }

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -779,10 +779,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         }
 
         // We add the 0.1 second buffer to account for the fact that the timer may fire slightly before the desired interval
-        if (lastSyncInterval + 0.1 < options.desiredSyncInterval) {
+        NSTimeInterval lastSyncIntervalWithBuffer = lastSyncInterval + 0.1;
+        if (lastSyncIntervalWithBuffer < options.desiredSyncInterval) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Skipping sync: desired sync interval | desiredSyncInterval = %d; lastSyncInterval = %f",
-                                                                                  options.desiredSyncInterval, lastSyncInterval + 0.1]];
+                                                                                  options.desiredSyncInterval, lastSyncIntervalWithBuffer]];
 
             return;
         }


### PR DESCRIPTION
When setting `desiredStoppedUpdateInterval`, `desiredMovingUpdateInterval` and `desiredSyncInterval` to the same value (e.g. 10), I've been observing cases where we skip a sync because the timer fired just slightly prematurely, due to the difference in when we start the `track` and when we update `lastSentAt`. This buffer prevents that edge case and allows for expected behavior when setting sync intervals as one would normally.