### PR TITLE
Fix notification diff on replay

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -443,7 +443,7 @@
                                                                 source:source
                                                             verified:verified
                                                         publishableKey:publishableKey
-                                                notificationsRemaining:notificationsDelivered
+                                                notificationsRemaining:notificationsRemaining
                                                 locationMetadata:locationMetadata
                                                     completionHandler:completionHandler];
         }];
@@ -512,8 +512,21 @@
                                     NSMutableDictionary *bufferParams = [params mutableCopy];
                                     bufferParams[@"replayed"] = @(YES);
 
-                                    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"Setting %lu notifications remaining", (unsigned long)notificationsRemaining.count]];
-                                    [RadarState setRegisteredNotifications:notificationsRemaining];
+                                    if (@available(iOS 13.0, *)) {
+                                        if ([RadarSettings sdkConfiguration].useNotificationDiffV2) {
+                                            [[RadarNotificationHelper_Swift shared]
+                                             removeRegisteredNotificationsWithNotifications:params[@"notificationDiff"]
+                                             completionHandler:^() {}
+                                            ];
+                                        } else {
+                                            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"Setting %lu notifications remaining", (unsigned long)notificationsRemaining.count]];
+                                            [RadarState setRegisteredNotifications:notificationsRemaining];
+                                        }
+                                    } else {
+                                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"Setting %lu notifications remaining", (unsigned long)notificationsRemaining.count]];
+                                        [RadarState setRegisteredNotifications:notificationsRemaining];
+                                    }
+                                    
                                     [[RadarReplayBuffer sharedInstance] writeNewReplayToBuffer:bufferParams];
                                 } else if (options.replay == RadarTrackingOptionsReplayStops && stopped &&
                                         !(source == RadarLocationSourceForegroundLocation || source == RadarLocationSourceManualLocation)) {

--- a/RadarSDK/RadarNotificationHelper.h
+++ b/RadarSDK/RadarNotificationHelper.h
@@ -35,7 +35,7 @@ typedef void (^NotificationPermissionCheckCompletion)(BOOL granted);
 
 @interface RadarNotificationHelper_Swift : NSObject
 + (RadarNotificationHelper_Swift*) shared;
-- (void)registerGeofenceNotificationsWithGeofences:(NSArray<NSDictionary<NSString *, id> *> * _Nonnull)geofences completionHandler:(void (^ _Nonnull)(void))completionHandler;
+- (void)registerGeofenceNotificationsWithGeofences:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)geofences completionHandler:(void (^ _Nonnull)(void))completionHandler;
 - (void)getDeliveredNotificationsWithCompletionHandler:(void (^ _Nonnull)(NSArray<NSDictionary<NSString *, id> *> * _Nonnull))completionHandler;
 - (void)removeRegisteredNotificationsWithNotifications:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)notifications completionHandler:(void (^ _Nonnull)(void))completionHandler;
 @end

--- a/RadarSDK/RadarNotificationHelper.h
+++ b/RadarSDK/RadarNotificationHelper.h
@@ -37,6 +37,7 @@ typedef void (^NotificationPermissionCheckCompletion)(BOOL granted);
 + (RadarNotificationHelper_Swift*) shared;
 - (void)registerGeofenceNotificationsWithGeofences:(NSArray<NSDictionary<NSString *, id> *> * _Nonnull)geofences completionHandler:(void (^ _Nonnull)(void))completionHandler;
 - (void)getDeliveredNotificationsWithCompletionHandler:(void (^ _Nonnull)(NSArray<NSDictionary<NSString *, id> *> * _Nonnull))completionHandler;
+- (void)removeRegisteredNotificationsWithNotifications:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)notifications completionHandler:(void (^ _Nonnull)(void))completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -171,6 +171,24 @@ actor RadarNotificationHelper: NSObject {
         return []
     }
     
+    public func removeRegisteredNotifications(notifications: [[String: Sendable]]?) async {
+        guard let notifications else {
+            return
+        }
+        guard var registered = radarState.registeredNotifications else {
+            return
+        }
+        if isRegistering {
+            return
+        }
+        let idsToRemove = notifications.compactMap { $0["identifier"] as? String }
+        
+        registered.removeAll { notification in
+            idsToRemove.contains { $0 == notification.identifier }
+        }
+        radarState.registeredNotifications = registered
+    }
+    
     public func notificationPermission() async -> String {
         let permissions = await notificationCenter.radarNotificationPermissions()
         guard let data = try? JSONEncoder().encode(permissions) else {

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -45,7 +45,11 @@ actor RadarNotificationHelper: NSObject {
         self.radarState = radarState
     }
 
-    public func registerGeofenceNotifications(geofences: [[String: Sendable]]) async {
+    public func registerGeofenceNotifications(geofences: [[String: Sendable]]?) async {
+        guard let geofences else {
+            return
+        }
+        
         let now = Date()
         let notifications: [UNNotificationRequest] = geofences.compactMap { (geofenceDict) -> UNNotificationRequest? in
             if let json = try? JSONSerialization.data(withJSONObject: geofenceDict),

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -185,10 +185,13 @@ actor RadarNotificationHelper: NSObject {
         if isRegistering {
             return
         }
-        let idsToRemove = notifications.compactMap { $0["identifier"] as? String }
+        let idsToRemove = Set(notifications.compactMap { $0["identifier"] as? String })
+        if idsToRemove.isEmpty {
+            return
+        }
         
         registered.removeAll { notification in
-            idsToRemove.contains { $0 == notification.identifier }
+            idsToRemove.contains(notification.identifier)
         }
         radarState.registeredNotifications = registered
     }

--- a/RadarSDKTests/RadarNotificationHelperTest.swift
+++ b/RadarSDKTests/RadarNotificationHelperTest.swift
@@ -163,7 +163,7 @@ struct RadarNotificationHelperTest {
         #expect(delivered.count == 2)
 
         let deliveredIds = delivered.compactMap { $0["identifier"] as? String }
-        #expect(deliveredIds == ["radar_geofence_2", "radar_geofence_3"])
+        #expect(Set(deliveredIds) == Set(["radar_geofence_2", "radar_geofence_3"]))
     }
     
     @Test("getDelivered returns empty when notifications are not sendable")


### PR DESCRIPTION
removes the "sent" notification diffs from registered, as they'll be saved in replay

tested on simulator.

* project, turn replay for tracking options to all.

* sync down notitifcations
* list registered + pending
* simulate a send by removing one of the notifications (or walk around)
* turn off wifi
* track once
* track should fail due to network error
* registered notifications should be updated to be only the two remaining.