### PR TITLE
Wire up host failover for verified requests

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -189,7 +189,6 @@
 		E6B93B752C90E5B8003CB858 /* RadarInitializeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E6B93B732C90E5B8003CB858 /* RadarInitializeOptions.m */; };
 		E6EEC56E2B20F41A00DD096B /* RadarFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = E6EEC56D2B20F41A00DD096B /* RadarFileStorage.h */; };
 		E6EEC5702B20F45D00DD096B /* RadarFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = E6EEC56F2B20F45D00DD096B /* RadarFileStorage.m */; };
-		EDAF8FD7594B70A232D75878 /* RadarHostFailover.m in Sources */ = {isa = PBXBuildFile; fileRef = E7695BC480E0ECAF59360176 /* RadarHostFailover.m */; };
 		F64C83552F6B54EF00943B7A /* RadarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64C83542F6B54EA00943B7A /* RadarState.swift */; };
 		F64FF0D52E4D2B4700DF3926 /* RadarInAppMessageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0D42E4D2B4700DF3926 /* RadarInAppMessageDelegate.m */; };
 		F64FF0D72E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0D62E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift */; };
@@ -403,7 +402,6 @@
 		DDD7BD0325EC3015002473B3 /* RadarRouteMatrix.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarRouteMatrix.m; sourceTree = "<group>"; };
 		DDF1157C2524E18100D575C4 /* RadarTrip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarTrip.m; sourceTree = "<group>"; };
 		DE1E7643239724FD006F34A1 /* search_geofences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = search_geofences.json; sourceTree = "<group>"; };
-		E2237B267BE941C16913F5A0 /* RadarHostFailover.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RadarHostFailover.h; sourceTree = "<group>"; };
 		E658DB062CB46277004E0F01 /* RadarOperatingHours.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarOperatingHours.h; sourceTree = "<group>"; };
 		E658DB082CB462AA004E0F01 /* RadarOperatingHour.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarOperatingHour.m; sourceTree = "<group>"; };
 		E658DB0B2CB46B50004E0F01 /* RadarOperatingHours+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RadarOperatingHours+Internal.h"; sourceTree = "<group>"; };
@@ -412,7 +410,6 @@
 		E6B93B732C90E5B8003CB858 /* RadarInitializeOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarInitializeOptions.m; sourceTree = "<group>"; };
 		E6EEC56D2B20F41A00DD096B /* RadarFileStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarFileStorage.h; sourceTree = "<group>"; };
 		E6EEC56F2B20F45D00DD096B /* RadarFileStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarFileStorage.m; sourceTree = "<group>"; };
-		E7695BC480E0ECAF59360176 /* RadarHostFailover.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RadarHostFailover.m; sourceTree = "<group>"; };
 		F64C83542F6B54EA00943B7A /* RadarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarState.swift; sourceTree = "<group>"; };
 		F64FF0D42E4D2B4700DF3926 /* RadarInAppMessageDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarInAppMessageDelegate.m; sourceTree = "<group>"; };
 		F64FF0D62E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessageDelegate.swift; sourceTree = "<group>"; };
@@ -653,8 +650,6 @@
 				82F7FAED2A65FE030055AA4B /* RadarVerificationManager.m */,
 				DD27CB7D235D13F000299FEC /* Models */,
 				53CCD781275E576B00F79CC8 /* Util */,
-				E2237B267BE941C16913F5A0 /* RadarHostFailover.h */,
-				E7695BC480E0ECAF59360176 /* RadarHostFailover.m */,
 			);
 			path = RadarSDK;
 			sourceTree = "<group>";

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		E6B93B752C90E5B8003CB858 /* RadarInitializeOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = E6B93B732C90E5B8003CB858 /* RadarInitializeOptions.m */; };
 		E6EEC56E2B20F41A00DD096B /* RadarFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = E6EEC56D2B20F41A00DD096B /* RadarFileStorage.h */; };
 		E6EEC5702B20F45D00DD096B /* RadarFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = E6EEC56F2B20F45D00DD096B /* RadarFileStorage.m */; };
