### PR TITLE
Add user _id to createTrip

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		78D8CE3E23AD7FEE009E91F5 /* geocode_ip.json in Resources */ = {isa = PBXBuildFile; fileRef = 78D8CE3D23AD7FEE009E91F5 /* geocode_ip.json */; };
 		825732512B72BE1900DF8B88 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 825732502B72BE1900DF8B88 /* PrivacyInfo.xcprivacy */; };
 		825732522B72BE1900DF8B88 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 825732502B72BE1900DF8B88 /* PrivacyInfo.xcprivacy */; };
+		82AE65832BD6F38800FA6E1F /* create_trip.json in Resources */ = {isa = PBXBuildFile; fileRef = 82AE65822BD6F38800FA6E1F /* create_trip.json */; };
 		82D04ABB29722ED20036619F /* RadarReplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 82D04AB829722ED20036619F /* RadarReplay.h */; };
 		82D04ABC29722ED20036619F /* RadarReplayBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 82D04AB929722ED20036619F /* RadarReplayBuffer.m */; };
 		82D04ABD29722ED20036619F /* RadarReplayBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 82D04ABA29722ED20036619F /* RadarReplayBuffer.h */; };
@@ -185,6 +186,7 @@
 		78D8CE3B23AD78A1009E91F5 /* geocode.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = geocode.json; sourceTree = "<group>"; };
 		78D8CE3D23AD7FEE009E91F5 /* geocode_ip.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = geocode_ip.json; sourceTree = "<group>"; };
 		825732502B72BE1900DF8B88 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		82AE65822BD6F38800FA6E1F /* create_trip.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = create_trip.json; sourceTree = "<group>"; };
 		82D04AB829722ED20036619F /* RadarReplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarReplay.h; sourceTree = "<group>"; };
 		82D04AB929722ED20036619F /* RadarReplayBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarReplayBuffer.m; sourceTree = "<group>"; };
 		82D04ABA29722ED20036619F /* RadarReplayBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadarReplayBuffer.h; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 		DD103213237F1778003DD408 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				82AE65822BD6F38800FA6E1F /* create_trip.json */,
 				53B3B26A23EE41B400080818 /* context.json */,
 				966D885F288F7404008C0D00 /* conversion_event.json */,
 				968C839828A6D8350030103E /* conversion_event_nil_event.json */,
@@ -762,6 +765,7 @@
 				DD4D4D2723E648FF00D36C1D /* route_distance.json in Resources */,
 				78D8CE3E23AD7FEE009E91F5 /* geocode_ip.json in Resources */,
 				DD5E35E323820796002D93FF /* search_places.json in Resources */,
+				82AE65832BD6F38800FA6E1F /* create_trip.json in Resources */,
 				DD103215237F1795003DD408 /* track.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RadarSDK/Include/RadarTrip.h
+++ b/RadarSDK/Include/RadarTrip.h
@@ -82,6 +82,11 @@ typedef NS_ENUM(NSInteger, RadarTripStatus) {
 @property (assign, nonatomic, readonly) float etaDuration;
 
 /**
+ The optional scheduled arrival time for the trip.
+ */
+@property (nullable, copy, nonatomic, readonly) NSDate *scheduledArrivalAt;
+
+/**
  The status of the trip.
  */
 @property (assign, nonatomic, readonly) RadarTripStatus status;

--- a/RadarSDK/Include/RadarTripOptions.h
+++ b/RadarSDK/Include/RadarTripOptions.h
@@ -25,7 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
             destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
      destinationGeofenceExternalId:(NSString *_Nullable)destinationGeofenceExternalId
