### PR TITLE
FENCE-2793: Classify network errors in RadarAPIHelper

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		BA353F092F8826B500E553A1 /* RadatSyncTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = BA353F082F8826AF00E553A1 /* RadatSyncTestHelper.m */; };
 		BA353F8D2F89A17500E553A1 /* RadarRemoteTrackingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA353F8C2F89A16A00E553A1 /* RadarRemoteTrackingOptions.swift */; };
 		BA353F8F2F8D4D0E00E553A1 /* RadarOfflineEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA353F8E2F8D4D0800E553A1 /* RadarOfflineEventManager.swift */; };
+		9DACF4A7161A400A81B6B370 /* RadarAPIHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FACB1BB65B49969B63CEA7 /* RadarAPIHelperTests.swift */; };
 		BA3540202F8EBFBD00E553A1 /* RadarOfflineEventManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */; };
 		BA3540222F90020F00E553A1 /* RadarOfflineEventManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BA3540212F90020900E553A1 /* RadarOfflineEventManager.h */; };
 		BA3540242F9033A900E553A1 /* RadarSerializedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */; };
@@ -330,6 +331,7 @@
 		BA353F082F8826AF00E553A1 /* RadatSyncTestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadatSyncTestHelper.m; sourceTree = "<group>"; };
 		BA353F8C2F89A16A00E553A1 /* RadarRemoteTrackingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarRemoteTrackingOptions.swift; sourceTree = "<group>"; };
 		BA353F8E2F8D4D0800E553A1 /* RadarOfflineEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarOfflineEventManager.swift; sourceTree = "<group>"; };
+		D1FACB1BB65B49969B63CEA7 /* RadarAPIHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelperTests.swift; sourceTree = "<group>"; };
 		BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarOfflineEventManagerTests.swift; sourceTree = "<group>"; };
 		BA3540212F90020900E553A1 /* RadarOfflineEventManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarOfflineEventManager.h; sourceTree = "<group>"; };
 		BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSerializedTests.swift; sourceTree = "<group>"; };
@@ -662,6 +664,7 @@
 		DD236C822308797B00EB88F9 /* RadarSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				D1FACB1BB65B49969B63CEA7 /* RadarAPIHelperTests.swift */,
 				BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */,
 				BA35401F2F8EBFAD00E553A1 /* RadarOfflineEventManagerTests.swift */,
 				BA353F082F8826AF00E553A1 /* RadatSyncTestHelper.m */,
@@ -1107,6 +1110,7 @@
 				DD8E2F7D24018C54002D51AB /* CLVisitMock.m in Sources */,
 				DD8E2F7A24018C37002D51AB /* CLLocationManagerMock.m in Sources */,
 				BA3540242F9033A900E553A1 /* RadarSerializedTests.swift in Sources */,
