### PR TITLE
FENCE-2717: Add Batching

### DIFF
--- a/RadarSDK/Include/RadarTrackingOptions.h
+++ b/RadarSDK/Include/RadarTrackingOptions.h
@@ -182,6 +182,16 @@ typedef NS_ENUM(NSInteger, RadarTrackingOptionsType) {
 @property (nonatomic, assign) BOOL usePressure;
 
 /**
+ Determines the time interval between batch events, in seconds. Set to 0 to disable interval-based batching.
+ */
+@property (nonatomic, assign) int batchInterval;
+
+/**
+ Determines the size of each batch. Set to 0 to disable size-based batching.
+ */
+@property (nonatomic, assign) int batchSize;
+
+/**
  The type of tracking options.
  */
 @property (nonatomic, assign) RadarTrackingOptionsType type;

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -471,6 +471,24 @@
                 notificationsRemaining:(NSArray *)notificationsRemaining
                 locationMetadata:(NSDictionary *)locationMetadata
             completionHandler:(RadarTrackAPICompletionHandler)completionHandler {
+    
+    BOOL batchingEnabled = (options.batchSize > 0 || options.batchInterval > 0);
+
+    if (batchingEnabled && source != RadarLocationSourceManualLocation && source != RadarLocationSourceForegroundLocation) {
+        NSMutableDictionary *batchParams = [params mutableCopy];
+
+        RadarReplayBuffer *buffer = [RadarReplayBuffer sharedInstance];
+        [buffer addToBatch:batchParams options:options];
+
+        if ([buffer shouldFlushBatchWithOptions:options]) {
+            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                               message:@"Flushing batch: size limit reached"];
+            [buffer flushBatch];
+        }
+
+        completionHandler(RadarStatusSuccess, nil, nil, nil, nil, nil, nil);
+        return;
+    }
 
     NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -486,6 +486,7 @@
             [buffer flushBatch];
         }
 
+        [RadarSettings updateLastTrackedTime];
         completionHandler(RadarStatusSuccess, nil, nil, nil, nil, nil, nil);
         return;
     }

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1272,7 +1272,8 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
     }
 
     CLLocation *location = [locations lastObject];
-    if (self.completionHandlers.count) {
+    RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
+    if (self.completionHandlers.count && (sdkConfiguration.skipForegroundCheck || [RadarUtilsDeprecated foreground])) {
         [self handleLocation:location source:RadarLocationSourceForegroundLocation];
     } else {
         BOOL tracking = [RadarSettings tracking];

--- a/RadarSDK/RadarReplayBuffer.h
+++ b/RadarSDK/RadarReplayBuffer.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #import "RadarReplay.h"
+@class RadarTrackingOptions;
 
 // 2d: figure out what this means
 NS_ASSUME_NONNULL_BEGIN
@@ -30,6 +31,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)clearBuffer;
 
 - (void)loadReplaysFromPersistentStore;
+
+- (void)addToBatch:(NSMutableDictionary *)params options:(RadarTrackingOptions *)options;
+
+- (BOOL)shouldFlushBatchWithOptions:(RadarTrackingOptions *)options;
+
+- (void)scheduleBatchTimerWithInterval:(int)interval;
+
+- (void)cancelBatchTimer;
+
+- (void)flushBatch;
+
+- (NSUInteger)batchCount;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarReplayBuffer.m
+++ b/RadarSDK/RadarReplayBuffer.m
@@ -192,8 +192,6 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 #pragma mark - Batch Methods
 
 - (void)addToBatch:(NSMutableDictionary *)params options:(RadarTrackingOptions *)options {
-    BOOL wasEmpty = (mutableReplayBuffer.count == 0);
-
     NSMutableDictionary *batchParams = [params mutableCopy];
     batchParams[@"replayed"] = @(YES);
     long nowMs = (long)([NSDate date].timeIntervalSince1970 * 1000);

--- a/RadarSDK/RadarReplayBuffer.m
+++ b/RadarSDK/RadarReplayBuffer.m
@@ -202,10 +202,10 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 
     [self writeNewReplayToBuffer:batchParams];
 
-    if (wasEmpty) {
+    if (!batchStartTime) {
         batchStartTime = [NSDate date];
 
-        if (options.batchInterval > 0) {
+        if (options.batchInterval > 0 && !batchFlushTimer) {
             [self scheduleBatchTimerWithInterval:options.batchInterval];
         }
     }
@@ -250,14 +250,20 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 }
 
 - (void)cancelBatchTimer {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    void (^cancelTimerBlock)(void) = ^{
         if (self->batchFlushTimer) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:@"Canceling batch timer"];
             [self->batchFlushTimer invalidate];
             self->batchFlushTimer = nil;
         }
-    });
+    };
+    
+    if ([NSThread isMainThread]) {
+        cancelTimerBlock();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), cancelTimerBlock);
+    }
 }
 
 - (void)flushBatch {

--- a/RadarSDK/RadarReplayBuffer.m
+++ b/RadarSDK/RadarReplayBuffer.m
@@ -19,7 +19,6 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
     NSMutableArray<RadarReplay *> *mutableReplayBuffer;
     BOOL isFlushing;
     NSTimer *batchFlushTimer;
-    NSDate *batchStartTime;
 }
 
 - (instancetype)init {
@@ -28,7 +27,6 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
         mutableReplayBuffer = [NSMutableArray<RadarReplay *> new];
         isFlushing = NO;
         batchFlushTimer = nil;
-        batchStartTime = nil;
     }
     return self;
 }
