### PR TITLE
FENCE-2756: Add verified host health failover

### DIFF
--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -61,6 +61,34 @@
 					</dict>
 				</array>
 			</dict>
+			<key>api-verified.radar.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSPinnedCAIdentities</key>
+				<array>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>KwccWaCgrnaw6tsrrSO61FgLacNgG2MMLq8GE6+oP5I=</string>
+					</dict>
+				</array>
+			</dict>
 		</dict>
 	</dict>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -159,6 +159,10 @@
 		BA3540202F8EBFBD00E553A1 /* RadarOfflineEventManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */; };
 		BA3540222F90020F00E553A1 /* RadarOfflineEventManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BA3540212F90020900E553A1 /* RadarOfflineEventManager.h */; };
 		BA3540242F9033A900E553A1 /* RadarSerializedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */; };
+		C0DEF1012F91000100AA0001 /* RadarFailoverAPICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0012F91000100AA0001 /* RadarFailoverAPICoordinator.swift */; };
+		C0DEF1022F91000100AA0002 /* RadarFailoverAPICoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = C0DEF0022F91000100AA0002 /* RadarFailoverAPICoordinator.h */; };
+		C0DEF1032F91000100AA0003 /* RadarFailoverAPICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0032F91000100AA0003 /* RadarFailoverAPICoordinatorTests.swift */; };
+		C0DEF1042F91000100AA0004 /* RadarAPIClientFailoverWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0042F91000100AA0004 /* RadarAPIClientFailoverWiringTests.swift */; };
 		BA46C1662F4CF3F200031891 /* RadarTripLeg.h in Headers */ = {isa = PBXBuildFile; fileRef = BA46C1652F4CF3E900031891 /* RadarTripLeg.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BA46C1682F4CF46600031891 /* RadarTripLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = BA46C1672F4CF45600031891 /* RadarTripLeg.m */; };
 		BA46C16A2F4E0A9000031891 /* trip_with_legs.json in Resources */ = {isa = PBXBuildFile; fileRef = BA46C1692F4E0A8300031891 /* trip_with_legs.json */; };
@@ -333,6 +337,10 @@
 		BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarOfflineEventManagerTests.swift; sourceTree = "<group>"; };
 		BA3540212F90020900E553A1 /* RadarOfflineEventManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarOfflineEventManager.h; sourceTree = "<group>"; };
 		BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSerializedTests.swift; sourceTree = "<group>"; };
+		C0DEF0012F91000100AA0001 /* RadarFailoverAPICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarFailoverAPICoordinator.swift; sourceTree = "<group>"; };
+		C0DEF0022F91000100AA0002 /* RadarFailoverAPICoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarFailoverAPICoordinator.h; sourceTree = "<group>"; };
+		C0DEF0032F91000100AA0003 /* RadarFailoverAPICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarFailoverAPICoordinatorTests.swift; sourceTree = "<group>"; };
+		C0DEF0042F91000100AA0004 /* RadarAPIClientFailoverWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIClientFailoverWiringTests.swift; sourceTree = "<group>"; };
 		BA46C1652F4CF3E900031891 /* RadarTripLeg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarTripLeg.h; sourceTree = "<group>"; };
 		BA46C1672F4CF45600031891 /* RadarTripLeg.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarTripLeg.m; sourceTree = "<group>"; };
 		BA46C1692F4E0A8300031891 /* trip_with_legs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = trip_with_legs.json; sourceTree = "<group>"; };
@@ -591,6 +599,8 @@
 				DD236C9823087F9200EB88F9 /* RadarAPIClient.h */,
 				DD236C9923087F9200EB88F9 /* RadarAPIClient.m */,
 				F6513DDB2E54F63100523472 /* RadarAPIClient.swift */,
+				C0DEF0022F91000100AA0002 /* RadarFailoverAPICoordinator.h */,
+				C0DEF0012F91000100AA0001 /* RadarFailoverAPICoordinator.swift */,
 				82DF18772C5830C300301B17 /* RadarActivityManager.h */,
 				82DF18782C5830C300301B17 /* RadarActivityManager.m */,
 				DD633EC1237C5B800026C91A /* RadarAPIHelper.h */,