+				9DACF4A7161A400A81B6B370 /* RadarAPIHelperTests.swift in Sources */,
 				BA353F092F8826B500E553A1 /* RadatSyncTestHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -118,11 +118,14 @@
                 NSTimeInterval latency = [requestStart timeIntervalSinceNow] * -1;
 
                 if (error) {
+                    long elapsedMs = (long)(latency * 1000);
+                    NSString *host = req.URL.host ?: @"unknown";
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [[RadarLogger sharedInstance]
                             logWithLevel:RadarLogLevelError
                                     type:RadarLogTypeSDKError
-                                 message:[NSString stringWithFormat:@"Received network error | error = %@", error]];
+                                 message:[NSString stringWithFormat:@"Network error | host = %@; errorDomain = %@; errorCode = %ld; errorDescription = %@; elapsedMs = %ld",
+                                          host, error.domain, (long)error.code, error.localizedDescription, elapsedMs]];
                         completionHandler(RadarStatusErrorNetwork, nil);
                     });
 

--- a/RadarSDK/RadarAPIHelper.swift
+++ b/RadarSDK/RadarAPIHelper.swift
@@ -34,7 +34,20 @@ final class RadarApiHelper: Sendable {
             request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
         }
         
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let startTime = Date()
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let elapsedMs = Int(Date().timeIntervalSince(startTime) * 1000)
+            RadarLogger.shared.log(
+                level: .error,
+                message: RadarApiHelper.networkErrorMessage(host: urlObject.host, error: error, elapsedMs: elapsedMs),
+                type: .sdkError
+            )
+            throw error
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
@@ -66,5 +79,10 @@ final class RadarApiHelper: Sendable {
         let (data, response) = try await request(method: method, url: url, query: query, headers: headers, body: body)
 
         return (data, response)
+    }
+
+    static func networkErrorMessage(host: String?, error: Error, elapsedMs: Int) -> String {
+        let nsError = error as NSError
+        return "Network error | host = \(host ?? "unknown"); errorDomain = \(nsError.domain); errorCode = \(nsError.code); errorDescription = \(nsError.localizedDescription); elapsedMs = \(elapsedMs)"
     }
 }

--- a/RadarSDKTests/RadarAPIHelperTests.swift
+++ b/RadarSDKTests/RadarAPIHelperTests.swift
@@ -1,0 +1,64 @@
+//
+//  RadarAPIHelperTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import RadarSDK
+
+@Suite
+struct RadarAPIHelperTests {
+
+    @Test func networkErrorMessage_includesHost() {
+        let error = URLError(.timedOut)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 1234)
+        #expect(message.contains("host = api.radar.io"))
+    }
+
+    @Test func networkErrorMessage_nilHostShowsUnknown() {
+        let error = URLError(.timedOut)
+        let message = RadarApiHelper.networkErrorMessage(host: nil, error: error, elapsedMs: 0)
+        #expect(message.contains("host = unknown"))
+    }
+
+    @Test func networkErrorMessage_includesElapsedMs() {
+        let error = URLError(.timedOut)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 5678)
+        #expect(message.contains("elapsedMs = 5678"))
+    }
+
+    @Test func networkErrorMessage_timeout() {
+        let error = URLError(.timedOut)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 0)
+        #expect(message.contains("errorDomain = NSURLErrorDomain"))
+        #expect(message.contains("errorCode = \(URLError.Code.timedOut.rawValue)"))
+    }
+
+    @Test func networkErrorMessage_dnsFailure() {
+        let error = URLError(.cannotFindHost)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 0)
+        #expect(message.contains("errorCode = \(URLError.Code.cannotFindHost.rawValue)"))
+    }
+
+    @Test func networkErrorMessage_sslFailure() {
+        let error = URLError(.secureConnectionFailed)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 0)
+        #expect(message.contains("errorCode = \(URLError.Code.secureConnectionFailed.rawValue)"))
+    }
+
+    @Test func networkErrorMessage_cannotConnect() {
+        let error = URLError(.cannotConnectToHost)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 0)
+        #expect(message.contains("errorCode = \(URLError.Code.cannotConnectToHost.rawValue)"))
+    }
+
+    @Test func networkErrorMessage_includesErrorDescription() {
+        let error = URLError(.timedOut)
+        let message = RadarApiHelper.networkErrorMessage(host: "api.radar.io", error: error, elapsedMs: 0)
+        #expect(message.contains("errorDescription ="))
+        #expect(!message.contains("errorDescription = ;"))
+    }
+}


### PR DESCRIPTION
## Summary

Linear: [FENCE-2793](https://linear.app/radarlabs/issue/FENCE-2793/investigate-sdk-failure-modes)

iOS port of Android [PR #509](https://github.com/radarlabs/radar-sdk-android/pull/509). Network errors in `RadarAPIHelper` now log structured diagnostic information instead of a generic error message, to help investigate why some users can't reach `api.radar.io` (suspected DNS/ad-blocking tools like Pi-hole, NextDNS, AdGuard).

- **`RadarAPIHelper.m`**: Error handler now logs `host`, `errorDomain`, `errorCode`, `errorDescription`, and `elapsedMs`
- **`RadarAPIHelper.swift`**: Same structured logging added to the async/await path; `networkErrorMessage(host:error:elapsedMs:)` extracted as a static helper
- **`RadarAPIHelperTests.swift`**: 8 new Swift Testing unit tests covering the message format for various `NSURLError` codes (timeout, DNS, SSL, connect refused, etc.)

Example log output:
```
Network error | host = api.radar.io; errorDomain = NSURLErrorDomain; errorCode = -1001; errorDescription = The request timed out.; elapsedMs = 3421
```

## Test plan

- [ ] Non-routable host — confirm `kind = TIMEOUT` with `elapsedMs ≈ 10000`
`static let DefaultHost = "https://api.radar.io"` -> `static let DefaultHost = "https://not-host"` with your local changes
- [ ] Happy-path `track()` still succeeds with no error log