@@ -200,12 +198,8 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 
     [self writeNewReplayToBuffer:batchParams];
 
-    if (!batchStartTime) {
-        batchStartTime = [NSDate date];
-
-        if (options.batchInterval > 0 && !batchFlushTimer) {
-            [self scheduleBatchTimerWithInterval:options.batchInterval];
-        }
+    if (options.batchInterval > 0 && !batchFlushTimer) {
+        [self scheduleBatchTimerWithInterval:options.batchInterval];
     }
 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
@@ -242,6 +236,7 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
                                                                   block:^(NSTimer *_Nonnull timer) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:@"Batch timer fired"];
+            self->batchFlushTimer = nil;
             [self flushBatch];
         }];
     });
@@ -265,8 +260,12 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 }
 
 - (void)flushBatch {
+    if (isFlushing) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                           message:@"Skipping batch flush; already flushing replays"];
+        return;
+    }
     [self cancelBatchTimer];
-    batchStartTime = nil;
     [self flushReplaysWithCompletionHandler:nil completionHandler:nil];
 }
 

--- a/RadarSDK/RadarReplayBuffer.m
+++ b/RadarSDK/RadarReplayBuffer.m
@@ -11,12 +11,15 @@
 #import "RadarReplay.h"
 #import "RadarLogger.h"
 #import "RadarSettings.h"
+#import "RadarTrackingOptions.h"
 
 static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 
 @implementation RadarReplayBuffer {
     NSMutableArray<RadarReplay *> *mutableReplayBuffer;
     BOOL isFlushing;
+    NSTimer *batchFlushTimer;
+    NSDate *batchStartTime;
 }
 
 - (instancetype)init {
@@ -24,6 +27,8 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
     if (self) {
         mutableReplayBuffer = [NSMutableArray<RadarReplay *> new];
         isFlushing = NO;
+        batchFlushTimer = nil;
+        batchStartTime = nil;
     }
     return self;
 }
