### PR TITLE
Propagate NSError through RadarAPICompletionHandler

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		BA8647B32F6C5B3500F1A199 /* RadarPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647B22F6C5B2B00F1A199 /* RadarPlace.swift */; };
 		BA8647B72F6C5C0A00F1A199 /* RadarBeacon.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647B62F6C5C0600F1A199 /* RadarBeacon.swift */; };
 		BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */; };
+		EC0000022F6C7DB700F1A199 /* RadarAPIHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0000012F6C7DB700F1A199 /* RadarAPIHelperTests.swift */; };
 		BA8647BB2F6C8F0E00F1A199 /* SyncRegionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647BA2F6C8F0600F1A199 /* SyncRegionResponse.swift */; };
 		DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD103210237E0C47003DD408 /* RadarSDKTests.m */; };
 		DD103215237F1795003DD408 /* track.json in Resources */ = {isa = PBXBuildFile; fileRef = DD103214237F1795003DD408 /* track.json */; };
@@ -335,6 +336,7 @@
 		BA8647B22F6C5B2B00F1A199 /* RadarPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarPlace.swift; sourceTree = "<group>"; };
 		BA8647B62F6C5C0600F1A199 /* RadarBeacon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarBeacon.swift; sourceTree = "<group>"; };
 		BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSyncManagerTests.swift; sourceTree = "<group>"; };
+		EC0000012F6C7DB700F1A199 /* RadarAPIHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelperTests.swift; sourceTree = "<group>"; };
 		BA8647BA2F6C8F0600F1A199 /* SyncRegionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRegionResponse.swift; sourceTree = "<group>"; };
 		DD103210237E0C47003DD408 /* RadarSDKTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarSDKTests.m; sourceTree = "<group>"; };
 		DD103214237F1795003DD408 /* track.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = track.json; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 				BA353F082F8826AF00E553A1 /* RadatSyncTestHelper.m */,
 				BA353F072F88269F00E553A1 /* RadarSyncTestHelper.h */,
 				BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */,
+				EC0000012F6C7DB700F1A199 /* RadarAPIHelperTests.swift */,
 				BA46C16B2F4E0CEC00031891 /* RadarTripLegTest.m */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
@@ -1080,6 +1083,7 @@
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,
 				DD8E2F7724018C25002D51AB /* RadarAPIHelperMock.m in Sources */,
 				BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */,
+				EC0000022F6C7DB700F1A199 /* RadarAPIHelperTests.swift in Sources */,
 				96B465BC27D6732500D7119B /* CLLocation+RadarTests.m in Sources */,
 				DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */,
 				DD8E2F7124018BF9002D51AB /* RadarTestUtils.m in Sources */,

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -139,7 +139,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (!res) {
                             completionHandler(status, nil);
                             return;
@@ -176,7 +176,7 @@
                                 sleep:NO
                            logPayload:NO
                       extendedTimeout:YES
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                             id eventsObj = res[@"events"];
                             id userObj = res[@"user"];
 
@@ -505,7 +505,7 @@
                                     sleep:YES
                             logPayload:YES
                         extendedTimeout:NO
-                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                             if (status != RadarStatusSuccess || !res) {
                                 if (options.replay == RadarTrackingOptionsReplayAll) {
                                     // create a copy of params that we can use to write to the buffer in case of request failure
@@ -692,7 +692,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res){
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error){
 
                     }];
 }
@@ -752,7 +752,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -823,7 +823,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -870,7 +870,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, nil);
                         }
@@ -918,7 +918,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -957,7 +957,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1023,7 +1023,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1083,7 +1083,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1123,7 +1123,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, nil);
                         }
@@ -1202,7 +1202,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1258,7 +1258,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1303,7 +1303,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1367,7 +1367,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, RadarAddressVerificationStatusNone);
                         }
@@ -1427,7 +1427,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1469,7 +1469,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1502,7 +1502,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, NO);
                         }
@@ -1580,7 +1580,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1656,7 +1656,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1703,7 +1703,7 @@ completionHandler:(RadarSendEventAPICompletionHandler _Nonnull)completionHandler
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1751,7 +1751,7 @@ completionHandler:(RadarSendEventAPICompletionHandler _Nonnull)completionHandler
                                 sleep:NO
                            logPayload:NO // avoid logging the logging call
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         return completionHandler(status);
                     }];
 }

--- a/RadarSDK/RadarAPIHelper.h
+++ b/RadarSDK/RadarAPIHelper.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^_Nullable RadarAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res);
+typedef void (^_Nullable RadarAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error);
 
 @interface RadarAPIHelper : NSObject
 

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -123,7 +123,7 @@
                             logWithLevel:RadarLogLevelError
                                     type:RadarLogTypeSDKError
                                  message:[NSString stringWithFormat:@"Received network error | error = %@", error]];
-                        completionHandler(RadarStatusErrorNetwork, nil);
+                        completionHandler(RadarStatusErrorNetwork, nil, error);
                     });
 
                     if (sleep) {
@@ -138,7 +138,7 @@
                 id resObj = [NSJSONSerialization JSONObjectWithData:data options:0 error:&deserializationError];
                 if (deserializationError || ![resObj isKindOfClass:[NSDictionary class]]) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        completionHandler(RadarStatusErrorServer, nil);
+                        completionHandler(RadarStatusErrorServer, nil, nil);
                     });
 
                     if (sleep) {
@@ -190,7 +190,7 @@
                 }
 
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completionHandler(status, res);
+                    completionHandler(status, res, nil);
                 });
 
                 if (sleep) {
@@ -218,7 +218,7 @@
                 dispatch_semaphore_signal(self.semaphore);
             }
             dispatch_async(dispatch_get_main_queue(), ^{
-                completionHandler(RadarStatusErrorBadRequest, nil);
+                completionHandler(RadarStatusErrorBadRequest, nil, nil);
             });
             return;
         }

