### PR TITLE
automate lifecycle logging

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,8 @@
 # Migration guides
 
+## 3.16.x t0 3.17.x
+- Remove calls to `logTermination`, `logBackgrounding` and `logResigningActive` as they should be called automatically.
+
 ## 3.12.x to 3.13.x
 -  The `Radar.trackVerified()` method now returns `token: RadarVerifiedLocationToken`, which includes `user`, `events`, `token,`, `expiresAt`, `expiresIn`, and `passed`. The `Radar.trackVerifiedToken()` method has been removed, since `Radar.trackVerified()` now returns a signed JWT.
 

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1119,24 +1119,6 @@ logConversionWithNotification
  */
 + (void)setLogLevel:(RadarLogLevel)level;
 
-/**
- Log application terminating. Include this in your application delegate's applicationWillTerminate: method.
-
- */
-+ (void)logTermination;
-
-/**
- Log application entering background. Include this in your application delegate's applicationDidEnterBackground: method.
- */
-+ (void)logBackgrounding;
-
-/**
- Log application resigning active. Include this in your application delegate's applicationWillResignActive: method.
-
- */
-+ (void)logResigningActive;
-
-
 #pragma mark - Helpers
 
 /**

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1119,6 +1119,22 @@ logConversionWithNotification
  */
 + (void)setLogLevel:(RadarLogLevel)level;
 
+
+/**
+  @deprecated Log application terminating. Include this in your application delegate's applicationWillTerminate: method.
+ */
++ (void)logTermination;
+
+/**
+  @deprecated Log application entering background. Include this in your application delegate's applicationDidEnterBackground: method.
+ */
++ (void)logBackgrounding;
+
+/**
+  @deprecated Log application resigning active. Include this in your application delegate's applicationWillResignActive: method.
+ */
++ (void)logResigningActive;
+
 #pragma mark - Helpers
 
 /**

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1119,21 +1119,20 @@ logConversionWithNotification
  */
 + (void)setLogLevel:(RadarLogLevel)level;
 
-
 /**
   @deprecated Log application terminating. Include this in your application delegate's applicationWillTerminate: method.
  */
-+ (void)logTermination;
++ (void)logTermination __attribute__((deprecated("Logging is now automatic.")));
 
 /**
   @deprecated Log application entering background. Include this in your application delegate's applicationDidEnterBackground: method.
  */
-+ (void)logBackgrounding;
++ (void)logBackgrounding __attribute__((deprecated("Logging is now automatic.")));
 
 /**
   @deprecated Log application resigning active. Include this in your application delegate's applicationWillResignActive: method.
  */
-+ (void)logResigningActive;
++ (void)logResigningActive __attribute__((deprecated("Logging is now automatic.")));
 
 #pragma mark - Helpers
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1303,7 +1303,8 @@
         [Radar trackOnceWithCompletionHandler:nil];
     }
 }
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)applicationDidEnterBackground {
     [Radar logBackgrounding];
 }
@@ -1315,6 +1316,7 @@
 - (void)applicationWillTerminate {
     [Radar logTermination];
 }
+#pragma clang diagnostic po
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1316,7 +1316,7 @@
 - (void)applicationWillTerminate {
     [Radar logTermination];
 }
-#pragma clang diagnostic po
+#pragma clang diagnostic pop
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -54,6 +54,19 @@
                                              selector:@selector(applicationWillEnterForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
+                                             selector:@selector(logTermination)
+                                                 name:UIApplicationWillTerminateNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
+                                             selector:@selector(logBackgrounding)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
+                                             selector:@selector(logResigningActive)
+                                                 name:UIApplicationWillResignActiveNotification
+                                               object:nil];
     
     [RadarSettings setPublishableKey:publishableKey];
 
@@ -1044,16 +1057,16 @@
     [RadarSdkConfiguration updateSdkConfigurationFromServer];
 }
 
-+ (void)logTermination { 
+- (void)logTermination { 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:YES append:YES];
 }
 
-+ (void)logBackgrounding {
+- (void)logBackgrounding {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App entering background" includeDate:YES includeBattery:YES append:YES];
     [[RadarLogBuffer sharedInstance] persistLogs];
 }
 
-+ (void)logResigningActive {
+- (void)logResigningActive {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App resigning active" includeDate:YES includeBattery:YES];
 }
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -56,15 +56,15 @@
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
-                                             selector:@selector(logTermination)
+                                             selector:@selector(applicationWillTerminate)
                                                  name:UIApplicationWillTerminateNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
-                                             selector:@selector(logBackgrounding)
+                                             selector:@selector(applicationDidEnterBackground)
                                                  name:UIApplicationDidEnterBackgroundNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
-                                             selector:@selector(logResigningActive)
+                                             selector:@selector(applicationWillResignActive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
     
@@ -1057,16 +1057,16 @@
     [RadarSdkConfiguration updateSdkConfigurationFromServer];
 }
 
-- (void)logTermination { 
++ (void)logTermination { 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:YES append:YES];
 }
 
-- (void)logBackgrounding {
++ (void)logBackgrounding {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App entering background" includeDate:YES includeBattery:YES append:YES];
     [[RadarLogBuffer sharedInstance] persistLogs];
 }
 
-- (void)logResigningActive {
++ (void)logResigningActive {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeNone message:@"App resigning active" includeDate:YES includeBattery:YES];
 }
 
@@ -1302,6 +1302,18 @@
     if (sdkConfiguration.trackOnceOnAppOpen) {
         [Radar trackOnceWithCompletionHandler:nil];
     }
+}
+
+- (void)applicationDidEnterBackground {
+    [Radar logBackgrounding];
+}
+
+- (void)applicationWillResignActive {
+    [Radar logResigningActive];
+}
+
+- (void)applicationWillTerminate {
+    [Radar logTermination];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Automate lifecycle logging and remove the need for users to mess with the app delegate.

This should be shipped as part of one line. It should be configured by either/both client side arguments. 