+		EDAF8FD7594B70A232D75878 /* RadarHostFailover.m in Sources */ = {isa = PBXBuildFile; fileRef = E7695BC480E0ECAF59360176 /* RadarHostFailover.m */; };
 		F64C83552F6B54EF00943B7A /* RadarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64C83542F6B54EA00943B7A /* RadarState.swift */; };
 		F64FF0D52E4D2B4700DF3926 /* RadarInAppMessageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0D42E4D2B4700DF3926 /* RadarInAppMessageDelegate.m */; };
 		F64FF0D72E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0D62E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift */; };
@@ -402,6 +403,7 @@
 		DDD7BD0325EC3015002473B3 /* RadarRouteMatrix.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarRouteMatrix.m; sourceTree = "<group>"; };
 		DDF1157C2524E18100D575C4 /* RadarTrip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarTrip.m; sourceTree = "<group>"; };
 		DE1E7643239724FD006F34A1 /* search_geofences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = search_geofences.json; sourceTree = "<group>"; };
+		E2237B267BE941C16913F5A0 /* RadarHostFailover.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RadarHostFailover.h; sourceTree = "<group>"; };
 		E658DB062CB46277004E0F01 /* RadarOperatingHours.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarOperatingHours.h; sourceTree = "<group>"; };
 		E658DB082CB462AA004E0F01 /* RadarOperatingHour.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarOperatingHour.m; sourceTree = "<group>"; };
 		E658DB0B2CB46B50004E0F01 /* RadarOperatingHours+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RadarOperatingHours+Internal.h"; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 		E6B93B732C90E5B8003CB858 /* RadarInitializeOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarInitializeOptions.m; sourceTree = "<group>"; };
 		E6EEC56D2B20F41A00DD096B /* RadarFileStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarFileStorage.h; sourceTree = "<group>"; };
 		E6EEC56F2B20F45D00DD096B /* RadarFileStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarFileStorage.m; sourceTree = "<group>"; };
+		E7695BC480E0ECAF59360176 /* RadarHostFailover.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RadarHostFailover.m; sourceTree = "<group>"; };
 		F64C83542F6B54EA00943B7A /* RadarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarState.swift; sourceTree = "<group>"; };
 		F64FF0D42E4D2B4700DF3926 /* RadarInAppMessageDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarInAppMessageDelegate.m; sourceTree = "<group>"; };
 		F64FF0D62E4D2B7300DF3926 /* RadarInAppMessageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessageDelegate.swift; sourceTree = "<group>"; };
@@ -650,6 +653,8 @@
 				82F7FAED2A65FE030055AA4B /* RadarVerificationManager.m */,
 				DD27CB7D235D13F000299FEC /* Models */,
 				53CCD781275E576B00F79CC8 /* Util */,
+				E2237B267BE941C16913F5A0 /* RadarHostFailover.h */,
+				E7695BC480E0ECAF59360176 /* RadarHostFailover.m */,
 			);
 			path = RadarSDK;
 			sourceTree = "<group>";
@@ -870,8 +875,6 @@
 			dependencies = (
 			);
 			name = RadarSDK;
-			packageProductDependencies = (
-			);
 			productName = RadarSDK;
 			productReference = 0107A9E82621FFB9008AB52F /* RadarSDK.framework */;
 			productType = "com.apple.product-type.framework";
@@ -925,8 +928,6 @@
 				Base,
 			);
 			mainGroup = DD236C6B2308797B00EB88F9;