@@ -182,6 +187,87 @@ static const int MAX_BUFFER_SIZE = 120; // one hour of updates
 
 - (void)dropOldestReplay {
     [mutableReplayBuffer removeObjectsInRange:NSMakeRange(0, 1)];
+}
+
+#pragma mark - Batch Methods
+
+- (void)addToBatch:(NSMutableDictionary *)params options:(RadarTrackingOptions *)options {
+    BOOL wasEmpty = (mutableReplayBuffer.count == 0);
+
+    NSMutableDictionary *batchParams = [params mutableCopy];
+    batchParams[@"replayed"] = @(YES);
+    long nowMs = (long)([NSDate date].timeIntervalSince1970 * 1000);
+    batchParams[@"updatedAtMs"] = @(nowMs);
+    [batchParams removeObjectForKey:@"updatedAtMsDiff"];
+
+    [self writeNewReplayToBuffer:batchParams];
+
+    if (wasEmpty) {
+        batchStartTime = [NSDate date];
+
+        if (options.batchInterval > 0) {
+            [self scheduleBatchTimerWithInterval:options.batchInterval];
+        }
+    }
+
+    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                       message:[NSString stringWithFormat:@"Added to batch | size = %lu",
+                                                (unsigned long)mutableReplayBuffer.count]];
+}
+
+- (BOOL)shouldFlushBatchWithOptions:(RadarTrackingOptions *)options {
+    if (mutableReplayBuffer.count == 0) {
+        return NO;
+    }
+
+    if (options.batchSize > 0 && mutableReplayBuffer.count >= (NSUInteger)options.batchSize) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                           message:@"Batch size limit reached"];
+        return YES;
+    }
+
+    return NO;
+}
+
+- (void)scheduleBatchTimerWithInterval:(int)interval {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->batchFlushTimer) {
+            [self->batchFlushTimer invalidate];
+            self->batchFlushTimer = nil;
+        }
+
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                           message:[NSString stringWithFormat:@"Scheduling batch timer | interval = %d", interval]];
+
+        self->batchFlushTimer = [NSTimer scheduledTimerWithTimeInterval:interval
+                                                                repeats:NO
+                                                                  block:^(NSTimer *_Nonnull timer) {
+            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                               message:@"Batch timer fired"];
+            [self flushBatch];
+        }];
+    });
+}
+
+- (void)cancelBatchTimer {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->batchFlushTimer) {
+            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                               message:@"Canceling batch timer"];
+            [self->batchFlushTimer invalidate];
+            self->batchFlushTimer = nil;
+        }
+    });
+}
+
+- (void)flushBatch {
+    [self cancelBatchTimer];
+    batchStartTime = nil;
+    [self flushReplaysWithCompletionHandler:nil completionHandler:nil];
+}
+
+- (NSUInteger)batchCount {
+    return mutableReplayBuffer.count;
 }
 
 @end

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)bufferGeofenceEntries;
 - (BOOL)bufferGeofenceExits;
 - (BOOL)stopDetection;
+- (BOOL)skipForegroundCheck;
 - (instancetype)initWithDict:(NSDictionary *_Nullable)dict;
 - (NSDictionary *)dictionaryValue;
 @end

