### PR TITLE
fix notification authorization value for track call

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -314,7 +314,7 @@
     if (locationAccuracyAuthorization) {
         params[@"locationAccuracyAuthorization"] = locationAccuracyAuthorization;
     }
-    params[@"notificationAuthorization"] = [RadarState notificationPermissionGranted] ? @"true" : @"false";
+    params[@"notificationAuthorization"] = @([RadarState notificationPermissionGranted]);
 
     params[@"trackingOptions"] = [options dictionaryValue];
 


### PR DESCRIPTION
the value was a string of "true" / "false" indicating a boolean, which would be weird to parse from the server and more confusing. It is fixed to be a string now. Checked this with a track call

<img width="452" alt="image" src="https://github.com/user-attachments/assets/13f05d80-7d7d-43de-91b5-69030ecee0e7">
