### PR TITLE
return default RadarSDKConfiguration

### DIFF
--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -203,10 +203,8 @@ internal class RadarSettings: NSObject {
 
     public static var sdkConfiguration: RadarSdkConfiguration? {
         get {
-            if let options = RadarUserDefaults.dictionary(forKey: .SdkConfiguration) {
-                return RadarSdkConfiguration(dict: options)
-            }
-            return nil
+            let options = RadarUserDefaults.dictionary(forKey: .SdkConfiguration)
+            return RadarSdkConfiguration(dict: options)
         }
         set {
             RadarUserDefaults.set(newValue?.dictionaryValue(), forKey: .SdkConfiguration)


### PR DESCRIPTION
likely need to make a patch release for this.

update RadarSettings so sdkConfiguration always return a value (default initialized)

otherwise fraud init will try to initialize a dictionary with a nil value and crash.