--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -12,6 +12,7 @@ internal class RadarSettings: NSObject {
     
     static let DefaultHost = "https://api.radar.io"
     static let DefaultVerifiedHost = "https://api-verified.radar.io"
+    static let DefaultVerifiedHostFallback = "https://api-verified2.radar.io"
     
     public static func setAppGroup(_ appGroup: String?) {
         // this call needs to by synchronised to prevent race conditions in checking / updating the app group
@@ -258,7 +259,11 @@ internal class RadarSettings: NSObject {
     public static var verifiedHost: String {
         RadarUserDefaults.string(forKey: .VerifiedHost) ?? DefaultVerifiedHost
     }
-    
+
+    public static var verifiedHostFallback: String {
+        RadarUserDefaults.string(forKey: .VerifiedHostFallback) ?? DefaultVerifiedHostFallback
+    }
+
     public static var userDebug: Bool {
         get {
             return RadarUserDefaults.bool(forKey: .UserDebug)

--- a/RadarSDK/RadarUserDefaults.swift
+++ b/RadarSDK/RadarUserDefaults.swift
@@ -35,6 +35,7 @@ class RadarUserDefaults: NSObject {
         case Host = "radar-host"
         case LastTrackedTime = "radar-lastTrackedTime"
         case VerifiedHost = "radar-verifiedHost"
+        case VerifiedHostFallback = "radar-verifiedHostFallback"
         case LastAppOpenTime = "radar-lastAppOpenTime"
         case UserDebug = "radar-userDebug"
         case XPlatformSDKType = "radar-xPlatformSDKType"

--- a/RadarSDKTests/RadarAPIHelperMock.h
+++ b/RadarSDKTests/RadarAPIHelperMock.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) RadarStatus mockStatus;
 @property (nonnull, strong, nonatomic) NSDictionary *mockResponse;
+@property (nullable, strong, nonatomic) NSError *mockError;
 
 // Properties to capture last request for testing
 @property (nonatomic, strong, nullable) NSString *lastMethod;

--- a/RadarSDKTests/RadarAPIHelperMock.m
+++ b/RadarSDKTests/RadarAPIHelperMock.m
@@ -53,7 +53,7 @@
         status = self.mockStatus;
     }
     
-    completionHandler(status, response);
+    completionHandler(status, response, self.mockError);
 }
 
 - (void)setMockResponse:(NSDictionary *)response forMethod:(NSString *)urlString {

--- a/RadarSDKTests/RadarAPIHelperTests.swift
+++ b/RadarSDKTests/RadarAPIHelperTests.swift
@@ -1,0 +1,55 @@
+//
+//  RadarAPIHelperTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import RadarSDK
+
+@Suite struct RadarAPIHelperTests {
+
+    @Test("completion handler receives nil error on success")
+    func completionHandler_nilErrorOnSuccess() {
+        let mock = RadarAPIHelperMock()
+        mock.mockStatus = .success
+        mock.mockResponse = [:]
+
+        var receivedError: Error?
+        var receivedStatus: RadarStatus = .errorUnknown
+        mock.request(withMethod: "GET", url: "https://api.radar.io/test",
+                     headers: nil, params: nil, sleep: false, logPayload: false,
+                     extendedTimeout: false) { status, _, error in
+            receivedStatus = status
+            receivedError = error
+        }
+
+        #expect(receivedError == nil)
+        #expect(receivedStatus == .success)
+    }
+
+    @Test("completion handler propagates NSError through RadarAPICompletionHandler")
+    func completionHandler_propagatesError() {
+        let mock = RadarAPIHelperMock()
+        mock.mockStatus = .errorNetwork
+        mock.mockResponse = [:]
+        let expectedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        mock.mockError = expectedError
+
+        var receivedError: Error?
+        var receivedStatus: RadarStatus = .success
+        mock.request(withMethod: "GET", url: "https://api.radar.io/test",
+                     headers: nil, params: nil, sleep: false, logPayload: false,
+                     extendedTimeout: false) { status, _, error in
+            receivedStatus = status
+            receivedError = error
+        }
+
+        #expect(receivedError != nil)
+        #expect((receivedError as? NSError)?.domain == NSURLErrorDomain)
+        #expect((receivedError as? NSError)?.code == NSURLErrorNotConnectedToInternet)
+        #expect(receivedStatus == .errorNetwork)
+    }
+}

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "RadarSyncTestHelper.h"
+#import "RadarAPIHelperMock.h"


### PR DESCRIPTION
https://linear.app/radarlabs/issue/FENCE-2756/sdk-support-for-alternative-hosts

[ADR for failover hosts in the SDKS](https://www.notion.so/SDK-Failover-ADR-344e42b18f96800fa6bdf8ecb9828afe?source=copy_link)

## Summary
- Adds `NSError` parameter to `RadarAPICompletionHandler` so callers can inspect specific `NSURLError` codes, this will be needed for the `RadarHostFailover` class so it knows when to try the failover host.
- Updates all callsites in `RadarAPIClient` and `RadarAPIHelper` to pass the error through
- Foundation for host failover logic in follow-up PRs
- Add a basic test verifying the error gets passed through
- It is worth noting that we are only applying a failover to the verified endpoint for now, so that is why this is only set up for that right now.

## Stack
1. **This PR**
2. #571 Add RadarHostFailover class with exponential backoff
3. #572 Wire up host failover + feature flag

## Test plan
No functional changes yet, just regression tests
- [ ] Verify existing API calls still work end-to-end