### PR TITLE
Surface Swift Testing failures in make test-pretty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: 26.3
+      xcode: 26.4.1
     steps:
       - run:
           name: Configure Git to use PAT for submodules

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,17 @@ build-pretty:
 	set -o pipefail && xcodebuild $(XC_ARGS) | xcpretty
 
 test-pretty:
-	set -o pipefail && xcodebuild $(XC_TEST_ARGS) test -skip-testing:RadarSDKTests/InAppMessageTest -skip-testing:RadarSDKTests/RadarSettingsTest -skip-testing:RadarSDKTests/RadarNotificationHelperTest | xcpretty --report junit
+	@set -o pipefail; \
+	  xcodebuild $(XC_TEST_ARGS) test -skip-testing:RadarSDKTests/InAppMessageTest -skip-testing:RadarSDKTests/RadarSettingsTest -skip-testing:RadarSDKTests/RadarNotificationHelperTest 2>&1 \
+	    | tee /tmp/radar-sdk-ios-test.log \
+	    | xcpretty --report junit; \
+	  status=$$?; \
+	  if [ $$status -ne 0 ]; then \
+	    echo ""; \
+	    echo "=== Swift Testing issues (hidden by xcpretty) ==="; \
+	    grep -E "^(Testing failed:|.*✘ Test |.*recorded an issue|.* failed after .* with [0-9]+ issue|Crash: )" /tmp/radar-sdk-ios-test.log || echo "(no Swift Testing failure markers found — see /tmp/radar-sdk-ios-test.log)"; \
+	  fi; \
+	  exit $$status
 
 test-swift:
 	xcodebuild $(XC_TEST_ARGS) test -only-testing:RadarSDKTests/InAppMessageTest -only-testing:RadarSDKTests/RadarSettingsTest -only-testing:RadarSDKTests/RadarNotificationHelperTest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 17,OS=26.2"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 17,OS=26.4.1"
 PROJECT := RadarSDK
 PROJECT_EXAMPLE := Example/Example
 SCHEME := XCFramework


### PR DESCRIPTION
## Summary

- Bump the default test destination to iPhone 17, OS 26.4.1, the most up to date version. Also the CI XCode version so it has the newest tools
- Make `make test-pretty` surface Swift Testing failures and crashes that xcpretty silently drops, so a non-zero exit from xcodebuild always comes with a visible reason.

## Why

`xcpretty` doesn't understand Swift Testing output. When a `@Test` function fails an `#expect`, or a Swift Testing suite crashes during `init`/`deinit`, xcpretty prints a clean XCTest summary with all green checkmarks while xcodebuild still exits 65. The result is a `make test-pretty` log that looks like everything passed, ending in `** TEST FAILED **` with no indication of what actually broke — you have to dig into the `.xcresult` bundle to find out.

The fix tees raw xcodebuild output to a temp log alongside the xcpretty pipe, and on non-zero exit prints any Swift Testing failure markers (`✘ Test ... recorded an issue`, `failed after ... with N issue`, `Crash:`, `Testing failed:`) under a clearly labeled section so they appear right next to xcpretty's XCTest summary.

Verified by temporarily injecting `#expect(false, ...)` into an existing Swift Testing case — the failure now surfaces with file/line:

```
=== Swift Testing issues (hidden by xcpretty) ===
✘ Test "..." recorded an issue at RadarOfflineEventManagerTests.swift:105:17: Expectation failed: false
✘ Test "..." failed after 1.279 seconds with 1 issue.
make: *** [test-pretty] Error 65
```

This should make CI errors easier to read