--- a/RadarSDK/RadarSdkConfiguration.swift
+++ b/RadarSDK/RadarSdkConfiguration.swift
@@ -65,6 +65,7 @@ class RadarSdkConfiguration: NSObject {
     let bufferGeofenceEntries: Bool
     let bufferGeofenceExits: Bool
     let stopDetection: Bool
+    let skipForegroundCheck: Bool
     
     public init(dict: [String: Any]?) {
         originalDict = dict
@@ -85,6 +86,7 @@ class RadarSdkConfiguration: NSObject {
         bufferGeofenceEntries = dict?["bufferGeofenceEntries"] as? Bool ?? true
         bufferGeofenceExits = dict?["bufferGeofenceExits"] as? Bool ?? true
         stopDetection = dict?["stopDetection"] as? Bool ?? false
+        skipForegroundCheck = dict?["skipForegroundCheck"] as? Bool ?? true
     }
     
     public func dictionaryValue() -> [String: Any] {
@@ -108,7 +110,8 @@ class RadarSdkConfiguration: NSObject {
             "defaultGeofenceDwellThreshold": defaultGeofenceDwellThreshold,
             "bufferGeofenceEntries": bufferGeofenceEntries,
             "bufferGeofenceExits": bufferGeofenceExits,
-            "stopDetection": stopDetection
+            "stopDetection": stopDetection,
+            "skipForegroundCheck": skipForegroundCheck
         ]
     }
 }

--- a/RadarSDK/RadarSdkConfiguration.swift
+++ b/RadarSDK/RadarSdkConfiguration.swift
@@ -117,7 +117,7 @@ class RadarSdkConfiguration: NSObject {
             "bufferGeofenceEntries": bufferGeofenceEntries,
             "bufferGeofenceExits": bufferGeofenceExits,
             "stopDetection": stopDetection,
-            "skipForegroundCheck": skipForegroundCheck
+            "skipForegroundCheck": skipForegroundCheck,
             "useOfflineRTOUpdates": useOfflineRTOUpdates,
             "offlineEventGenerationEnabled": offlineEventGenerationEnabled,
             "remoteTrackingOptions": RadarRemoteTrackingOptions.toDictionaries(remoteTrackingOptions) as Any

--- a/RadarSDK/RadarTrackingOptions.m
+++ b/RadarSDK/RadarTrackingOptions.m
@@ -32,6 +32,8 @@ NSString *const kBeacons = @"beacons";
 NSString *const kUseIndoorScan = @"useIndoorScan";
 NSString *const kUseMotion = @"useMotion";
 NSString *const kUsePressure = @"usePressure";
+NSString *const kBatchInterval = @"batchInterval";
+NSString *const kBatchSize = @"batchSize";
 
 NSString *const kDesiredAccuracyHigh = @"high";
 NSString *const kDesiredAccuracyMedium = @"medium";
@@ -76,6 +78,8 @@ NSString *const kTypeIsUser = @"is-user";
     options.useIndoorScan = NO;
     options.useMotion = NO;
     options.usePressure = NO;
+    options.batchInterval = 0;
+    options.batchSize = 0;
     return options;
 }
 
@@ -103,6 +107,8 @@ NSString *const kTypeIsUser = @"is-user";
     options.useIndoorScan = NO;
     options.useMotion = NO;
     options.usePressure = NO;
+    options.batchInterval = 0;
+    options.batchSize = 0;
     return options;
 }
 
@@ -130,6 +136,8 @@ NSString *const kTypeIsUser = @"is-user";
     options.useIndoorScan = NO;
     options.useMotion = NO;
     options.usePressure = NO;
+    options.batchInterval = 0;
+    options.batchSize = 0;
     return options;
 }
 
@@ -297,6 +305,8 @@ NSString *const kTypeIsUser = @"is-user";
     options.useIndoorScan = [dict[kUseIndoorScan] boolValue];
     options.useMotion = [dict[kUseMotion] boolValue];
     options.usePressure = [dict[kUsePressure] boolValue];
+    options.batchInterval = [dict[kBatchInterval] intValue];
+    options.batchSize = [dict[kBatchSize] intValue];
     options.type = [RadarTrackingOptions typeForString:dict[kType]];
     return options;
 }
@@ -333,6 +343,8 @@ NSString *const kTypeIsUser = @"is-user";
     dict[kUseIndoorScan] = @(self.useIndoorScan);
     dict[kUseMotion] = @(self.useMotion);
     dict[kUsePressure] = @(self.usePressure);
+    dict[kBatchInterval] = @(self.batchInterval);
+    dict[kBatchSize] = @(self.batchSize);
     dict[kType] = [RadarTrackingOptions stringForType:self.type];
     return dict;
 }
