### PR TITLE
Add serialization of createdAt and actualCreatedAt to events

### DIFF
--- a/RadarSDK.podspec
+++ b/RadarSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'RadarSDK'
-  s.version               = '3.8.11'
+  s.version               = '3.8.12'
   s.summary               = 'iOS SDK for Radar, the leading geofencing and location tracking platform'
   s.homepage              = 'https://radar.com'
   s.author                = { 'Radar Labs, Inc.' => 'support@radar.com' }

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -860,7 +860,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -890,7 +890,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = io.radar.sdk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -973,7 +973,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.12;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1031,7 +1031,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = "-fembed-bitcode";

--- a/RadarSDK/RadarEvent.m
+++ b/RadarSDK/RadarEvent.m
@@ -447,6 +447,10 @@
     [dict setValue:locationDict forKey:@"location"];
     [dict setValue:@(self.replayed) forKey:@"replayed"];
     [dict setValue:self.metadata forKey:@"metadata"];
+    NSString *createdAtString = [RadarUtils.isoDateFormatter stringFromDate:self.createdAt];
+    [dict setValue:createdAtString forKey:@"createdAt"];
+    NSString *actualCreatedAtString = [RadarUtils.isoDateFormatter stringFromDate:self.actualCreatedAt];
+    [dict setValue:actualCreatedAtString forKey:@"actualCreatedAt"];
     return dict;
 }
 

--- a/RadarSDK/RadarUtils.m
+++ b/RadarSDK/RadarUtils.m
@@ -45,7 +45,7 @@ static NSDateFormatter *_isoDateFormatter;
 }
 
 + (NSString *)sdkVersion {
-    return @"3.8.11";
+    return @"3.8.12";
 }
 
 + (NSString *)deviceId {


### PR DESCRIPTION
We already do this on Android, but it's been missing from iOS: https://github.com/radarlabs/radar-sdk-android/blob/9b334a5ffedd086879939ea28b0e1313dbb8dd8a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt#L353-L354