@@ -664,6 +674,8 @@
 			children = (
 				BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */,
 				BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */,
+				C0DEF0042F91000100AA0004 /* RadarAPIClientFailoverWiringTests.swift */,
+				C0DEF0032F91000100AA0003 /* RadarFailoverAPICoordinatorTests.swift */,
 				BA353F082F8826AF00E553A1 /* RadatSyncTestHelper.m */,
 				BA353F072F88269F00E553A1 /* RadarSyncTestHelper.h */,
 				BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */,
@@ -796,6 +808,7 @@
 				96A5A10F27AD9F7F007B960B /* RadarRouteDuration.h in Headers */,
 				BA46C1662F4CF3F200031891 /* RadarTripLeg.h in Headers */,
 				BA3540222F90020F00E553A1 /* RadarOfflineEventManager.h in Headers */,
+				C0DEF1022F91000100AA0002 /* RadarFailoverAPICoordinator.h in Headers */,
 				96A5A10627AD9F7F007B960B /* RadarFraud.h in Headers */,
 				01F99CFB2965C182004E8CF3 /* RadarConfig.h in Headers */,
 				96A5A0CF27AD9F41007B960B /* RadarAddress+Internal.h in Headers */,
@@ -1030,6 +1043,7 @@
 				F65F79372EF4560B00399E84 /* RadarInAppMessage.m in Sources */,
 				0107AAAA26220165008AB52F /* RadarGeofenceGeometry.m in Sources */,
 				BA8647AD2F6C527B00F1A199 /* RadarSyncState.swift in Sources */,
+				C0DEF1012F91000100AA0001 /* RadarFailoverAPICoordinator.swift in Sources */,
 				0107AAEC262201A6008AB52F /* RadarTrip.m in Sources */,
 				9679F4A327CD8DE200800797 /* CLLocation+Radar.m in Sources */,
 				BA8647B32F6C5B3500F1A199 /* RadarPlace.swift in Sources */,
@@ -1098,6 +1112,8 @@
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,
 				DD8E2F7724018C25002D51AB /* RadarAPIHelperMock.m in Sources */,
 				BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */,
+				C0DEF1042F91000100AA0004 /* RadarAPIClientFailoverWiringTests.swift in Sources */,
+				C0DEF1032F91000100AA0003 /* RadarFailoverAPICoordinatorTests.swift in Sources */,
 				96B465BC27D6732500D7119B /* CLLocation+RadarTests.m in Sources */,
 				DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */,
 				DD8E2F7124018BF9002D51AB /* RadarTestUtils.m in Sources */,

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -34,6 +34,7 @@
 #import "RadarUser+Internal.h"
 #import "RadarUtils.h"
 #import "RadarVerificationManager.h"
+#import "RadarFailoverAPICoordinator.h"
 #import "RadarVerifiedLocationToken+Internal.h"
 #import "RadarNotificationHelper.h"
 #import <os/log.h>
@@ -127,11 +128,45 @@
     [queryString appendFormat:@"&verified=%@", verified ? @"true" : @"false"];
     [queryString appendFormat:@"&clientSdkConfiguration=%@", [RadarUtils dictionaryToJson:[RadarSettings clientSdkConfiguration]]];
 
+    NSDictionary *headers = [RadarAPIClient headersWithPublishableKey:publishableKey];
+
+    void (^responseHandler)(RadarStatus, NSDictionary *) = ^(RadarStatus status, NSDictionary *_Nullable res) {
+        if (!res) {
+            completionHandler(status, nil);
+            return;
+        }
+
+        [Radar flushLogs];
+
+        RadarConfig *config = [RadarConfig fromDictionary:res];
+
+        completionHandler(status, config);
+    };
+
+    if (verified && [[RadarSettings sdkConfiguration] useVerifiedHostFailover]) {
+        NSString *path = [NSString stringWithFormat:@"/v1/config?%@", queryString];
+        RadarAPIHelper *apiHelper = self.apiHelper;
+        [[RadarFailoverAPICoordinator verifiedSharedInstance]
+            requestWithPath:path
+             performRequest:^(NSString * _Nonnull verifiedUrl, void (^ _Nonnull innerCompletion)(RadarStatus, NSDictionary<NSObject *, id> * _Nullable)) {
+                [apiHelper requestWithMethod:@"GET"
+                                         url:verifiedUrl
+                                     headers:headers
+                                      params:nil
+                                       sleep:NO
+                                  logPayload:YES
+                             extendedTimeout:NO
+                           completionHandler:innerCompletion];
+             }
+          completionHandler:^(RadarStatus status, NSDictionary<NSObject *, id> * _Nullable res) {
+                responseHandler(status, res);
+            }];
+        return;
+    }
+
     NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
     NSString *url = [NSString stringWithFormat:@"%@/v1/config?%@", host, queryString];
     url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-
-    NSDictionary *headers = [RadarAPIClient headersWithPublishableKey:publishableKey];
 
     [self.apiHelper requestWithMethod:@"GET"
                                   url:url
@@ -140,18 +175,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
-                        if (!res) {
-                            completionHandler(status, nil);
-                            return;
-                        }
-
-                        [Radar flushLogs];
-
-                        RadarConfig *config = [RadarConfig fromDictionary:res];
-        
-                        completionHandler(status, config);
-                    }];
+                    completionHandler:responseHandler];
 }
 
 - (void)flushReplays:(NSArray<NSDictionary *> *_Nonnull)replays
@@ -492,10 +516,6 @@
         return;
     }
 
-    NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
-    NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];
-    url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-
     NSDictionary *headers = [RadarAPIClient headersWithPublishableKey:publishableKey];
 
     NSArray<RadarReplay *> *replays = [[RadarReplayBuffer sharedInstance] flushableReplays];
@@ -531,14 +551,7 @@
             }
         }];
     } else {
-        [self.apiHelper requestWithMethod:@"POST"
-                                    url:url
-                                headers:headers
-                                params:requestParams
-                                    sleep:YES
-                            logPayload:YES
-                        extendedTimeout:NO
-                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+        void (^handleTrackResponse)(RadarStatus, NSDictionary *) = ^(RadarStatus status, NSDictionary *_Nullable res) {
                             if (status != RadarStatusSuccess || !res) {
                                 if (options.replay == RadarTrackingOptionsReplayAll) {
                                     // create a copy of params that we can use to write to the buffer in case of request failure
@@ -710,7 +723,39 @@
                             [[RadarDelegateHolder sharedInstance] didFailWithStatus:status];
             
                             completionHandler(RadarStatusErrorServer, nil, nil, nil, nil, nil, nil);
-                        }];
+                        };
+
+        if (verified && [[RadarSettings sdkConfiguration] useVerifiedHostFailover]) {
+            RadarAPIHelper *apiHelper = self.apiHelper;
+            [[RadarFailoverAPICoordinator verifiedSharedInstance]
+                requestWithPath:@"/v1/track"
+                 performRequest:^(NSString * _Nonnull verifiedUrl, void (^ _Nonnull innerCompletion)(RadarStatus, NSDictionary<NSObject *, id> * _Nullable)) {
+                    [apiHelper requestWithMethod:@"POST"
+                                             url:verifiedUrl
+                                         headers:headers
+                                          params:requestParams
+                                           sleep:YES
+                                      logPayload:YES
+                                 extendedTimeout:NO
+                               completionHandler:innerCompletion];
+                 }
+              completionHandler:^(RadarStatus status, NSDictionary<NSObject *, id> * _Nullable res) {
+                    handleTrackResponse(status, res);
+                }];
+        } else {
+            NSString *host = verified ? [RadarSettings verifiedHost] : [RadarSettings host];
+            NSString *url = [NSString stringWithFormat:@"%@/v1/track", host];
+            url = [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
+            [self.apiHelper requestWithMethod:@"POST"
+                                          url:url
+                                      headers:headers
+                                       params:requestParams
+                                        sleep:YES
+                                   logPayload:YES
+                              extendedTimeout:NO
+                            completionHandler:handleTrackResponse];
+        }
     }
 }
 

--- a/RadarSDK/RadarFailoverAPICoordinator.h
+++ b/RadarSDK/RadarFailoverAPICoordinator.h
@@ -1,0 +1,26 @@
+//
+//  RadarFailoverAPICoordinator.h
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Radar.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RadarFailoverAPICoordinator : NSObject
+
++ (instancetype)verifiedSharedInstance;
+
+- (void)requestWithPath:(NSString *)path
+         performRequest:(void (^)(NSString *url, void (^completion)(RadarStatus status, NSDictionary<NSObject *, id> *_Nullable res)))performRequest
+      completionHandler:(void (^)(RadarStatus status, NSDictionary<NSObject *, id> *_Nullable res))completionHandler;
+
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarFailoverAPICoordinator.swift
+++ b/RadarSDK/RadarFailoverAPICoordinator.swift
@@ -153,7 +153,7 @@ internal final class RadarFailoverAPICoordinator: NSObject, @unchecked Sendable 
         }
 
         healthCheck(primaryHost) { [weak self] healthy in
-            self?.healthQueue.async {
+            self?.healthQueue.async { [weak self] in
                 self?.finishHealthCheck(healthy: healthy)
             }
         }
@@ -203,7 +203,7 @@ internal final class RadarFailoverAPICoordinator: NSObject, @unchecked Sendable 
         return combined.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? combined
     }
 