-			packageReferences = (
-			);
 			productRefGroup = DD236C762308797B00EB88F9 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -136,7 +136,8 @@ static NSSet<NSNumber *> *failoverErrorCodes;
                          extendedTimeout:(BOOL)extendedTimeout
                        completionHandler:(RadarAPICompletionHandler)completionHandler {
 
-    NSString *host = [self.verifiedHostFailover currentHost];
+    BOOL useHostFailover = [RadarSettings sdkConfiguration].useHostFailover;
+    NSString *host = useHostFailover ? [self.verifiedHostFailover currentHost] : [RadarSettings verifiedHost];
     NSString *url = [[NSString stringWithFormat:@"%@%@", host, path]
         stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
 
@@ -148,7 +149,7 @@ static NSSet<NSNumber *> *failoverErrorCodes;
                            logPayload:logPayload
                       extendedTimeout:extendedTimeout
                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
-        if (status == RadarStatusErrorNetwork && [RadarAPIClient isFailoverError:error]) {
+        if (useHostFailover && status == RadarStatusErrorNetwork && [RadarAPIClient isFailoverError:error]) {
             BOOL hasAlternate = [self.verifiedHostFailover reportFailure];
             if (hasAlternate) {
                 NSString *retryHost = [self.verifiedHostFailover currentHost];
@@ -177,7 +178,7 @@ static NSSet<NSNumber *> *failoverErrorCodes;
             }
         }
 
-        if (status == RadarStatusSuccess) {
+        if (useHostFailover && status == RadarStatusSuccess) {
             [self.verifiedHostFailover reportSuccess];
         }
         completionHandler(status, res, error);

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -8,6 +8,7 @@
 #import "RadarAPIClient.h"
 
 #import "Radar+Internal.h"
+#import "RadarHostFailover.h"
 #import "Radar.h"
 #import "RadarAddress+Internal.h"
 #import "RadarBeacon+Internal.h"
@@ -45,7 +46,25 @@
 #import "RadarSDK-Swift.h"
 #endif
 
+static NSSet<NSNumber *> *failoverErrorCodes;
+
+@interface RadarAPIClient ()
+
+@property (strong, nonatomic) RadarHostFailover *verifiedHostFailover;
+
+@end
+
 @implementation RadarAPIClient
+
++ (void)initialize {
+    if (self == [RadarAPIClient class]) {
+        failoverErrorCodes = [NSSet setWithArray:@[
+            @(NSURLErrorCannotConnectToHost),
+            @(NSURLErrorTimedOut),
+            @(NSURLErrorNetworkConnectionLost)
+        ]];
+    }
+}
 
 + (instancetype)sharedInstance {
     static dispatch_once_t once;
@@ -60,6 +79,10 @@
     self = [super init];
     if (self) {
         _apiHelper = [RadarAPIHelper new];
+        _verifiedHostFailover = [[RadarHostFailover alloc] initWithHosts:@[
+            [RadarSettings verifiedHost],
+            [RadarSettings verifiedHostFallback]
+        ]];
     }
     return self;
 }
@@ -100,6 +123,67 @@
     return headers;
 }
 
++ (BOOL)isFailoverError:(NSError *)error {
+    return error && [error.domain isEqualToString:NSURLErrorDomain] && [failoverErrorCodes containsObject:@(error.code)];
+}
+
+- (void)performVerifiedRequestWithMethod:(NSString *)method
+                                    path:(NSString *)path
+                                 headers:(NSDictionary *)headers
+                                  params:(NSDictionary *_Nullable)params
+                                   sleep:(BOOL)sleep
+                              logPayload:(BOOL)logPayload
+                         extendedTimeout:(BOOL)extendedTimeout
+                       completionHandler:(RadarAPICompletionHandler)completionHandler {
+
+    NSString *host = [self.verifiedHostFailover currentHost];
+    NSString *url = [[NSString stringWithFormat:@"%@%@", host, path]
+        stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
+    [self.apiHelper requestWithMethod:method
+                                  url:url
+                              headers:headers
+                               params:params
+                                sleep:sleep
+                           logPayload:logPayload
+                      extendedTimeout:extendedTimeout
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
+        if (status == RadarStatusErrorNetwork && [RadarAPIClient isFailoverError:error]) {
+            BOOL hasAlternate = [self.verifiedHostFailover reportFailure];
+            if (hasAlternate) {
+                NSString *retryHost = [self.verifiedHostFailover currentHost];
+                [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo
+                                                  message:[NSString stringWithFormat:@"Host failover: retrying on %@", retryHost]];
+
+                NSString *retryUrl = [[NSString stringWithFormat:@"%@%@", retryHost, path]
+                    stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
+                [self.apiHelper requestWithMethod:method
+                                              url:retryUrl
+                                          headers:headers
+                                           params:params
+                                            sleep:sleep
+                                       logPayload:logPayload
+                                  extendedTimeout:extendedTimeout
+                                completionHandler:^(RadarStatus retryStatus, NSDictionary *_Nullable retryRes, NSError *_Nullable retryError) {
+                    if (retryStatus == RadarStatusSuccess) {
+                        [self.verifiedHostFailover reportSuccess];
+                    } else if (retryStatus == RadarStatusErrorNetwork && [RadarAPIClient isFailoverError:retryError]) {
+                        [self.verifiedHostFailover reportFailure];
+                    }
+                    completionHandler(retryStatus, retryRes, retryError);
+                }];
+                return;
+            }
+        }
+
+        if (status == RadarStatusSuccess) {
+            [self.verifiedHostFailover reportSuccess];
+        }
+        completionHandler(status, res, error);
+    }];
+}
+
 - (void)getConfigForUsage:(NSString *_Nullable)usage verified:(BOOL)verified completionHandler:(RadarConfigAPICompletionHandler _Nonnull)completionHandler {
     NSString *publishableKey = [RadarSettings publishableKey];
     if (!publishableKey) {
@@ -126,31 +210,45 @@
     [queryString appendFormat:@"&verified=%@", verified ? @"true" : @"false"];
     [queryString appendFormat:@"&clientSdkConfiguration=%@", [RadarUtils dictionaryToJson:[RadarSettings clientSdkConfiguration]]];
 
-    NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
-    NSString *url = [NSString stringWithFormat:@"%@/v1/config?%@", host, queryString];
-    url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-
     NSDictionary *headers = [RadarAPIClient headersWithPublishableKey:publishableKey];
 
-    [self.apiHelper requestWithMethod:@"GET"
-                                  url:url
-                              headers:headers
-                               params:nil
-                                sleep:NO
-                           logPayload:YES
-                      extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
-                        if (!res) {
-                            completionHandler(status, nil);
-                            return;
-                        }
+    void (^configCompletionHandler)(RadarStatus, NSDictionary *_Nullable, NSError *_Nullable) = ^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
+        if (!res) {
+            completionHandler(status, nil);
+            return;
+        }
 
-                        [Radar flushLogs];
+        [Radar flushLogs];
 
-                        RadarConfig *config = [RadarConfig fromDictionary:res];
-        
-                        completionHandler(status, config);
-                    }];
+        RadarConfig *config = [RadarConfig fromDictionary:res];
+
+        completionHandler(status, config);
+    };
+
+    if (verified) {
+        NSString *path = [NSString stringWithFormat:@"/v1/config?%@", queryString];
+        [self performVerifiedRequestWithMethod:@"GET"
+                                          path:path
+                                       headers:headers
+                                        params:nil
+                                         sleep:NO
+                                    logPayload:YES
+                               extendedTimeout:NO
+                             completionHandler:configCompletionHandler];
+    } else {
+        NSString *host = [RadarSettings host];
+        NSString *url = [NSString stringWithFormat:@"%@/v1/config?%@", host, queryString];
+        url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
+        [self.apiHelper requestWithMethod:@"GET"
+                                      url:url
+                                  headers:headers
+                                   params:nil
+                                    sleep:NO
+                               logPayload:YES
+                          extendedTimeout:NO
+                        completionHandler:configCompletionHandler];
+    }
 }
 
 - (void)flushReplays:(NSArray<NSDictionary *> *_Nonnull)replays
@@ -472,10 +570,6 @@
                 locationMetadata:(NSDictionary *)locationMetadata
             completionHandler:(RadarTrackAPICompletionHandler)completionHandler {
 
-    NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
-    NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];
-    url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-
     NSDictionary *headers = [RadarAPIClient headersWithPublishableKey:publishableKey];
 
     NSArray<RadarReplay *> *replays = [[RadarReplayBuffer sharedInstance] flushableReplays];
@@ -498,14 +592,7 @@
             completionHandler(status, nil, nil, nil, nil, nil, nil);
         }];
     } else {
-        [self.apiHelper requestWithMethod:@"POST"
-                                    url:url
-                                headers:headers
-                                params:requestParams
-                                    sleep:YES
-                            logPayload:YES
-                        extendedTimeout:NO
-                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
+        void (^trackCompletionHandler)(RadarStatus, NSDictionary *_Nullable, NSError *_Nullable) = ^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                             if (status != RadarStatusSuccess || !res) {
                                 if (options.replay == RadarTrackingOptionsReplayAll) {
                                     // create a copy of params that we can use to write to the buffer in case of request failure
@@ -662,7 +749,31 @@
                             [[RadarDelegateHolder sharedInstance] didFailWithStatus:status];
             
                             completionHandler(RadarStatusErrorServer, nil, nil, nil, nil, nil, nil);
-                        }];
+        };
+
+        if (verified) {
+            [self performVerifiedRequestWithMethod:@"POST"
+                                              path:@"/v1/track"
+                                           headers:headers
+                                            params:requestParams
+                                             sleep:YES
+                                        logPayload:YES
+                                   extendedTimeout:NO
+                                 completionHandler:trackCompletionHandler];
+        } else {
+            NSString *host = [RadarSettings host];
+            NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];
+            url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
+            [self.apiHelper requestWithMethod:@"POST"
+                                          url:url
+                                      headers:headers
+                                       params:requestParams
+                                        sleep:YES
+                                   logPayload:YES
+                              extendedTimeout:NO
+                            completionHandler:trackCompletionHandler];
+        }
     }
 }
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -148,12 +148,13 @@ static NSSet<NSNumber *> *failoverErrorCodes;
                            logPayload:logPayload
                       extendedTimeout:extendedTimeout
                     completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