@@ -363,7 +375,8 @@ NSString *const kTypeIsUser = @"is-user";
            self.useStoppedGeofence == options.useStoppedGeofence && self.stoppedGeofenceRadius == options.stoppedGeofenceRadius &&
            self.useMovingGeofence == options.useMovingGeofence && self.movingGeofenceRadius == options.movingGeofenceRadius && self.syncGeofences == options.syncGeofences &&
            self.useVisits == options.useVisits && self.useSignificantLocationChanges == options.useSignificantLocationChanges && self.beacons == options.beacons &&
-           self.useIndoorScan == options.useIndoorScan && self.useMotion == options.useMotion && self.usePressure == options.usePressure;
+           self.useIndoorScan == options.useIndoorScan && self.useMotion == options.useMotion && self.usePressure == options.usePressure &&
+           self.batchInterval == options.batchInterval && self.batchSize == options.batchSize;
 }
 
 @end

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -2164,7 +2164,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
 - (void)test_RadarReplayBuffer_shouldFlushBatchWithZeroSize {
     RadarTrackingOptions *options = RadarTrackingOptions.presetResponsive;
-    options.batchInterval = 30;
+    options.batchInterval = 0;
     options.batchSize = 0;
     
     

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -310,6 +310,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     [[RadarLogBuffer sharedInstance]clearBuffer];
     [[RadarLogBuffer sharedInstance]setPersistentLogFeatureFlag:YES];
     [[RadarReplayBuffer sharedInstance]clearBuffer];
+    [[RadarReplayBuffer sharedInstance] cancelBatchTimer];
     
     // Clear user tags to ensure tests don't interfere with each other
     NSArray<NSString *> *existingTags = [Radar getTags];
@@ -2078,6 +2079,43 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     XCTAssertNotEqualObjects(options, @"foo");
 }
 
