### PR TITLE
use Env variables for output

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -85,15 +85,15 @@ jobs:
       # get sha256 checksum of the XCFramework
       - name: Get SHA256 checksum (RadarSDK)
         id: checksum_radarsdk
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDK.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "{checksum}={$(shasum -a 256 RadarSDK.xcframework.zip | cut -d ' ' -f 1)}" >> $GITHUB_OUTPUT
       
       - name: Get SHA256 checksum (RadarSDKMotion)
         id: checksum_radarsdkmotion
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDKMotion.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "{checksum}={$(shasum -a 256 RadarSDKMotion.xcframework.zip | cut -d ' ' -f 1)}" >> $GITHUB_OUTPUT
 
       - name: Get SHA256 checksum (RadarSDKIndoors)
         id: checksum_radarsdkindoors
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDKIndoors.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "{checksum}={$(shasum -a 256 RadarSDKIndoors.xcframework.zip | cut -d ' ' -f 1)}" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         if: ${{ !github.event.release.prerelease }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/

Github are deprecating these, so before it's broken, we should update it to use the environment files

Warnings during publish: https://github.com/radarlabs/radar-sdk-ios/actions/runs/19439889806

! monitor the next release to make sure it works.