-        if (useHostFailover && status == RadarStatusErrorNetwork && [RadarAPIClient isFailoverError:error]) {
+        if (useHostFailover && [RadarAPIClient isFailoverError:error]) {
             BOOL hasAlternate = [self.verifiedHostFailover reportFailure];
             if (hasAlternate) {
                 NSString *retryHost = [self.verifiedHostFailover currentHost];
                 [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo
                                                   message:[NSString stringWithFormat:@"Host failover: retrying on %@", retryHost]];
+                NSLog(@"Host failover: retrying on %@", retryHost);
 
                 NSString *retryUrl = [[NSString stringWithFormat:@"%@%@", retryHost, path]
                     stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -8,7 +8,6 @@
 #import "RadarAPIClient.h"
 
 #import "Radar+Internal.h"
-#import "RadarHostFailover.h"
 #import "Radar.h"
 #import "RadarAddress+Internal.h"
 #import "RadarBeacon+Internal.h"

--- a/RadarSDK/RadarHostFailover.swift
+++ b/RadarSDK/RadarHostFailover.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class RadarHostFailover {
+@objc public final class RadarHostFailover: NSObject {
 
     private static let initialBackoffSeconds: TimeInterval = 30.0
     private static let maxBackoffSeconds: TimeInterval = 300.0
@@ -22,6 +22,10 @@ final class RadarHostFailover {
     private var currentBackoffSeconds: TimeInterval = RadarHostFailover.initialBackoffSeconds
     private var isRetryingPrimary: Bool = false
 
+    @objc public convenience init(hosts: [String]) {
+        self.init(hosts: hosts, now: { Date() })
+    }
+
     /// Initialize with an ordered list of hosts. Index 0 is the primary host.
     init(hosts: [String], now: @escaping () -> Date = { Date() }) {
         precondition(!hosts.isEmpty, "RadarHostFailover requires at least one host")
@@ -33,7 +37,7 @@ final class RadarHostFailover {
     /// In normal mode, returns the primary host.
     /// In failover mode with backoff not elapsed, returns the current fallback host.
     /// In failover mode with backoff elapsed, returns the primary host (retry attempt).
-    var currentHost: String {
+    @objc public var currentHost: String {
         stateQueue.sync {
             if activeHostIndex == 0 {
                 isRetryingPrimary = false
@@ -52,7 +56,7 @@ final class RadarHostFailover {
     }
 
     /// Call after a successful request. If we were retrying the primary, resets to normal mode.
-    func reportSuccess() {
+    @objc public func reportSuccess() {
         stateQueue.sync {
             if isRetryingPrimary {
                 RadarLogger.shared.debug("Host failover: primary host recovered, switching back")
@@ -67,8 +71,8 @@ final class RadarHostFailover {
     /// Call after a network error that should trigger failover.
     /// Advances to the next host if available.
     /// Returns true if a different host is available to retry on.
-    @discardableResult
-    func reportFailure() -> Bool {
+    @discardableResult @objc
+    public func reportFailure() -> Bool {
         stateQueue.sync {
             if isRetryingPrimary {
                 currentBackoffSeconds = min(currentBackoffSeconds * 2, RadarHostFailover.maxBackoffSeconds)

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)bufferGeofenceEntries;
 - (BOOL)bufferGeofenceExits;
 - (BOOL)stopDetection;
+- (BOOL)useHostFailover;
 - (instancetype)initWithDict:(NSDictionary *_Nullable)dict;
 - (NSDictionary *)dictionaryValue;
 @end

--- a/RadarSDK/RadarSdkConfiguration.swift
+++ b/RadarSDK/RadarSdkConfiguration.swift
@@ -65,7 +65,8 @@ class RadarSdkConfiguration: NSObject {
     let bufferGeofenceEntries: Bool
     let bufferGeofenceExits: Bool
     let stopDetection: Bool
-    
+    let useHostFailover: Bool
+
     public init(dict: [String: Any]?) {
         originalDict = dict
         logLevel = RadarLogLevel.from(string: dict?["logLevel"] as? String ?? "none")
@@ -85,6 +86,7 @@ class RadarSdkConfiguration: NSObject {
         bufferGeofenceEntries = dict?["bufferGeofenceEntries"] as? Bool ?? true
         bufferGeofenceExits = dict?["bufferGeofenceExits"] as? Bool ?? true
         stopDetection = dict?["stopDetection"] as? Bool ?? false
+        useHostFailover = dict?["useHostFailover"] as? Bool ?? false
     }
     
     public func dictionaryValue() -> [String: Any] {
@@ -108,7 +110,8 @@ class RadarSdkConfiguration: NSObject {
             "defaultGeofenceDwellThreshold": defaultGeofenceDwellThreshold,
             "bufferGeofenceEntries": bufferGeofenceEntries,
             "bufferGeofenceExits": bufferGeofenceExits,
-            "stopDetection": stopDetection
+            "stopDetection": stopDetection,
+            "useHostFailover": useHostFailover
         ]
     }
 }

--- a/RadarSDK/RadarSettings.h
+++ b/RadarSDK/RadarSettings.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)updateLastTrackedTime;
 + (NSDate *)lastTrackedTime;
 + (NSString *)verifiedHost;
++ (NSString *)verifiedHostFallback;
 + (BOOL)userDebug;
 + (void)setUserDebug:(BOOL)userDebug;
 + (void)updateLastAppOpenTime;

--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -12,7 +12,7 @@ internal class RadarSettings: NSObject {
     
     static let DefaultHost = "https://api.radar.io"
     static let DefaultVerifiedHost = "https://api-verified.radar.io"
-    static let DefaultVerifiedHostFallback = "https://api-verified-cf.use1.radar-staging.com"
+    static let DefaultVerifiedHostFallback = "https://api-verified-cf.use1.radar-staging.com" // should update to a prod URL be release
     
     public static func setAppGroup(_ appGroup: String?) {
         // this call needs to by synchronised to prevent race conditions in checking / updating the app group

--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -12,7 +12,7 @@ internal class RadarSettings: NSObject {
     
     static let DefaultHost = "https://api.radar.io"
     static let DefaultVerifiedHost = "https://api-verified.radar.io"
-    static let DefaultVerifiedHostFallback = "https://api-verified2.radar.io"
+    static let DefaultVerifiedHostFallback = "https://api-verified-cf.use1.radar-staging.com"
     
     public static func setAppGroup(_ appGroup: String?) {
         // this call needs to by synchronised to prevent race conditions in checking / updating the app group


### PR DESCRIPTION
https://linear.app/radarlabs/issue/FENCE-2756/sdk-support-for-alternative-hosts

[ADR for failover hosts in the SDKS](https://www.notion.so/SDK-Failover-ADR-344e42b18f96800fa6bdf8ecb9828afe?source=copy_link)

## Summary
- Adds failover-aware request helper to `RadarAPIClient` that retries on fallback host for network errors (`NSURLErrorCannotConnectToHost`, `NSURLErrorTimedOut`, `NSURLErrorNetworkConnectionLost`)
- Routes `/v1/config` and `/v1/track` verified calls through the failover helper
- Failover can be toggled on/off via server feature flag

## Stack
1. #570 Propagate NSError through RadarAPICompletionHandler
2. #571 Add RadarHostFailover class with exponential backoff
3. **This PR**

## Test plan
[Use this doc](https://www.notion.so/radarlabs/SDK-Failover-Testing-Guide-DNS-Hijacking-349e42b18f9680abb34be1b259598553?source=copy_link)