-    private static func defaultHealthCheck(primaryHost: String, completion: @escaping (Bool) -> Void) {
+    private static func defaultHealthCheck(primaryHost: String, completion: @escaping @Sendable (Bool) -> Void) {
         let urlString = url(host: primaryHost, path: "/health")
         guard let url = URL(string: urlString) else {
             completion(false)

--- a/RadarSDK/RadarFailoverAPICoordinator.swift
+++ b/RadarSDK/RadarFailoverAPICoordinator.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 @objc(RadarFailoverAPICoordinator)
-internal final class RadarFailoverAPICoordinator: NSObject {
+internal final class RadarFailoverAPICoordinator: NSObject, @unchecked Sendable {
 
-    typealias HealthCheck = (_ primaryHost: String, _ completion: @escaping (Bool) -> Void) -> Void
+    typealias HealthCheck = @Sendable (_ primaryHost: String, _ completion: @escaping @Sendable (Bool) -> Void) -> Void
 
     @objc(verifiedSharedInstance)
-    nonisolated(unsafe) static let verifiedShared = RadarFailoverAPICoordinator(
+    static let verifiedShared = RadarFailoverAPICoordinator(
         hostsProvider: { [RadarSettings.verifiedHost, RadarSettings.DefaultVerifiedHostSecondary] },
         logPrefix: "verified"
     )

--- a/RadarSDK/RadarFailoverAPICoordinator.swift
+++ b/RadarSDK/RadarFailoverAPICoordinator.swift
@@ -74,22 +74,6 @@ internal final class RadarFailoverAPICoordinator: NSObject {
         timer?.cancel()
     }
 
-    var isUsingSecondaryForTests: Bool {
-        locked { usingSecondaryHost }
-    }
-
-    var isHealthTimerActiveForTests: Bool {
-        locked { healthTimer != nil }
-    }
-
-    func runHealthCheckForTests() {
-        runHealthCheck()
-    }
-
-    func waitForHealthCheckForTests() {
-        healthQueue.sync {}
-    }
-
     private func selectedHost() -> (index: Int, host: String) {
         let hosts = hostsProvider()
         let wantsSecondary = locked { usingSecondaryHost }

--- a/RadarSDK/RadarFailoverAPICoordinator.swift
+++ b/RadarSDK/RadarFailoverAPICoordinator.swift
@@ -1,0 +1,242 @@
+//
+//  RadarFailoverAPICoordinator.swift
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+
+@objc(RadarFailoverAPICoordinator)
+internal final class RadarFailoverAPICoordinator: NSObject {
+
+    typealias HealthCheck = (_ primaryHost: String, _ completion: @escaping (Bool) -> Void) -> Void
+
+    @objc(verifiedSharedInstance)
+    nonisolated(unsafe) static let verifiedShared = RadarFailoverAPICoordinator(
+        hostsProvider: { [RadarSettings.verifiedHost, RadarSettings.DefaultVerifiedHostSecondary] },
+        logPrefix: "verified"
+    )
+
+    private let hostsProvider: () -> [String]
+    private let healthCheck: HealthCheck
+    private let healthInterval: TimeInterval
+    private let schedulesHealthChecks: Bool
+    private let healthQueue = DispatchQueue(label: "io.radar.failover.health")
+    private let lock = NSLock()
+    private let logPrefix: String
+
+    private var usingSecondaryHost = false
+    private var healthTimer: DispatchSourceTimer?
+    private var healthCheckInFlight = false
+
+    init(
+        hostsProvider: @escaping () -> [String],
+        healthInterval: TimeInterval = 15,
+        schedulesHealthChecks: Bool = true,
+        healthCheck: @escaping HealthCheck = RadarFailoverAPICoordinator.defaultHealthCheck,
+        logPrefix: String = ""
+    ) {
+        self.hostsProvider = hostsProvider
+        self.healthInterval = healthInterval
+        self.schedulesHealthChecks = schedulesHealthChecks
+        self.healthCheck = healthCheck
+        self.logPrefix = logPrefix
+        super.init()
+    }
+
+    @objc
+    func request(
+        path: String,
+        performRequest: @escaping (_ url: String, _ completion: @escaping (RadarStatus, [AnyHashable: Any]?) -> Void) -> Void,
+        completionHandler: @escaping (RadarStatus, [AnyHashable: Any]?) -> Void
+    ) {
+        let selection = selectedHost()
+        let url = Self.url(host: selection.host, path: path)
+
+        RadarLogger.shared.debug("\(logTag): request host[\(selection.index)] path=\(path)")
+
+        performRequest(url) { [weak self] status, res in
+            self?.record(status: status, res: res, hostIndex: selection.index)
+            completionHandler(status, res)
+        }
+    }
+
+    @objc
+    func reset() {
+        let timer = locked {
+            usingSecondaryHost = false
+            healthCheckInFlight = false
+            let timer = healthTimer
+            healthTimer = nil
+            return timer
+        }
+        timer?.cancel()
+    }
+
+    var isUsingSecondaryForTests: Bool {
+        locked { usingSecondaryHost }
+    }
+
+    var isHealthTimerActiveForTests: Bool {
+        locked { healthTimer != nil }
+    }
+
+    func runHealthCheckForTests() {
+        runHealthCheck()
+    }
+
+    func waitForHealthCheckForTests() {
+        healthQueue.sync {}
+    }
+
+    private func selectedHost() -> (index: Int, host: String) {
+        let hosts = hostsProvider()
+        let wantsSecondary = locked { usingSecondaryHost }
+        let index = wantsSecondary && hosts.count > 1 ? 1 : 0
+        let host = hosts.indices.contains(index) ? hosts[index] : RadarSettings.verifiedHost
+        return (index, host)
+    }
+
+    private func record(status: RadarStatus, res: [AnyHashable: Any]?, hostIndex: Int) {
+        guard hostIndex == 0 else {
+            return
+        }
+
+        if Self.isRadarResponse(res) {
+            return
+        }
+
+        if status == .errorNetwork || res == nil || !Self.isRadarResponse(res) {
+            failoverToSecondary()
+        }
+    }
+
+    private func failoverToSecondary() {
+        let hosts = hostsProvider()
+        guard hosts.count > 1 else {
+            RadarLogger.shared.warning("\(logTag): primary failed, but no secondary verified host is configured")
+            return
+        }
+
+        let shouldStartTimer = locked { () -> Bool in
+            let shouldStart = !usingSecondaryHost && healthTimer == nil && schedulesHealthChecks
+            usingSecondaryHost = true
+            return shouldStart
+        }
+
+        RadarLogger.shared.info("\(logTag): primary verified host failed; switching future requests to secondary")
+
+        if shouldStartTimer {
+            startHealthTimer()
+        }
+    }
+
+    private func startHealthTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: healthQueue)
+        timer.schedule(deadline: .now() + healthInterval, repeating: healthInterval)
+        timer.setEventHandler { [weak self] in
+            self?.runHealthCheck()
+        }
+
+        let shouldResume = locked { () -> Bool in
+            guard healthTimer == nil else {
+                return false
+            }
+            healthTimer = timer
+            return true
+        }
+
+        if shouldResume {
+            timer.resume()
+        } else {
+            timer.cancel()
+        }
+    }
+
+    private func runHealthCheck() {
+        let primaryHost = selectedPrimaryHost()
+        let shouldRun = locked { () -> Bool in
+            guard usingSecondaryHost, !healthCheckInFlight else {
+                return false
+            }
+            healthCheckInFlight = true
+            return true
+        }
+
+        guard shouldRun else {
+            return
+        }
+
+        healthCheck(primaryHost) { [weak self] healthy in
+            self?.healthQueue.async {
+                self?.finishHealthCheck(healthy: healthy)
+            }
+        }
+    }
+
+    private func finishHealthCheck(healthy: Bool) {
+        locked {
+            healthCheckInFlight = false
+        }
+
+        guard healthy else {
+            RadarLogger.shared.debug("\(logTag): primary verified host health check failed; staying on secondary")
+            return
+        }
+
+        let timer = locked { () -> DispatchSourceTimer? in
+            usingSecondaryHost = false
+            let timer = healthTimer
+            healthTimer = nil
+            return timer
+        }
+        timer?.cancel()
+        RadarLogger.shared.info("\(logTag): primary verified host health check succeeded; returning to primary")
+    }
+
+    private func selectedPrimaryHost() -> String {
+        let hosts = hostsProvider()
+        return hosts.first ?? RadarSettings.verifiedHost
+    }
+
+    private var logTag: String {
+        logPrefix.isEmpty ? "FailoverAPICoordinator" : "FailoverAPICoordinator[\(logPrefix)]"
+    }
+
+    private func locked<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    private static func isRadarResponse(_ res: [AnyHashable: Any]?) -> Bool {
+        res?["meta"] != nil
+    }
+
+    private static func url(host: String, path: String) -> String {
+        let combined = "\(host)\(path)"
+        return combined.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? combined
+    }
+
+    private static func defaultHealthCheck(primaryHost: String, completion: @escaping (Bool) -> Void) {
+        let urlString = url(host: primaryHost, path: "/health")
+        guard let url = URL(string: urlString) else {
+            completion(false)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 10
+
+        URLSession.shared.dataTask(with: request) { _, response, error in
+            guard error == nil, let httpResponse = response as? HTTPURLResponse else {
+                completion(false)
+                return
+            }
+
+            completion((200..<300).contains(httpResponse.statusCode))
+        }.resume()
+    }
+}

--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)useOfflineRTOUpdates;
 - (BOOL)offlineEventGenerationEnabled;
 - (NSArray<RadarRemoteTrackingOptions *> *_Nullable)remoteTrackingOptions;
+- (BOOL)useVerifiedHostFailover;
 - (instancetype)initWithDict:(NSDictionary *_Nullable)dict;
 - (NSDictionary *)dictionaryValue;
 @end

--- a/RadarSDK/RadarSdkConfiguration.swift
+++ b/RadarSDK/RadarSdkConfiguration.swift
@@ -69,6 +69,7 @@ class RadarSdkConfiguration: NSObject {
     let useOfflineRTOUpdates: Bool
     let offlineEventGenerationEnabled: Bool
     let remoteTrackingOptions: [RadarRemoteTrackingOptions]?
+    let useVerifiedHostFailover: Bool
     
     public init(dict: [String: Any]?) {
         originalDict = dict
@@ -93,6 +94,7 @@ class RadarSdkConfiguration: NSObject {
         useOfflineRTOUpdates = dict?["useOfflineRTOUpdates"] as? Bool ?? false
         offlineEventGenerationEnabled = dict?["offlineEventGenerationEnabled"] as? Bool ?? false
         remoteTrackingOptions = RadarRemoteTrackingOptions.from(array: dict?["remoteTrackingOptions"] as? [[String: Any]])
+        useVerifiedHostFailover = dict?["useVerifiedHostFailover"] as? Bool ?? false
     }
     
     public func dictionaryValue() -> [String: Any] {
@@ -120,7 +122,8 @@ class RadarSdkConfiguration: NSObject {
             "skipForegroundCheck": skipForegroundCheck,
             "useOfflineRTOUpdates": useOfflineRTOUpdates,
             "offlineEventGenerationEnabled": offlineEventGenerationEnabled,
-            "remoteTrackingOptions": RadarRemoteTrackingOptions.toDictionaries(remoteTrackingOptions) as Any
+            "remoteTrackingOptions": RadarRemoteTrackingOptions.toDictionaries(remoteTrackingOptions) as Any,
+            "useVerifiedHostFailover": useVerifiedHostFailover
         ]
     }
 }

--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -12,6 +12,7 @@ internal class RadarSettings: NSObject {
     
     static let DefaultHost = "https://api.radar.io"
     static let DefaultVerifiedHost = "https://api-verified.radar.io"
+    static let DefaultVerifiedHostSecondary = "https://api-verified.radar.com"
     
     public static func setAppGroup(_ appGroup: String?) {
         // this call needs to by synchronised to prevent race conditions in checking / updating the app group

--- a/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
+++ b/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
@@ -1,0 +1,185 @@
+//
+//  RadarAPIClientFailoverWiringTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+import ObjectiveC
+import Testing
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+
+    @Suite(.serialized)
+    final class RadarAPIClientFailoverWiringTests {
+
+        private let apiHelperMock = RadarAPIHelperMock()
+        private let apiClient: AnyObject
+
+        init() {
+            Radar.initialize(publishableKey: "prj_test_pk_0000000000000000")
+            apiClient = ObjCAPIClientBridge.sharedInstance()
+            ObjCAPIClientBridge.setAPIHelper(apiHelperMock, on: apiClient)
+            RadarFailoverAPICoordinator.verifiedShared.reset()
+        }
+
+        deinit {
+            RadarFailoverAPICoordinator.verifiedShared.reset()
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: nil)
+        }
+
+        private func setFailoverFlag(_ enabled: Bool) {
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useVerifiedHostFailover": enabled])
+        }
+
+        private func capturedConfigUrl(verified: Bool) async -> String? {
+            await withCheckedContinuation { continuation in
+                ObjCAPIClientBridge.getConfig(on: apiClient, usage: "wiring-test", verified: verified) { _, _ in
+                    continuation.resume(returning: self.apiHelperMock.lastUrl)
+                }
+            }
+        }
+
+        private func capturedTrackUrl(verified: Bool) async -> String? {
+            await withCheckedContinuation { continuation in
+                let location = CLLocation(latitude: 40.0, longitude: -73.0)
+                ObjCAPIClientBridge.track(on: apiClient, location: location, verified: verified) { _, _, _, _, _, _, _ in
+                    continuation.resume(returning: self.apiHelperMock.lastUrl)
+                }
+            }
+        }
+
+        @Test func verifiedConfigUsesPrimaryThenSecondaryWhenFailoverEnabled() async {
+            setFailoverFlag(true)
+            apiHelperMock.mockStatus = .errorServer
+            apiHelperMock.mockResponse = ["error": "cloudflare"]
+
+            let firstUrl = await capturedConfigUrl(verified: true)
+            let secondUrl = await capturedConfigUrl(verified: true)
+
+            #expect(firstUrl?.contains("api-verified.radar.io") == true)
+            #expect(firstUrl?.contains("api-verified.radar.com") == false)
+            #expect(secondUrl?.contains("api-verified.radar.com") == true)
+        }
+
+        @Test func verifiedConfigSkipsCoordinatorWhenFailoverDisabled() async {
+            setFailoverFlag(false)
+            apiHelperMock.mockStatus = .errorServer
+            apiHelperMock.mockResponse = ["error": "cloudflare"]
+
+            let firstUrl = await capturedConfigUrl(verified: true)
+            let secondUrl = await capturedConfigUrl(verified: true)
+
+            #expect(firstUrl?.contains("api-verified.radar.io") == true)
+            #expect(secondUrl?.contains("api-verified.radar.io") == true)
+            #expect(secondUrl?.contains("api-verified.radar.com") == false)
+        }
+
+        @Test func verifiedTrackUsesPrimaryThenSecondaryWhenFailoverEnabled() async {
+            setFailoverFlag(true)
+            apiHelperMock.mockStatus = .errorNetwork
+            apiHelperMock.mockResponse = [:]
+
+            let firstUrl = await capturedTrackUrl(verified: true)
+            let secondUrl = await capturedTrackUrl(verified: true)
+
+            #expect(firstUrl == "https://api-verified.radar.io/v1/track")
+            #expect(secondUrl == "https://api-verified.radar.com/v1/track")
+        }
+    }
+}
+
+private enum ObjCAPIClientBridge {
+
+    static func sharedInstance() -> AnyObject {
+        let selector = NSSelectorFromString("sharedInstance")
+        guard let method = class_getClassMethod(apiClientClass, selector) else {
+            fatalError("RadarAPIClient sharedInstance selector not found")
+        }
+
+        typealias Function = @convention(c) (AnyClass, Selector) -> AnyObject
+        let function = unsafeBitCast(method_getImplementation(method), to: Function.self)
+        return function(apiClientClass, selector)
+    }
+
+    static func setAPIHelper(_ helper: RadarAPIHelperMock, on client: AnyObject) {
+        let selector = NSSelectorFromString("setApiHelper:")
+        let implementation = client.method(for: selector)
+
+        typealias Function = @convention(c) (AnyObject, Selector, AnyObject) -> Void
+        let function = unsafeBitCast(implementation, to: Function.self)
+        function(client, selector, helper)
+    }
+
+    static func getConfig(
+        on client: AnyObject,
+        usage: String,
+        verified: Bool,
+        completion: @escaping @convention(block) (RadarStatus, AnyObject?) -> Void
+    ) {
+        let selector = NSSelectorFromString("getConfigForUsage:verified:completionHandler:")
+        let implementation = client.method(for: selector)
+
+        typealias Function = @convention(c) (AnyObject, Selector, NSString?, Bool, @escaping @convention(block) (RadarStatus, AnyObject?) -> Void) -> Void
+        let function = unsafeBitCast(implementation, to: Function.self)
+        function(client, selector, usage as NSString, verified, completion)
+    }
+
+    static func track(
+        on client: AnyObject,
+        location: CLLocation,
+        verified: Bool,
+        completion: @escaping @convention(block) (RadarStatus, NSDictionary?, NSArray?, AnyObject?, NSArray?, AnyObject?, AnyObject?) -> Void
+    ) {
+        let selector = NSSelectorFromString("trackWithLocation:stopped:foreground:source:replayed:beacons:indoorScan:verified:fraudPayload:expectedCountryCode:expectedStateCode:reason:transactionId:completionHandler:")
+        let implementation = client.method(for: selector)
+
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            CLLocation,
+            Bool,
+            Bool,
+            RadarLocationSource,
+            Bool,
+            NSArray?,
+            NSString?,
+            Bool,
+            NSString?,
+            NSString?,
+            NSString?,
+            NSString?,
+            NSString?,
+            @escaping @convention(block) (RadarStatus, NSDictionary?, NSArray?, AnyObject?, NSArray?, AnyObject?, AnyObject?) -> Void
+        ) -> Void
+        let function = unsafeBitCast(implementation, to: Function.self)
+        function(
+            client,
+            selector,
+            location,
+            false,
+            true,
+            RadarLocationSource(rawValue: 2)!,
+            false,
+            nil,
+            nil,
+            verified,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            completion
+        )
+    }
+
+    private static var apiClientClass: AnyClass {
+        guard let cls = NSClassFromString("RadarAPIClient") else {
+            fatalError("Objective-C RadarAPIClient class not found")
+        }
+        return cls
+    }
+}

--- a/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
+++ b/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
@@ -38,21 +38,31 @@ extension RadarSerializedTests {
             RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useVerifiedHostFailover": enabled])
         }
 
+        private func newUrlsContaining(_ substring: String, since startCount: Int) -> [String] {
+            let history = apiHelperMock.urlHistory
+            guard history.count > startCount else { return [] }
+            return history[startCount...].filter { $0.contains(substring) }
+        }
+
         private func capturedConfigUrl(verified: Bool) async -> String? {
-            await withCheckedContinuation { continuation in
+            let startCount = apiHelperMock.urlHistory.count
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 ObjCAPIClientBridge.getConfig(on: apiClient, usage: "wiring-test", verified: verified) { _, _ in
-                    continuation.resume(returning: self.apiHelperMock.lastUrl)
+                    continuation.resume()
                 }
             }
+            return newUrlsContaining("/v1/config", since: startCount).first
         }
 
         private func capturedTrackUrl(verified: Bool) async -> String? {
-            await withCheckedContinuation { continuation in
+            let startCount = apiHelperMock.urlHistory.count
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 let location = CLLocation(latitude: 40.0, longitude: -73.0)
                 ObjCAPIClientBridge.track(on: apiClient, location: location, verified: verified) { _, _, _, _, _, _, _ in
-                    continuation.resume(returning: self.apiHelperMock.lastUrl)
+                    continuation.resume()
                 }
             }
+            return newUrlsContaining("/v1/track", since: startCount).first
         }
 
         @Test func verifiedConfigUsesPrimaryThenSecondaryWhenFailoverEnabled() async {

--- a/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
+++ b/RadarSDKTests/RadarAPIClientFailoverWiringTests.swift
@@ -14,21 +14,24 @@ import Testing
 extension RadarSerializedTests {
 
     @Suite(.serialized)
-    final class RadarAPIClientFailoverWiringTests {
+    final class RadarAPIClientFailoverWiringTests: @unchecked Sendable {
 
         private let apiHelperMock = RadarAPIHelperMock()
         private let apiClient: AnyObject
+        private let originalApiHelper: AnyObject
 
         init() {
             Radar.initialize(publishableKey: "prj_test_pk_0000000000000000")
             apiClient = ObjCAPIClientBridge.sharedInstance()
+            originalApiHelper = ObjCAPIClientBridge.apiHelper(on: apiClient)
             ObjCAPIClientBridge.setAPIHelper(apiHelperMock, on: apiClient)
             RadarFailoverAPICoordinator.verifiedShared.reset()
         }
 
         deinit {
             RadarFailoverAPICoordinator.verifiedShared.reset()
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: nil)
+            ObjCAPIClientBridge.setAPIHelper(originalApiHelper, on: apiClient)
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [:])
         }
 
         private func setFailoverFlag(_ enabled: Bool) {
@@ -105,13 +108,22 @@ private enum ObjCAPIClientBridge {
         return function(apiClientClass, selector)
     }
 
-    static func setAPIHelper(_ helper: RadarAPIHelperMock, on client: AnyObject) {
+    static func setAPIHelper(_ helper: AnyObject, on client: AnyObject) {
         let selector = NSSelectorFromString("setApiHelper:")
         let implementation = client.method(for: selector)
 
         typealias Function = @convention(c) (AnyObject, Selector, AnyObject) -> Void
         let function = unsafeBitCast(implementation, to: Function.self)
         function(client, selector, helper)
+    }
+
+    static func apiHelper(on client: AnyObject) -> AnyObject {
+        let selector = NSSelectorFromString("apiHelper")
+        let implementation = client.method(for: selector)
+
+        typealias Function = @convention(c) (AnyObject, Selector) -> AnyObject
+        let function = unsafeBitCast(implementation, to: Function.self)
+        return function(client, selector)
     }
 
     static func getConfig(

--- a/RadarSDKTests/RadarAPIHelperMock.h
+++ b/RadarSDKTests/RadarAPIHelperMock.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *lastUrl;
 @property (nonatomic, strong, nullable) NSDictionary *lastHeaders;
 @property (nonatomic, strong, nullable) NSDictionary *lastParams;
+@property (nonatomic, strong, nonnull, readonly) NSArray<NSString *> *urlHistory;
 
 - (void)setMockResponse:(NSDictionary *)response forMethod:(NSString *)urlString;
 - (void)setMockStatus:(RadarStatus)mockStatus forMethod:(NSString *)urlString;

--- a/RadarSDKTests/RadarAPIHelperMock.m
+++ b/RadarSDKTests/RadarAPIHelperMock.m
@@ -11,6 +11,8 @@
 
 @property (nonnull, strong, nonatomic) NSMutableDictionary *mockResponses;
 @property (nonnull, strong, nonatomic) NSMutableDictionary *mockStatuses;
+@property (nonnull, strong, nonatomic) NSMutableArray<NSString *> *mutableUrlHistory;
+@property (nonnull, strong, nonatomic) NSLock *urlHistoryLock;
 
 @end
 
@@ -22,9 +24,18 @@
     if (self) {
         self.mockResponses = [NSMutableDictionary new];
         self.mockStatuses = [NSMutableDictionary new];
+        self.mutableUrlHistory = [NSMutableArray new];
+        self.urlHistoryLock = [NSLock new];
     }
 
     return self;
+}
+
+- (NSArray<NSString *> *)urlHistory {
+    [self.urlHistoryLock lock];
+    NSArray<NSString *> *snapshot = [self.mutableUrlHistory copy];
+    [self.urlHistoryLock unlock];
+    return snapshot;
 }
 
 - (void)requestWithMethod:(NSString *)method
@@ -40,6 +51,9 @@
     self.lastUrl = url;
     self.lastHeaders = headers;
     self.lastParams = params;
+    [self.urlHistoryLock lock];
+    [self.mutableUrlHistory addObject:url];
+    [self.urlHistoryLock unlock];
     
     NSDictionary *response = self.mockResponses[url];
     if (response == nil) {

--- a/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
+++ b/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
@@ -10,7 +10,7 @@ import Testing
 @testable import RadarSDK
 
 @Suite(.serialized)
-final class RadarFailoverAPICoordinatorTests {
+final class RadarFailoverAPICoordinatorTests: @unchecked Sendable {
 
     private let primaryHost = "https://primary.example.com"
     private let secondaryHost = "https://secondary.example.com"

--- a/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
+++ b/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
@@ -24,12 +24,13 @@ final class RadarFailoverAPICoordinatorTests {
     }
 
     private func makeCoordinator(
+        healthInterval: TimeInterval = 15,
         schedulesHealthChecks: Bool = false,
         healthCheck: @escaping RadarFailoverAPICoordinator.HealthCheck = { _, completion in completion(false) }
     ) -> RadarFailoverAPICoordinator {
         RadarFailoverAPICoordinator(
             hostsProvider: { [self.primaryHost, self.secondaryHost] },
-            healthInterval: 15,
+            healthInterval: healthInterval,
             schedulesHealthChecks: schedulesHealthChecks,
             healthCheck: healthCheck
         )
@@ -68,7 +69,12 @@ final class RadarFailoverAPICoordinatorTests {
 
         #expect(result.status == .success)
         #expect(result.urls == ["https://primary.example.com/v1/track"])
-        #expect(coordinator.isUsingSecondaryForTests == false)
+
+        let second = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(second.urls == ["https://primary.example.com/v1/track"])
     }
 
     @Test func primaryNetworkErrorSwitchesOnlyFutureRequestsToSecondary() {
@@ -80,7 +86,6 @@ final class RadarFailoverAPICoordinatorTests {
 
         #expect(first.status == .errorNetwork)
         #expect(first.urls == ["https://primary.example.com/v1/track"])
-        #expect(coordinator.isUsingSecondaryForTests)
 
         let second = runRequest(coordinator: coordinator) { _ in
             (.success, self.radarResponse())
@@ -98,7 +103,6 @@ final class RadarFailoverAPICoordinatorTests {
         }
 
         #expect(first.urls == ["https://primary.example.com/v1/track"])
-        #expect(coordinator.isUsingSecondaryForTests)
 
         let second = runRequest(coordinator: coordinator) { _ in
             (.success, self.radarResponse())
@@ -116,55 +120,84 @@ final class RadarFailoverAPICoordinatorTests {
 
         #expect(result.status == .errorServer)
         #expect(result.urls == ["https://primary.example.com/v1/track"])
-        #expect(coordinator.isUsingSecondaryForTests == false)
+
+        let second = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(second.urls == ["https://primary.example.com/v1/track"])
     }
 
     @Test func failoverStartsHealthTimer() {
-        let coordinator = makeCoordinator(schedulesHealthChecks: true)
+        let healthCheckRan = DispatchSemaphore(value: 0)
+        let coordinator = makeCoordinator(healthInterval: 0.01, schedulesHealthChecks: true) { _, completion in
+            completion(false)
+            healthCheckRan.signal()
+        }
         defer { coordinator.reset() }
 
         _ = runRequest(coordinator: coordinator) { _ in
             (.errorNetwork, nil)
         }
 
-        #expect(coordinator.isUsingSecondaryForTests)
-        #expect(coordinator.isHealthTimerActiveForTests)
+        #expect(healthCheckRan.wait(timeout: .now() + 1) == .success)
     }
 
     @Test func failedHealthCheckKeepsSecondaryActive() {
-        let coordinator = makeCoordinator { _, completion in
+        let healthCheckRan = DispatchSemaphore(value: 0)
+        let coordinator = makeCoordinator(healthInterval: 0.01, schedulesHealthChecks: true) { _, completion in
             completion(false)
+            healthCheckRan.signal()
         }
+        defer { coordinator.reset() }
 
         _ = runRequest(coordinator: coordinator) { _ in
             (.errorNetwork, nil)
         }
 
-        coordinator.runHealthCheckForTests()
-        coordinator.waitForHealthCheckForTests()
-
-        #expect(coordinator.isUsingSecondaryForTests)
-    }
-
-    @Test func positiveHealthCheckReturnsToPrimary() {
-        let coordinator = makeCoordinator { host, completion in
-            #expect(host == self.primaryHost)
-            completion(true)
-        }
-
-        _ = runRequest(coordinator: coordinator) { _ in
-            (.errorNetwork, nil)
-        }
-
-        coordinator.runHealthCheckForTests()
-        coordinator.waitForHealthCheckForTests()
-
-        #expect(coordinator.isUsingSecondaryForTests == false)
+        #expect(healthCheckRan.wait(timeout: .now() + 1) == .success)
 
         let result = runRequest(coordinator: coordinator) { _ in
             (.success, self.radarResponse())
         }
 
+        #expect(result.urls == ["https://secondary.example.com/v1/track"])
+    }
+
+    @Test func positiveHealthCheckReturnsToPrimary() {
+        let healthCheckRan = DispatchSemaphore(value: 0)
+        let coordinator = makeCoordinator(healthInterval: 0.01, schedulesHealthChecks: true) { host, completion in
+            #expect(host == self.primaryHost)
+            completion(true)
+            healthCheckRan.signal()
+        }
+        defer { coordinator.reset() }
+
+        _ = runRequest(coordinator: coordinator) { _ in
+            (.errorNetwork, nil)
+        }
+
+        #expect(healthCheckRan.wait(timeout: .now() + 1) == .success)
+
+        let result = eventuallyRunPrimaryRequest(coordinator: coordinator) {
+            (.success, self.radarResponse())
+        }
+
         #expect(result.urls == ["https://primary.example.com/v1/track"])
+    }
+
+    private func eventuallyRunPrimaryRequest(
+        coordinator: RadarFailoverAPICoordinator,
+        respond: @escaping () -> (RadarStatus, [AnyHashable: Any]?)
+    ) -> (status: RadarStatus, res: [AnyHashable: Any]?, urls: [String]) {
+        let deadline = Date().addingTimeInterval(1)
+        var latest = runRequest(coordinator: coordinator) { _ in respond() }
+
+        while latest.urls.last != "https://primary.example.com/v1/track" && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+            latest = runRequest(coordinator: coordinator) { _ in respond() }
+        }
+
+        return latest
     }
 }

--- a/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
+++ b/RadarSDKTests/RadarFailoverAPICoordinatorTests.swift
@@ -1,0 +1,170 @@
+//
+//  RadarFailoverAPICoordinatorTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import RadarSDK
+
+@Suite(.serialized)
+final class RadarFailoverAPICoordinatorTests {
+
+    private let primaryHost = "https://primary.example.com"
+    private let secondaryHost = "https://secondary.example.com"
+
+    private func radarResponse() -> [AnyHashable: Any] {
+        ["meta": ["code": 200], "user": ["_id": "u"]]
+    }
+
+    private func nonRadarResponse() -> [AnyHashable: Any] {
+        ["error": "bad gateway"]
+    }
+
+    private func makeCoordinator(
+        schedulesHealthChecks: Bool = false,
+        healthCheck: @escaping RadarFailoverAPICoordinator.HealthCheck = { _, completion in completion(false) }
+    ) -> RadarFailoverAPICoordinator {
+        RadarFailoverAPICoordinator(
+            hostsProvider: { [self.primaryHost, self.secondaryHost] },
+            healthInterval: 15,
+            schedulesHealthChecks: schedulesHealthChecks,
+            healthCheck: healthCheck
+        )
+    }
+
+    private func runRequest(
+        coordinator: RadarFailoverAPICoordinator,
+        respond: @escaping (String) -> (RadarStatus, [AnyHashable: Any]?)
+    ) -> (status: RadarStatus, res: [AnyHashable: Any]?, urls: [String]) {
+        var urls: [String] = []
+        var finalStatus: RadarStatus = .errorUnknown
+        var finalRes: [AnyHashable: Any]?
+
+        coordinator.request(
+            path: "/v1/track",
+            performRequest: { url, completion in
+                urls.append(url)
+                let response = respond(url)
+                completion(response.0, response.1)
+            },
+            completionHandler: { status, res in
+                finalStatus = status
+                finalRes = res
+            }
+        )
+
+        return (finalStatus, finalRes, urls)
+    }
+
+    @Test func primaryRadarResponseStaysPrimary() {
+        let coordinator = makeCoordinator()
+
+        let result = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(result.status == .success)
+        #expect(result.urls == ["https://primary.example.com/v1/track"])
+        #expect(coordinator.isUsingSecondaryForTests == false)
+    }
+
+    @Test func primaryNetworkErrorSwitchesOnlyFutureRequestsToSecondary() {
+        let coordinator = makeCoordinator()
+
+        let first = runRequest(coordinator: coordinator) { _ in
+            (.errorNetwork, nil)
+        }
+
+        #expect(first.status == .errorNetwork)
+        #expect(first.urls == ["https://primary.example.com/v1/track"])
+        #expect(coordinator.isUsingSecondaryForTests)
+
+        let second = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(second.status == .success)
+        #expect(second.urls == ["https://secondary.example.com/v1/track"])
+    }
+
+    @Test func primaryNonRadarResponseSwitchesFutureRequestsToSecondary() {
+        let coordinator = makeCoordinator()
+
+        let first = runRequest(coordinator: coordinator) { _ in
+            (.errorServer, self.nonRadarResponse())
+        }
+
+        #expect(first.urls == ["https://primary.example.com/v1/track"])
+        #expect(coordinator.isUsingSecondaryForTests)
+
+        let second = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(second.urls == ["https://secondary.example.com/v1/track"])
+    }
+
+    @Test func primaryRadarErrorWithMetaDoesNotSwitch() {
+        let coordinator = makeCoordinator()
+
+        let result = runRequest(coordinator: coordinator) { _ in
+            (.errorServer, ["meta": ["code": 500]])
+        }
+
+        #expect(result.status == .errorServer)
+        #expect(result.urls == ["https://primary.example.com/v1/track"])
+        #expect(coordinator.isUsingSecondaryForTests == false)
+    }
+
+    @Test func failoverStartsHealthTimer() {
+        let coordinator = makeCoordinator(schedulesHealthChecks: true)
+        defer { coordinator.reset() }
+
+        _ = runRequest(coordinator: coordinator) { _ in
+            (.errorNetwork, nil)
+        }
+
+        #expect(coordinator.isUsingSecondaryForTests)
+        #expect(coordinator.isHealthTimerActiveForTests)
+    }
+
+    @Test func failedHealthCheckKeepsSecondaryActive() {
+        let coordinator = makeCoordinator { _, completion in
+            completion(false)
+        }
+
+        _ = runRequest(coordinator: coordinator) { _ in
+            (.errorNetwork, nil)
+        }
+
+        coordinator.runHealthCheckForTests()
+        coordinator.waitForHealthCheckForTests()
+
+        #expect(coordinator.isUsingSecondaryForTests)
+    }
+
+    @Test func positiveHealthCheckReturnsToPrimary() {
+        let coordinator = makeCoordinator { host, completion in
+            #expect(host == self.primaryHost)
+            completion(true)
+        }
+
+        _ = runRequest(coordinator: coordinator) { _ in
+            (.errorNetwork, nil)
+        }
+
+        coordinator.runHealthCheckForTests()
+        coordinator.waitForHealthCheckForTests()
+
+        #expect(coordinator.isUsingSecondaryForTests == false)
+
+        let result = runRequest(coordinator: coordinator) { _ in
+            (.success, self.radarResponse())
+        }
+
+        #expect(result.urls == ["https://primary.example.com/v1/track"])
+    }
+}

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "RadarSyncTestHelper.h"
+#import "RadarAPIHelperMock.h"


### PR DESCRIPTION
## Summary
- add verified-host failover for verified config and track requests behind `useVerifiedHostFailover`
- switch future verified requests to `api-verified.radar.com` after primary non-Radar/network failures while preserving existing request retry behavior
- probe `primary/health` every 15 seconds after failover and return to primary on any 2xx response
- add coordinator and API client wiring coverage
