### PR TITLE
return public key error if no key detected in get config

### DIFF
--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -49,7 +49,11 @@
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
     
-    [RadarSettings setPublishableKey:publishableKey];
+    if (publishableKey != nil) {
+        [RadarSettings setPublishableKey:publishableKey];
+    } else {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelWarning type:RadarLogTypeSDKCall message:@"initialize called with nil key"];
+    }
 
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
     if (sdkConfiguration.usePersistence) {

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -83,7 +83,7 @@
 - (void)getConfigForUsage:(NSString *_Nullable)usage verified:(BOOL)verified completionHandler:(RadarConfigAPICompletionHandler _Nonnull)completionHandler {
     NSString *publishableKey = [RadarSettings publishableKey];
     if (!publishableKey) {
-        return;
+        return completionHandler(RadarStatusErrorPublishableKey, nil);
     }
 
     NSMutableString *queryString = [NSMutableString new];
@@ -119,7 +119,7 @@
                       extendedTimeout:NO
                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
                         if (!res) {
-                            return;
+                            return completionHandler(status, nil);
                         }
 
                         [Radar flushLogs];
@@ -134,7 +134,7 @@
    completionHandler:(RadarFlushReplaysAPICompletionHandler _Nonnull)completionHandler {
     NSString *publishableKey = [RadarSettings publishableKey];
     if (!publishableKey) {
-        return;
+        return completionHandler(RadarStatusErrorPublishableKey, nil);
     }
 
     NSString *host = [RadarSettings host];


### PR DESCRIPTION
Verified the trackVerified call now returns public key error if Radar is not initialized (public key = nil)