### PR TITLE
Shicheng/fence 1995 start tracking on initialize

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -26,11 +26,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         Radar.stopTracking()
         
         // Replace with a valid test publishable key
-        Radar.initialize(publishableKey: "prj_test_pk_d9020be31f7cd2357d59a728008f469b1395ee4e")
+        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
         Radar.setDelegate(self)
         Radar.setVerifiedDelegate(self)
-        
-        return true
 
         if UIApplication.shared.applicationState != .background {
             Radar.getLocation { (status, location, stopped) in

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -21,10 +21,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         locationManager.delegate = self
         self.requestLocationPermissions()
 
+        UserDefaults.standard.set("https://api-shicheng.radar-staging.com", forKey:"radar-host")
+        
         // Replace with a valid test publishable key
-        Radar.initialize(publishableKey: "prj_test_pk_0000000000000000000000000000000000000000")
+        Radar.initialize(publishableKey: "prj_test_pk_d9020be31f7cd2357d59a728008f469b1395ee4e")
         Radar.setDelegate(self)
         Radar.setVerifiedDelegate(self)
+        
+        return true
 
         if UIApplication.shared.applicationState != .background {
             Radar.getLocation { (status, location, stopped) in

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -23,6 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         UserDefaults.standard.set("https://api-shicheng.radar-staging.com", forKey:"radar-host")
         
+        Radar.stopTracking()
+        
         // Replace with a valid test publishable key
         Radar.initialize(publishableKey: "prj_test_pk_d9020be31f7cd2357d59a728008f469b1395ee4e")
         Radar.setDelegate(self)

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -76,8 +76,10 @@
                                          }
                                          
                                          RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
-                                         if (sdkConfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
-                                            [Radar startTrackingWithOptions:[RadarSettings trackingOptions]];
+                                         if (sdkConfiguration != nil) {
+                                             if (sdkConfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
+                                                [Radar startTrackingWithOptions:[RadarSettings trackingOptions]];
+                                             }
                                          }
 
                                          [self flushLogs];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -75,6 +75,11 @@
                                          [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
                                          [RadarSettings setFeatureSettings:config.meta.featureSettings];
                                          [RadarSettings setSdkConfiguration:config.meta.sdkConfiguration];
+                                         
+                                         if (config.meta.sdkconfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
+                                            [Radar startTrackingWithOptions:[RadarSettings getTrackingOptions]];
+                                         }
+
                                          [self flushLogs];
                                      }];
 }

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -76,8 +76,8 @@
                                          [RadarSettings setFeatureSettings:config.meta.featureSettings];
                                          [RadarSettings setSdkConfiguration:config.meta.sdkConfiguration];
                                          
-                                         if (config.meta.sdkconfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
-                                            [Radar startTrackingWithOptions:[RadarSettings getTrackingOptions]];
+                                         if (config.meta.sdkConfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
+                                            [Radar startTrackingWithOptions:[RadarSettings trackingOptions]];
                                          }
 
                                          [self flushLogs];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -69,14 +69,14 @@
     [[RadarAPIClient sharedInstance] getConfigForUsage:@"initialize"
                                               verified:NO
                                      completionHandler:^(RadarStatus status, RadarConfig *config) {
-                                         if (status != RadarStatusSuccess || !config) {
-                                            return;
+                                         if (status == RadarStatusSuccess && config) {
+                                             [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
+                                             [RadarSettings setFeatureSettings:config.meta.featureSettings];
+                                             [RadarSettings setSdkConfiguration:config.meta.sdkConfiguration];
                                          }
-                                         [[RadarLocationManager sharedInstance] updateTrackingFromMeta:config.meta];
-                                         [RadarSettings setFeatureSettings:config.meta.featureSettings];
-                                         [RadarSettings setSdkConfiguration:config.meta.sdkConfiguration];
                                          
-                                         if (config.meta.sdkConfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
+                                         RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
+                                         if (sdkConfiguration.startTrackingOnInitialize && ![RadarSettings tracking]) {
                                             [Radar startTrackingWithOptions:[RadarSettings trackingOptions]];
                                          }
 

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param dict A dictionary to extract the settings from.
  */
-+ (RadarSdkConfiguration *_Nullable)sdkConfigurationFromDictionary:(NSDictionary *)dict;
++ (RadarSdkConfiguration *_Nullable)sdkConfigurationFromDictionary:(NSDictionary *_Nullable)dict;
 
 /**
  Returns a dictionary representation of the object.

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  Initializes a new RadarSdkConfiguration object with given value.
  */
 - (instancetype)initWithLogLevel:(RadarLogLevel)logLevel
-       startTrackingOnInitialize:(bool)startTrackingOnInitialize;
+       startTrackingOnInitialize:(BOOL)startTrackingOnInitialize;
 
 /**
  Creates a RadarSdkConfiguration object from the provided dictionary.

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -19,10 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) RadarLogLevel logLevel;
 
+@property (nonatomic, assign) BOOL startTrackingOnInitialize;
+
 /**
  Initializes a new RadarSdkConfiguration object with given value.
  */
-- (instancetype)initWithLogLevel:(RadarLogLevel)logLevel;
+- (instancetype)initWithLogLevel:(RadarLogLevel)logLevel
+       startTrackingOnInitialize:(bool)startTrackingOnInitialize;
 
 /**
  Creates a RadarSdkConfiguration object from the provided dictionary.

--- a/RadarSDK/RadarSdkConfiguration.m
+++ b/RadarSDK/RadarSdkConfiguration.m
@@ -15,9 +15,11 @@
 
 @implementation RadarSdkConfiguration
 
-- (instancetype)initWithLogLevel:(RadarLogLevel)logLevel {
+- (instancetype)initWithLogLevel:(RadarLogLevel)logLevel
+      startTrackingOnInitialize:(bool)startTrackingOnInitialize {
     if (self = [super init]) {
         _logLevel = logLevel;
+        _startTrackingOnInitialize = startTrackingOnInitialize;
     }
     return self;
 }
@@ -33,13 +35,22 @@
         logLevel = [RadarLog levelFromString:(NSString *)logLevelObj];
     }
 
-    return [[RadarSdkConfiguration alloc] initWithLogLevel:logLevel];
+    NSObject *startTrackingOnInitializeObj = dict[@"startTrackingOnInitialize"]; 
+    BOOL startTrackingOnInitialize = NO;
+    if (startTrackingOnInitializeObj && [startTrackingOnInitializeObj isKindOfClass:[NSNumber class]]) {
+        startTrackingOnInitialize = [(NSNumber *)startTrackingOnInitializeObj boolValue];
+    }
+
+    return [[RadarSdkConfiguration alloc] initWithLogLevel:logLevel 
+                                 startTrackingOnInitialize:startTrackingOnInitialize];
 }
 
 - (NSDictionary *)dictionaryValue {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     NSString *logLevelString = [RadarLog stringForLogLevel:_logLevel];
     [dict setValue:logLevelString forKey:@"logLevel"];
+
+    [dict setValue:@(_startTrackingOnInitialize) forKey:@"startTrackingOnInitialize"];
     
     return dict;
 }

--- a/RadarSDK/RadarSdkConfiguration.m
+++ b/RadarSDK/RadarSdkConfiguration.m
@@ -16,7 +16,7 @@
 @implementation RadarSdkConfiguration
 
 - (instancetype)initWithLogLevel:(RadarLogLevel)logLevel
-      startTrackingOnInitialize:(bool)startTrackingOnInitialize {
+       startTrackingOnInitialize:(BOOL)startTrackingOnInitialize {
     if (self = [super init]) {
         _logLevel = logLevel;
         _startTrackingOnInitialize = startTrackingOnInitialize;

--- a/RadarSDK/RadarSdkConfiguration.m
+++ b/RadarSDK/RadarSdkConfiguration.m
@@ -24,7 +24,7 @@
     return self;
 }
 
-+ (RadarSdkConfiguration *_Nullable)sdkConfigurationFromDictionary:(NSDictionary *)dict {
++ (RadarSdkConfiguration *_Nullable)sdkConfigurationFromDictionary:(NSDictionary *_Nullable)dict {
     if (!dict) {
         return nil;
     }
@@ -41,7 +41,7 @@
         startTrackingOnInitialize = [(NSNumber *)startTrackingOnInitializeObj boolValue];
     }
 
-    return [[RadarSdkConfiguration alloc] initWithLogLevel:logLevel 
+    return [[RadarSdkConfiguration alloc] initWithLogLevel:logLevel
                                  startTrackingOnInitialize:startTrackingOnInitialize];
 }
 

--- a/RadarSDK/RadarSettings.h
+++ b/RadarSDK/RadarSettings.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setFeatureSettings:(RadarFeatureSettings *_Nullable)featureSettings;
 + (NSDictionary *)clientSdkConfiguration;
 + (void)setSdkConfiguration:(RadarSdkConfiguration *_Nullable)sdkConfiguration;
++ (RadarSdkConfiguration *_Nullable)sdkConfiguration;
 + (RadarLogLevel)logLevel;
 + (void)setLogLevel:(RadarLogLevel)level;
 + (NSArray<NSString *> *_Nullable)beaconUUIDs;

--- a/RadarSDK/RadarSettings.m
+++ b/RadarSDK/RadarSettings.m
@@ -6,6 +6,9 @@
 //
 
 #import "RadarSettings.h"
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSUserDefaults.h>
+#include "RadarSdkConfiguration.h"
 #include <objc/NSObject.h>
 
 #import "Radar+Internal.h"
@@ -32,6 +35,7 @@ static NSString *const kPreviousTrackingOptions = @"radar-previousTrackingOption
 static NSString *const kRemoteTrackingOptions = @"radar-remoteTrackingOptions";
 static NSString *const kFeatureSettings = @"radar-featureSettings";
 static NSString *const kClientSdkConfiguration = @"radar-clientSdkConfiguration";
+static NSString *const kSdkConfiguration = @"radar-sdkConfiguration";
 static NSString *const kTripOptions = @"radar-tripOptions";
 static NSString *const kLogLevel = @"radar-logLevel";
 static NSString *const kBeaconUUIDs = @"radar-beaconUUIDs";
@@ -243,7 +247,13 @@ static NSString *const kXPlatformSDKVersion = @"radar-xPlatformSDKVersion";
                             [RadarUtils dictionaryToJson:[sdkConfiguration dictionaryValue]]]];
     if (sdkConfiguration) {
         [[NSUserDefaults standardUserDefaults] setInteger:(int)sdkConfiguration.logLevel forKey:kLogLevel];
+        [[NSUserDefaults standardUserDefaults] setObject:[sdkConfiguration dictionaryValue] forKey:kSdkConfiguration];
     }
+}
+
++ (RadarSdkConfiguration *_Nullable)sdkConfiguration {
+    NSDictionary *sdkConfigurationDict = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kSdkConfiguration];
+    return [RadarSdkConfiguration sdkConfigurationFromDictionary:sdkConfigurationDict];
 }
 
 + (RadarLogLevel)logLevel {

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -1490,7 +1490,8 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_RadarSdkConfiguration {
-    RadarSdkConfiguration *sdkConfiguration = [[RadarSdkConfiguration alloc] initWithLogLevel:RadarLogLevelWarning];
+    RadarSdkConfiguration *sdkConfiguration = [[RadarSdkConfiguration alloc] initWithLogLevel:RadarLogLevelWarning
+                                                                    startTrackingOnInitialize:YES];
 
     [RadarSettings setSdkConfiguration:sdkConfiguration];
     XCTAssertEqual([RadarSettings logLevel], RadarLogLevelWarning);
@@ -1522,8 +1523,11 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
                                  }];
     
     [RadarSettings setLogLevel:RadarLogLevelDebug];
-    NSDictionary *sdkConfigurationDict = [RadarSettings clientSdkConfiguration];
-    XCTAssertEqual([RadarLog levelFromString:(NSString *)sdkConfigurationDict[@"logLevel"]], RadarLogLevelDebug);
+    NSDictionary *clientSdkConfigurationDict = [RadarSettings clientSdkConfiguration];
+    XCTAssertEqual([RadarLog levelFromString:(NSString *)clientSdkConfigurationDict[@"logLevel"]], RadarLogLevelDebug);
+    
+    RadarSdkConfiguration *savedSdkConfiguration = [RadarSettings sdkConfiguration];
+    XCTAssertEqual(savedSdkConfiguration.startTrackingOnInitialize, YES);
 }
 
 @end

--- a/RadarSDKTests/Resources/get_config_response.json
+++ b/RadarSDKTests/Resources/get_config_response.json
@@ -9,7 +9,10 @@
             "radarLowPowerManagerDistanceFilter": 3000
         },
         "sdkConfiguration": {
-            "logLevel": "info"
+            "logLevel": "info",
+            "startTrackingOnInitialize": true,
+            "trackOnceOnInitialize": true,
+            "trackOnceOnResume": false,
         }
     }
 }


### PR DESCRIPTION
tested with example app, verified via logs startTracking() is called when the startTrackingOnInitialize variable is set to true. Also only called when tracking is not started.

Will remove the testing stuff in AppDelegate if everything else looks good.

see https://github.com/radarlabs/radar-sdk-ios/pull/357