+- (void)test_RadarTrackingOptions_batchingFieldsInEquality {
+    RadarTrackingOptions *a = RadarTrackingOptions.presetEfficient;
+    RadarTrackingOptions *b = RadarTrackingOptions.presetEfficient;
+    XCTAssertEqualObjects(a, b);
+    
+    b.batchInterval = 30;
+    XCTAssertNotEqualObjects(a, b);
+    
+    b.batchInterval = 0;
+    b.batchSize = 5;
+    XCTAssertNotEqualObjects(a, b);
+}
+
+- (void)test_RadarTrackingOptions_batchingSerialization {
+    RadarTrackingOptions *options = RadarTrackingOptions.presetEfficient;
+    options.batchInterval = 30;
+    options.batchSize = 5;
+    
+    NSDictionary *dict = [options dictionaryValue];
+    XCTAssertEqualObjects(dict[@"batchInterval"], @30);
+    XCTAssertEqualObjects(dict[@"batchSize"], @5);
+    
+    RadarTrackingOptions *roundTripped = [RadarTrackingOptions trackingOptionsFromDictionary:dict];
+    XCTAssertEqual(roundTripped.batchInterval, 30);
+    XCTAssertEqual(roundTripped.batchSize, 5);
+    XCTAssertEqualObjects(options, roundTripped);
+}
+
+- (void)test_RadarTrackingOptions_presetsDisableBatching {
+    XCTAssertEqual(RadarTrackingOptions.presetContinuous.batchInterval, 0);
+    XCTAssertEqual(RadarTrackingOptions.presetContinuous.batchSize, 0);
+    XCTAssertEqual(RadarTrackingOptions.presetResponsive.batchInterval, 0);
+    XCTAssertEqual(RadarTrackingOptions.presetResponsive.batchSize, 0);
+    XCTAssertEqual(RadarTrackingOptions.presetEfficient.batchInterval, 0);
+    XCTAssertEqual(RadarTrackingOptions.presetEfficient.batchSize, 0);
+}
+
 - (void)test_RadarFileStorage_writeAndRead {
     NSData *originalData = [@"Test data" dataUsingEncoding:NSUTF8StringEncoding];
     [self.fileSystem writeData:originalData toFileAtPath:self.testFilePath];
@@ -2085,6 +2123,59 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     [self.fileSystem writeData:originalData2 toFileAtPath:self.testFilePath];
     NSData *readData = [self.fileSystem readFileAtPath:self.testFilePath];
     XCTAssertEqualObjects(originalData2, readData, @"Data read from file should be equal to original data");
+}
+
+- (void)test_RadarReplayBuffer_addToBatchIncrementsCount {
+    RadarTrackingOptions *options = RadarTrackingOptions.presetResponsive;
+    options.batchInterval = 0;
+    options.batchSize = 10;
+    
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:0.1 longitude:0.1];
+    NSMutableDictionary *params = [RadarTestUtils createTrackParamWithLocation:location stopped:YES foreground:NO source:RadarLocationSourceBackgroundLocation replayed:NO beacons:@[] verified:NO attestationString:nil keyId:nil attestationError:nil encrypted:NO expectedCountryCode:nil expectedStateCode:nil];
+    
+    RadarReplayBuffer *buffer = [RadarReplayBuffer sharedInstance];
+    XCTAssertEqual([buffer batchCount], 0);
+    
+    [buffer addToBatch:params options:options];
+    XCTAssertEqual([buffer batchCount], 1);
+    
+    [buffer addToBatch:params options:options];
+    XCTAssertEqual([buffer batchCount], 2);
+}
+
+- (void)test_RadarReplayBuffer_shouldFlushBatchRespectsSize {
+    RadarTrackingOptions *options = RadarTrackingOptions.presetResponsive;
+    options.batchInterval = 0;
+    options.batchSize = 2;
+    
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:0.1 longitude:0.1];
+    NSMutableDictionary *params = [RadarTestUtils createTrackParamWithLocation:location stopped:YES foreground:NO source:RadarLocationSourceBackgroundLocation replayed:NO beacons:@[] verified:NO attestationString:nil keyId:nil attestationError:nil encrypted:NO expectedCountryCode:nil expectedStateCode:nil];
+
+    RadarReplayBuffer *buffer = [RadarReplayBuffer sharedInstance];
+    
+    XCTAssertFalse([buffer shouldFlushBatchWithOptions:options], @"Empty buffer should not flush");
+    
+    [buffer addToBatch:params options:options];
+    XCTAssertFalse([buffer shouldFlushBatchWithOptions:options], @"1 < batchSize=2, should not flush");
+    
+    [buffer addToBatch:params options:options];
+    XCTAssertTrue([buffer shouldFlushBatchWithOptions:options], @"2 >= batchSize= 2, should flush");
+}
+
+- (void)test_RadarReplayBuffer_shouldFlushBatchWithZeroSize {
+    RadarTrackingOptions *options = RadarTrackingOptions.presetResponsive;
+    options.batchInterval = 30;
+    options.batchSize = 0;
+    
+    
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:0.1 longitude:0.1];
+    NSMutableDictionary *params = [RadarTestUtils createTrackParamWithLocation:location stopped:YES foreground:NO source:RadarLocationSourceBackgroundLocation replayed:NO beacons:@[] verified:NO attestationString:nil keyId:nil attestationError:nil encrypted:NO expectedCountryCode:nil expectedStateCode:nil];
+
+    RadarReplayBuffer *buffer = [RadarReplayBuffer sharedInstance];
+    for (int i = 0; i < 5; i++) {
+        [buffer addToBatch:params options:options];
+    }
+    XCTAssertFalse([buffer shouldFlushBatchWithOptions:options], @"batchSize=0 means no size-based flush");
 }
 
 - (void)test_RadarFileStorage_allFilesInDirectory {
@@ -2235,5 +2326,20 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
     RadarSdkConfiguration *savedSdkConfiguration = [RadarSettings sdkConfiguration];
     XCTAssertEqual(savedSdkConfiguration.trackOnceOnAppOpen, YES);
     XCTAssertEqual(savedSdkConfiguration.startTrackingOnInitialize, YES);
+}
+
+- (void)test_RadarSdkConfiguration_skipForegroundCheckDefault {
+    RadarSdkConfiguration *defaults = [[RadarSdkConfiguration alloc] initWithDict:@{}];
+    XCTAssertTrue(defaults.skipForegroundCheck, @"skipForegroundCheck should default to true");
+
+    RadarSdkConfiguration *explicitFalse = [[RadarSdkConfiguration alloc] initWithDict:@{
+        @"skipForegroundCheck": @(NO)
+    }];
+    XCTAssertFalse(explicitFalse.skipForegroundCheck);
+    
+    RadarSdkConfiguration *explicitTrue = [[RadarSdkConfiguration alloc] initWithDict:@{
+        @"skipForegroundCheck": @(YES)
+    }];
+    XCTAssertTrue(explicitTrue.skipForegroundCheck);
 }
 @end