-                scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt;
+                scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt
+                          metadata:(NSDictionary *_Nullable)metadata
+                              mode:(RadarRouteMode)mode;
 
 /**
  A stable unique ID for the trip.

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -489,11 +489,13 @@
     [[RadarAPIClient sharedInstance] createTripWithOptions:tripOptions
                                          completionHandler:^(RadarStatus status, RadarTrip *trip, NSArray<RadarEvent *> *events) {
                                              if (status == RadarStatusSuccess) {
-                                                 RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
+                                                 if (trip != nil) {
+                                                    RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
                                                                                                 destinationGeofenceTag:trip.destinationGeofenceTag
                                                                                         destinationGeofenceExternalId:trip.destinationGeofenceExternalId
                                                                                                     scheduledArrivalAt:trip.scheduledArrivalAt];
-                                                 [RadarSettings setTripOptions:newTripOptions];
+                                                    [RadarSettings setTripOptions:newTripOptions];
+                                                 }
 
                                                  if (Radar.isTracking) {
                                                      [RadarSettings setPreviousTrackingOptions:[RadarSettings trackingOptions]];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -527,13 +527,15 @@
                                                     status:status
                                          completionHandler:^(RadarStatus status, RadarTrip *trip, NSArray<RadarEvent *> *events) {
                                              if (status == RadarStatusSuccess) {
-                                                RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
-                                                                                            destinationGeofenceTag:trip.destinationGeofenceTag
-                                                                                    destinationGeofenceExternalId:trip.destinationGeofenceExternalId
-                                                                                                scheduledArrivalAt:trip.scheduledArrivalAt
-                                                                                                            metadata:trip.metadata
-                                                                                                                mode:trip.mode];
-                                                 [RadarSettings setTripOptions:newTripOptions];
+                                                if (trip != nil) {
+                                                    RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
+                                                                                                destinationGeofenceTag:trip.destinationGeofenceTag
+                                                                                        destinationGeofenceExternalId:trip.destinationGeofenceExternalId
+                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt
+                                                                                                                metadata:trip.metadata
+                                                                                                                    mode:trip.mode];
+                                                    [RadarSettings setTripOptions:newTripOptions];
+                                                }
 
                                                  // flush location update to generate events
                                                  [[RadarLocationManager sharedInstance] getLocationWithCompletionHandler:nil];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -21,6 +21,7 @@
 #import "RadarVerificationManager.h"
 #import "RadarReplayBuffer.h"
 #import "RadarFeatureSettings.h"
+#import "RadarTripOptions.h"
 
 @interface Radar ()
 
@@ -488,7 +489,11 @@
     [[RadarAPIClient sharedInstance] createTripWithOptions:tripOptions
                                          completionHandler:^(RadarStatus status, RadarTrip *trip, NSArray<RadarEvent *> *events) {
                                              if (status == RadarStatusSuccess) {
-                                                 [RadarSettings setTripOptions:tripOptions];
+                                                 RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
+                                                                                                destinationGeofenceTag:trip.destinationGeofenceTag
+                                                                                        destinationGeofenceExternalId:trip.destinationGeofenceExternalId
+                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt];
+                                                 [RadarSettings setTripOptions:newTripOptions];
 
                                                  if (Radar.isTracking) {
                                                      [RadarSettings setPreviousTrackingOptions:[RadarSettings trackingOptions]];
@@ -518,7 +523,11 @@
                                                     status:status
                                          completionHandler:^(RadarStatus status, RadarTrip *trip, NSArray<RadarEvent *> *events) {
                                              if (status == RadarStatusSuccess) {
-                                                 [RadarSettings setTripOptions:options];
+                                                 RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
+                                                                                                destinationGeofenceTag:trip.destinationGeofenceTag
+                                                                                        destinationGeofenceExternalId:trip.destinationGeofenceExternalId
+                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt];
+                                                 [RadarSettings setTripOptions:newTripOptions];
 
                                                  // flush location update to generate events
                                                  [[RadarLocationManager sharedInstance] getLocationWithCompletionHandler:nil];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -493,7 +493,9 @@
                                                     RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
                                                                                                 destinationGeofenceTag:trip.destinationGeofenceTag
                                                                                         destinationGeofenceExternalId:trip.destinationGeofenceExternalId
-                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt];
+                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt
+                                                                                                                metadata:trip.metadata
+                                                                                                                   mode:trip.mode];
                                                     [RadarSettings setTripOptions:newTripOptions];
                                                  }
 
@@ -525,10 +527,12 @@
                                                     status:status
                                          completionHandler:^(RadarStatus status, RadarTrip *trip, NSArray<RadarEvent *> *events) {
                                              if (status == RadarStatusSuccess) {
-                                                 RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
-                                                                                                destinationGeofenceTag:trip.destinationGeofenceTag
-                                                                                        destinationGeofenceExternalId:trip.destinationGeofenceExternalId
-                                                                                                    scheduledArrivalAt:trip.scheduledArrivalAt];
+                                                RadarTripOptions *newTripOptions = [[RadarTripOptions alloc] initWithExternalId:trip.externalId
+                                                                                            destinationGeofenceTag:trip.destinationGeofenceTag
+                                                                                    destinationGeofenceExternalId:trip.destinationGeofenceExternalId
+                                                                                                scheduledArrivalAt:trip.scheduledArrivalAt
+                                                                                                            metadata:trip.metadata
+                                                                                                                mode:trip.mode];
                                                  [RadarSettings setTripOptions:newTripOptions];
 
                                                  // flush location update to generate events

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -528,6 +528,7 @@
     }
 
     NSMutableDictionary *params = [NSMutableDictionary new];
+    params[@"user"] = [RadarSettings _id];
     params[@"userId"] = RadarSettings.userId;
     params[@"externalId"] = options.externalId;
 

--- a/RadarSDK/RadarTrip+Internal.h
+++ b/RadarSDK/RadarTrip+Internal.h
@@ -19,6 +19,7 @@
                                 mode:(RadarRouteMode)mode
                          etaDistance:(float)etaDistance
                          etaDuration:(float)etaDuration
+                  scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt
                               status:(RadarTripStatus)status;
 - (instancetype _Nullable)initWithObject:(id _Nonnull)object;
 

--- a/RadarSDK/RadarTrip.m
+++ b/RadarSDK/RadarTrip.m
@@ -9,6 +9,7 @@
 #import "Radar.h"
 #import "RadarCoordinate+Internal.h"
 #import "RadarTrip+Internal.h"
+#import "RadarUtils.h"
 
 @implementation RadarTrip
 
@@ -21,6 +22,7 @@
                                 mode:(RadarRouteMode)mode
                          etaDistance:(float)etaDistance
                          etaDuration:(float)etaDuration
+                  scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt
                               status:(RadarTripStatus)status {
     self = [super init];
     if (self) {
@@ -33,6 +35,7 @@
         _mode = mode;
         _etaDistance = etaDistance;
         _etaDuration = etaDuration;
+        _scheduledArrivalAt = scheduledArrivalAt;
         _status = status;
     }
     return self;
@@ -54,6 +57,7 @@
     RadarRouteMode mode = RadarRouteModeCar;
     float etaDistance = 0;
     float etaDuration = 0;
+    NSDate *scheduledArrivalAt;
     RadarTripStatus status = RadarTripStatusUnknown;
 
     id idObj = dict[@"_id"];
@@ -141,6 +145,12 @@
         }
     }
 
+    id scheduledArrivalAtObj = dict[@"scheduledArrivalAt"];
+    if (scheduledArrivalAtObj && [scheduledArrivalAtObj isKindOfClass:[NSString class]]) {
+        NSString *scheduledArrivalAtStr = (NSString *)scheduledArrivalAtObj;
+        scheduledArrivalAt = [RadarUtils.isoDateFormatter dateFromString:scheduledArrivalAtStr];
+    }
+
     id statusObj = dict[@"status"];
     if (statusObj && [statusObj isKindOfClass:[NSString class]]) {
         NSString *statusStr = (NSString *)statusObj;
@@ -169,6 +179,7 @@
                                         mode:mode
                                  etaDistance:etaDistance
                                  etaDuration:etaDuration
+                          scheduledArrivalAt:scheduledArrivalAt
                                       status:status];
     }
 
@@ -190,6 +201,9 @@
     dict[@"mode"] = [Radar stringForMode:self.mode];
     NSDictionary *etaDict = @{@"distance": @(self.etaDistance), @"duration": @(self.etaDuration)};
     dict[@"eta"] = etaDict;
+    if (self.scheduledArrivalAt) {
+        dict[@"scheduledArrivalAt"] = [RadarUtils.isoDateFormatter stringFromDate:self.scheduledArrivalAt];
+    }
     dict[@"status"] = [Radar stringForTripStatus:self.status];
     return dict;
 }

--- a/RadarSDK/RadarTripOptions.m
+++ b/RadarSDK/RadarTripOptions.m
@@ -34,11 +34,15 @@ static NSString *const kApproachingThreshold = @"approachingThreshold";
 - (instancetype)initWithExternalId:(NSString *_Nonnull)externalId
             destinationGeofenceTag:(NSString *_Nullable)destinationGeofenceTag
      destinationGeofenceExternalId:(NSString *_Nullable)destinationGeofenceExternalId
-                scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt {
+                scheduledArrivalAt:(NSDate *_Nullable)scheduledArrivalAt
+                          metadata:(NSDictionary *_Nullable)metadata 
+                              mode:(RadarRouteMode)mode {
     self = [self initWithExternalId:externalId destinationGeofenceTag:destinationGeofenceTag destinationGeofenceExternalId:destinationGeofenceExternalId];
 
     if (self) {
         _scheduledArrivalAt = scheduledArrivalAt;
+        _metadata = metadata;
+        _mode = mode;
     }
 
     return self;
@@ -60,25 +64,29 @@ static NSString *const kApproachingThreshold = @"approachingThreshold";
             scheduledArrivalAt = [NSDate dateWithTimeIntervalSince1970:([(NSNumber *)scheduledArrivalAtObj doubleValue] / 1000.0)];
         }
     }
+    NSDictionary *metadata = dict[kMetadata];
+    NSString *modeStr = dict[kMode];
+    RadarRouteMode mode = RadarRouteModeCar;
+    if ([modeStr isEqualToString:@"foot"]) {
+        mode = RadarRouteModeFoot;
+    } else if ([modeStr isEqualToString:@"bike"]) {
+        mode = RadarRouteModeBike;
+    } else if ([modeStr isEqualToString:@"truck"]) {
+        mode = RadarRouteModeTruck;
+    } else if ([modeStr isEqualToString:@"motorbike"]) {
+        mode = RadarRouteModeMotorbike;
+    } else {
+        mode = RadarRouteModeCar;
+    }
 
     RadarTripOptions *options = [[RadarTripOptions alloc] initWithExternalId:dict[kExternalId]
                                                       destinationGeofenceTag:dict[kDestinationGeofenceTag]
                                                destinationGeofenceExternalId:dict[kDestinationGeofenceExternalId]
-                                                          scheduledArrivalAt:scheduledArrivalAt];
-    options.metadata = dict[kMetadata];
-    NSString *modeStr = dict[kMode];
-    if ([modeStr isEqualToString:@"foot"]) {
-        options.mode = RadarRouteModeFoot;
-    } else if ([modeStr isEqualToString:@"bike"]) {
-        options.mode = RadarRouteModeBike;
-    } else if ([modeStr isEqualToString:@"truck"]) {
-        options.mode = RadarRouteModeTruck;
-    } else if ([modeStr isEqualToString:@"motorbike"]) {
-        options.mode = RadarRouteModeMotorbike;
-    } else {
-        options.mode = RadarRouteModeCar;
-    }
+                                                          scheduledArrivalAt:scheduledArrivalAt
+                                                                    metadata:metadata
+                                                                        mode:mode];
     options.approachingThreshold = [dict[kApproachingThreshold] intValue];
+
     return options;
 }
 

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -716,6 +716,10 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTrip {
+    // here need to mock
+    self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
+    self.apiHelperMock.mockStatus = RadarStatusSuccess;
+    [self.apiHelperMock setMockResponse:[RadarTestUtils jsonDictionaryFromResource:@"create_trip"] forMethod:@"https://api.radar.io/v1/trips"];
     RadarTripOptions *options = [[RadarTripOptions alloc] initWithExternalId:@"tripExternalId"
                                                       destinationGeofenceTag:@"tripDestinationGeofenceTag"
                                                destinationGeofenceExternalId:@"tripDestinationExternalId"];
@@ -736,6 +740,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTripWithTrackingOptionsWhenTrackingIsInProgress {
+    // here need to mock
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedAlways;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
@@ -743,6 +748,8 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     [RadarSettings removePreviousTrackingOptions];
     RadarTrackingOptions *originalTrackingOptions = RadarTrackingOptions.presetEfficient;
     [Radar startTrackingWithOptions:originalTrackingOptions];
+    self.apiHelperMock.mockStatus = RadarStatusSuccess;
+    [self.apiHelperMock setMockResponse:[RadarTestUtils jsonDictionaryFromResource:@"create_trip"] forMethod:@"https://api.radar.io/v1/trips"];
 
     RadarTripOptions *tripOptions = [[RadarTripOptions alloc] initWithExternalId:@"testTrip" destinationGeofenceTag:@"someTag" destinationGeofenceExternalId:@"someId"];
     RadarTrackingOptions *tripTrackingOptions = RadarTrackingOptions.presetContinuous;
@@ -765,7 +772,10 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTripWithTrackingOptionsWhenTrackingIsNotInProgress {
+    // here need to mock
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedAlways;
+    self.apiHelperMock.mockStatus = RadarStatusSuccess;
+    [self.apiHelperMock setMockResponse:[RadarTestUtils jsonDictionaryFromResource:@"create_trip"] forMethod:@"https://api.radar.io/v1/trips"];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -716,17 +716,17 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTrip {
-    // here need to mock
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusSuccess;
     [self.apiHelperMock setMockResponse:[RadarTestUtils jsonDictionaryFromResource:@"create_trip"] forMethod:@"https://api.radar.io/v1/trips"];
     RadarTripOptions *options = [[RadarTripOptions alloc] initWithExternalId:@"tripExternalId"
                                                       destinationGeofenceTag:@"tripDestinationGeofenceTag"
-                                               destinationGeofenceExternalId:@"tripDestinationExternalId"];
-    options.metadata = @{@"foo": @"bar", @"baz": @YES, @"qux": @1};
-    options.mode = RadarRouteModeFoot;
+                                               destinationGeofenceExternalId:@"tripDestinationExternalId"
+                                               scheduledArrivalAt:nil
+                                                  metadata:@{@"foo": @"bar", @"baz": @YES, @"qux": @1}
+                                                        mode:RadarRouteModeFoot];
     [Radar startTripWithOptions:options];
-    XCTAssertEqualObjects(options, [Radar getTripOptions]);
+    XCTAssertTrue([[Radar getTripOptions] isEqual:options]);
 }
 
 - (void)test_Radar_completeTrip {
@@ -740,11 +740,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTripWithTrackingOptionsWhenTrackingIsInProgress {
-    // here need to mock
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedAlways;
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-
     [RadarSettings removePreviousTrackingOptions];
     RadarTrackingOptions *originalTrackingOptions = RadarTrackingOptions.presetEfficient;
     [Radar startTrackingWithOptions:originalTrackingOptions];
@@ -753,6 +749,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
     RadarTripOptions *tripOptions = [[RadarTripOptions alloc] initWithExternalId:@"testTrip" destinationGeofenceTag:@"someTag" destinationGeofenceExternalId:@"someId"];
     RadarTrackingOptions *tripTrackingOptions = RadarTrackingOptions.presetContinuous;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"create_trip"];
     [Radar startTripWithOptions:tripOptions
                 trackingOptions:tripTrackingOptions
               completionHandler:^(RadarStatus status, RadarTrip *_Nullable trip, NSArray<RadarEvent *> *_Nullable events) {
@@ -772,7 +769,6 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_startTripWithTrackingOptionsWhenTrackingIsNotInProgress {
-    // here need to mock
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedAlways;
     self.apiHelperMock.mockStatus = RadarStatusSuccess;
     [self.apiHelperMock setMockResponse:[RadarTestUtils jsonDictionaryFromResource:@"create_trip"] forMethod:@"https://api.radar.io/v1/trips"];

--- a/RadarSDKTests/Resources/create_trip.json
+++ b/RadarSDKTests/Resources/create_trip.json
@@ -1,0 +1,98 @@
+{
+    "meta": {
+        "code": 200
+    },
+    "trip": {
+        "_id": "6626a57c55032bd20beb67c2",
+        "createdAt": "2024-04-22T17:59:24.068Z",
+        "updatedAt": "2024-04-22T17:59:24.068Z",
+        "live": false,
+        "externalId": "1713808763770-user-1",
+        "userId": "user-1",
+        "mode": "car",
+        "status": "started",
+        "startedAt": "2024-04-22T17:59:24.068Z",
+        "destinationGeofenceTag": "stores",
+        "destinationGeofenceExternalId": "841-broadway",
+        "destinationLocation": {
+            "type": "Point",
+            "coordinates": [
+                -73.98012650276246,
+                40.739020572238076
+            ]
+        },
+        "metadata": {
+            "radar:approachingNotificationText": "You're approaching your destination",
+            "radar:arrivalNotificationText": "You've arrived at your destination"
+        },
+        "user": {
+            "_id": "6626a559f029d3f2ac5f60bd",
+            "userId": "user-1",
+            "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
+            "metadata": {
+                "waypointVersion": "1.1.4.1"
+            }
+        },
+        "locations": []
+    },
+    "user": {
+        "_id": "6626a559f029d3f2ac5f60bd",
+        "userId": "user-1",
+        "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
+        "metadata": {
+            "waypointVersion": "1.1.4.1"
+        }
+    },
+    "events": [
+        {
+            "createdAt": "2024-04-22T17:59:24.068Z",
+            "live": false,
+            "type": "user.started_trip",
+            "confidence": 3,
+            "actualCreatedAt": "2024-04-22T17:59:24.550Z",
+            "user": {
+                "_id": "6626a559f029d3f2ac5f60bd",
+                "userId": "user-1",
+                "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
+                "metadata": {
+                    "waypointVersion": "1.1.4.1"
+                }
+            },
+            "location": {
+                "type": "Point",
+                "coordinates": [
+                    -73.99095526998401,
+                    40.734282251604114
+                ]
+            },
+            "locationAccuracy": 35,
+            "trip": {
+                "_id": "6626a57c55032bd20beb67c2",
+                "createdAt": "2024-04-22T17:59:24.068Z",
+                "updatedAt": "2024-04-22T17:59:24.068Z",
+                "live": false,
+                "externalId": "1713808763770-user-1",
+                "userId": "user-1",
+                "mode": "car",
+                "status": "started",
+                "startedAt": "2024-04-22T17:59:24.068Z",
+                "destinationGeofenceTag": "tag",
+                "destinationGeofenceExternalId": "841-broadway-triple (2)",
+                "destinationLocation": {
+                    "type": "Point",
+                    "coordinates": [
+                        -73.98012650276246,
+                        40.739020572238076
+                    ]
+                },
+                "metadata": {
+                    "radar:approachingNotificationText": "You're approaching your destination",
+                    "radar:arrivalNotificationText": "You've arrived at your destination"
+                },
+                "locations": []
+            },
+            "_id": "6626a57c55032bd20beb67d4"
+        }
+    ]
+}
+

--- a/RadarSDKTests/Resources/create_trip.json
+++ b/RadarSDKTests/Resources/create_trip.json
@@ -7,13 +7,13 @@
         "createdAt": "2024-04-22T17:59:24.068Z",
         "updatedAt": "2024-04-22T17:59:24.068Z",
         "live": false,
-        "externalId": "1713808763770-user-1",
+        "externalId": "tripExternalId",
         "userId": "user-1",
-        "mode": "car",
+        "mode": "foot",
         "status": "started",
         "startedAt": "2024-04-22T17:59:24.068Z",
-        "destinationGeofenceTag": "stores",
-        "destinationGeofenceExternalId": "841-broadway",
+        "destinationGeofenceTag": "tripDestinationGeofenceTag",
+        "destinationGeofenceExternalId": "tripDestinationExternalId",
         "destinationLocation": {
             "type": "Point",
             "coordinates": [
@@ -22,16 +22,15 @@
             ]
         },
         "metadata": {
-            "radar:approachingNotificationText": "You're approaching your destination",
-            "radar:arrivalNotificationText": "You've arrived at your destination"
+            "foo": "bar",
+            "baz": true,
+            "qux": 1
         },
         "user": {
             "_id": "6626a559f029d3f2ac5f60bd",
             "userId": "user-1",
             "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
-            "metadata": {
-                "waypointVersion": "1.1.4.1"
-            }
+            "metadata": {}
         },
         "locations": []
     },
@@ -39,9 +38,7 @@
         "_id": "6626a559f029d3f2ac5f60bd",
         "userId": "user-1",
         "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
-        "metadata": {
-            "waypointVersion": "1.1.4.1"
-        }
+        "metadata": {}
     },
     "events": [
         {
@@ -54,9 +51,7 @@
                 "_id": "6626a559f029d3f2ac5f60bd",
                 "userId": "user-1",
                 "deviceId": "4911AE87-828C-4DF4-AB19-E8890265D41E",
-                "metadata": {
-                    "waypointVersion": "1.1.4.1"
-                }
+                "metadata": {}
             },
             "location": {
                 "type": "Point",
@@ -76,8 +71,8 @@
                 "mode": "car",
                 "status": "started",
                 "startedAt": "2024-04-22T17:59:24.068Z",
-                "destinationGeofenceTag": "tag",
-                "destinationGeofenceExternalId": "841-broadway-triple (2)",
+                "destinationGeofenceTag": "tripDestinationGeofenceTag",
+                "destinationGeofenceExternalId": "tripDestinationExternalId",
                 "destinationLocation": {
                     "type": "Point",
                     "coordinates": [


### PR DESCRIPTION
We actually don't need any change for setting the trip to the one returned as we already have that: https://github.com/radarlabs/radar-sdk-ios/blob/liammeier/fence-1902-send-user-on-starttrip-and-update-tripoptions-with-trip/RadarSDK/Radar.m#L491-L492