### PR TITLE
Optional stopped default value

### DIFF
--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL useLocationMetadata;
 
+@property (nonatomic, assign) BOOL stoppedDefaultValue;
+
 /**
  Initializes a new RadarSdkConfiguration object with given value.
  */

--- a/RadarSDK/RadarSdkConfiguration.m
+++ b/RadarSDK/RadarSdkConfiguration.m
@@ -69,6 +69,12 @@
         _useLocationMetadata = [(NSNumber *)useLocationMetadataObj boolValue];
     }
 
+    NSObject *stoppedDefaultValueObj = dict[@"stoppedDefaultValue"];
+    _stoppedDefaultValue = NO;
+    if (stoppedDefaultValueObj && [stoppedDefaultValueObj isKindOfClass:[NSNumber class]]) {
+        _stoppedDefaultValue = [(NSNumber *)stoppedDefaultValueObj boolValue];
+    }
+
     return self;
 }
 
@@ -83,6 +89,7 @@
     dict[@"useLogPersistence"] = @(_useLogPersistence);
     dict[@"useRadarModifiedBeacon"] = @(_useRadarModifiedBeacon);
     dict[@"useLocationMetadata"] = @(_useLocationMetadata);
+    dict[@"stoppedDefaultValue"] = @(_stoppedDefaultValue);
     
     return dict;
 }

--- a/RadarSDK/RadarState.m
+++ b/RadarSDK/RadarState.m
@@ -8,6 +8,8 @@
 #import "RadarState.h"
 #import "CLLocation+Radar.h"
 #import "RadarUtils.h"
+#import "RadarSettings.h"
+
 
 @implementation RadarState
 
@@ -75,7 +77,13 @@ static NSString *const kLastMotionActivityData = @"radar-lastMotionActivityData"
 }
 
 + (BOOL)stopped {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:kStopped];
+    NSNumber *stoppedValue = [[NSUserDefaults standardUserDefaults] objectForKey:kStopped];
+    if (stoppedValue == nil) {
+        // No value found, use default from RadarSdkConfiguration
+        RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
+        return sdkConfiguration.stoppedDefaultValue;
+    }
+    return [stoppedValue boolValue];
 }
 
 + (void)setStopped:(BOOL)stopped {


### PR DESCRIPTION
Presently `user.stopped` defaults to `NO` on the first `/track`. This allows us to set a default value via `RadarSdkConfiguration`. Some customers want the first `/track` to have `stopped: YES`.