### PR DESCRIPTION
## Summary

Adds server-controlled batching for non-foreground track requests to reduce network usage for customers who can tolerate deferred location sync, and introduces an opt-in iOS foreground-label gate behind a new SDK configuration flag.

## New SDK Components

**`RadarTrackingOptions.batchInterval`** — Maximum time (in seconds) a batch can accumulate before being flushed to `/v1/track`. Defaults to `0` in all presets (batching disabled).

**`RadarTrackingOptions.batchSize`** — Maximum number of track events per batch before being flushed. Defaults to `0` in all presets (batching disabled). Either field being `> 0` enables batching.

**`RadarSdkConfiguration.skipForegroundCheck`** — When `true`, preserves existing behavior: iOS `didUpdateLocations` with pending completion handlers is always treated as a `ForegroundLocation`. When `false`, the source is only labeled `ForegroundLocation` when the app is actually foregrounded. Defaults to `true` in the SDK so shipped behavior is unchanged until the server-side `FeatureSetting` rolls out.

## How It Works

**Batching.** `RadarReplayBuffer` is reused as the batch store, leveraging the existing replay pipeline on the server. When batching is enabled and a non-manual, non-foreground track request arrives, `RadarAPIClient.makeTrackRequestWithParams:` short-circuits the normal POST, stamps the params as a replay, and writes them to the buffer via `addToBatch:options:`. The request returns `RadarStatusSuccess` immediately.

The buffer is flushed when either:
- `batchSize` is reached (checked synchronously after each `addToBatch:` via `shouldFlushBatchWithOptions:`)
- `batchInterval` seconds elapse from the first add (tracked via an `NSTimer` scheduled when the buffer transitions from empty)

Foreground and manual track calls always bypass the batch and are sent immediately so user-visible calls stay responsive.

**Foreground check.** `RadarLocationManager` now reads `skipForegroundCheck` from the active `RadarSdkConfiguration` when `didUpdateLocations:` fires with outstanding completion handlers. With the default (`true`), behavior is identical to today. Server can opt individual customers into the new behavior by sending `skipForegroundCheck: false` in the `/v1/config` response, pending a companion server PR that adds the `FeatureSetting` + superuser project toggle + dconfig rollout knobs.

## Tests

Added to `RadarSDKTests.m` alongside the existing `test_RadarReplayBuffer_*`, `test_RadarTrackingOptions_*`, and `test_RadarSdkConfiguration` tests:

- Preset defaults for `batchInterval` / `batchSize`
- Round-trip serialization of the new tracking options
- Equality including the new fields
- `addToBatch:` increments `batchCount`
- `shouldFlushBatchWithOptions:` respects `batchSize` thresholds and handles `batchSize = 0`
- `skipForegroundCheck` defaults to `true` when absent from the dict

Per `CLAUDE.md` new code should be Swift, but the classes under test here are still Objective-C and the existing test infrastructure for them is Obj-C. Co-locating with the existing tests avoids spinning up a Swift bridging test harness just for these. These will be ported whenever the replay buffer is migrated to Swift.