### PR TITLE
Fix parsing of geofence coordinates

### DIFF
--- a/RadarSDK/RadarGeofence.m
+++ b/RadarSDK/RadarGeofence.m
@@ -223,7 +223,7 @@
         [dict setValue:[polygonGeometry.center dictionaryValue] forKey:@"geometryCenter"];
         if (polygonGeometry._coordinates) {
             // Nest coordinate array; Per GeoJSON spec: for type "Polygon", the "coordinates" member must be an array of LinearRing coordinate arrays.
-            [dict setValue:[[RadarGeofence arrayForGeometryCoordinates:polygonGeometry._coordinates]] forKey:@"coordinates"];
+            [dict setValue:@[[RadarGeofence arrayForGeometryCoordinates:polygonGeometry._coordinates]] forKey:@"coordinates"];
         }
         [dict setValue:@"Polygon" forKey:@"type"];
     }

--- a/RadarSDK/RadarGeofence.m
+++ b/RadarSDK/RadarGeofence.m
@@ -222,7 +222,8 @@
         [dict setValue:@(polygonGeometry.radius) forKey:@"geometryRadius"];
         [dict setValue:[polygonGeometry.center dictionaryValue] forKey:@"geometryCenter"];
         if (polygonGeometry._coordinates) {
-            [dict setValue:[RadarGeofence arrayForGeometryCoordinates:polygonGeometry._coordinates] forKey:@"coordinates"];
+            // Nest coordinate array; Per GeoJSON spec: for type "Polygon", the "coordinates" member must be an array of LinearRing coordinate arrays.
+            [dict setValue:[[RadarGeofence arrayForGeometryCoordinates:polygonGeometry._coordinates]] forKey:@"coordinates"];
         }
         [dict setValue:@"Polygon" forKey:@"type"];
     }


### PR DESCRIPTION
I was under the impression that this issue was fixed and merged previously but apparently it is not. 

@lmeier the P1 fix that you made in waypoint addresses this issue in iOS but breaks android. This PR is the more appropriate  fix for the issue.