### PR TITLE
FENCE-2795: add ability to configure default network timeout

### DIFF
--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSInteger, RadarStatus) {
     RadarStatusErrorLocation,
     /// Beacon ranging error or timeout (5 seconds)
     RadarStatusErrorBluetooth,
-    /// Network error or timeout (10 seconds)
+    /// Network error or timeout (default 10 seconds; override with `RadarInitializeOptions.networkTimeoutInterval`)
     RadarStatusErrorNetwork,
     /// Bad request (missing or invalid params)
     RadarStatusErrorBadRequest,

--- a/RadarSDK/Include/RadarInitializeOptions.h
+++ b/RadarSDK/Include/RadarInitializeOptions.h
@@ -16,7 +16,9 @@
 @property (assign, nonatomic) BOOL silentPush;
 @property (assign, nonatomic) BOOL trackVerifiedAutoFailover;
 
-/// Request and resource timeout in seconds for standard API calls. Default is 10. Invalid values (non-finite or ≤ 0) fall back to the default; values are clamped to the range 1…300.
+/// Request and resource timeout in seconds for standard API calls. Default 10 seconds.
+/// Invalid values (non-finite or ≤ 0) fall back to the default; values are
+/// clamped to the range 1…300.
 @property (assign, nonatomic) NSTimeInterval networkTimeoutInterval;
 
 - (NSDictionary *_Nonnull)dictionaryValue;

--- a/RadarSDK/Include/RadarInitializeOptions.h
+++ b/RadarSDK/Include/RadarInitializeOptions.h
@@ -16,6 +16,9 @@
 @property (assign, nonatomic) BOOL silentPush;
 @property (assign, nonatomic) BOOL trackVerifiedAutoFailover;
 
+/// Request and resource timeout in seconds for standard API calls. Default is 10. Invalid values (non-finite or ≤ 0) fall back to the default; values are clamped to the range 1…300.
+@property (assign, nonatomic) NSTimeInterval networkTimeoutInterval;
+
 - (NSDictionary *_Nonnull)dictionaryValue;
 - (instancetype _Nonnull)initWithDict:(NSDictionary *_Nullable)dict;
 

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -15,21 +15,24 @@
 
 static NSTimeInterval RadarAPIHelperStandardNetworkTimeoutInterval(void) {
     RadarInitializeOptions *opts = [RadarSettings initializeOptions];
-    NSTimeInterval t = opts ? opts.networkTimeoutInterval : 10;
-    if (t <= 0 || isnan(t) || isinf(t)) {
-        t = 10;
+    NSTimeInterval interval = opts ? opts.networkTimeoutInterval : 10;
+
+    // Validate
+    if (interval <= 0 || isnan(interval) || isinf(interval)) {
+        interval = 10;
     }
-    if (t < 1) {
-        t = 1;
-    } else if (t > 300) {
-        t = 300;
+
+    // Clamp to reasonable range
+    if (interval < 1) {
+        interval = 1;
+    } else if (interval > 300) {
+        interval = 300;
     }
-    return t;
+
+    return interval;
 }
 
-static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterval standard) {
-    return MAX(25, standard * 2.5);
-}
+static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterval standard) { return standard * 2.5; }
 
 @interface RadarAPIHelper ()
 
@@ -81,17 +84,16 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
         NSMutableURLRequest *req = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
         req.HTTPMethod = method;
 
-        NSString * paramJsonStr = [RadarUtils dictionaryToJson:params];
-        NSString * headersJsonStr = [RadarUtils dictionaryToJson:headers];
+        NSString *paramJsonStr = [RadarUtils dictionaryToJson:params];
+        NSString *headersJsonStr = [RadarUtils dictionaryToJson:headers];
 
         if (logPayload) {
             [[RadarLogger sharedInstance]
                 logWithLevel:RadarLogLevelDebug
                      message:[NSString stringWithFormat:@"📍 Radar API request | method = %@; url = %@; headers = %@; params = %@", method, url, headersJsonStr, paramJsonStr]];
         } else {
-            [[RadarLogger sharedInstance]
-                logWithLevel:RadarLogLevelDebug
-                     message:[NSString stringWithFormat:@"📍 Radar API request | method = %@; url = %@; headers = %@", method, url, headersJsonStr]];
+            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                               message:[NSString stringWithFormat:@"📍 Radar API request | method = %@; url = %@; headers = %@", method, url, headersJsonStr]];
         }
 
         @try {
@@ -142,10 +144,9 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
 
                 if (error) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        [[RadarLogger sharedInstance]
-                            logWithLevel:RadarLogLevelError
-                                    type:RadarLogTypeSDKError
-                                 message:[NSString stringWithFormat:@"Received network error | error = %@", error]];
+                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelError
+                                                              type:RadarLogTypeSDKError
+                                                           message:[NSString stringWithFormat:@"Received network error | error = %@", error]];
                         completionHandler(RadarStatusErrorNetwork, nil);
                     });
 
@@ -196,7 +197,7 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                     }
 
                     res = (NSDictionary *)resObj;
-                    NSString * resJsonStr = [RadarUtils dictionaryToJson:res];
+                    NSString *resJsonStr = [RadarUtils dictionaryToJson:res];
 
                     if (params && [params objectForKey:@"replays"]) {
                         NSArray *replays = [params objectForKey:@"replays"];
@@ -207,8 +208,8 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                     } else {
                         [[RadarLogger sharedInstance]
                             logWithLevel:RadarLogLevelDebug
-                                 message:[NSString stringWithFormat:@"📍 Radar API response | method = %@; url = %@; statusCode = %ld; latency = %f; res = %@",
-                                                                    method, url, (long)statusCode, latency, resJsonStr]];
+                                 message:[NSString stringWithFormat:@"📍 Radar API response | method = %@; url = %@; statusCode = %ld; latency = %f; res = %@", method, url,
+                                                                    (long)statusCode, latency, resJsonStr]];
                     }
                 }
 
@@ -224,9 +225,8 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
 
             void (^dataTaskRetryHandler)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
                 if (error && [error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorNetworkConnectionLost) {
-                    [[RadarLogger sharedInstance]
-                        logWithLevel:RadarLogLevelDebug
-                             message:[NSString stringWithFormat:@"📍 Radar API retrying after lost connection | url = %@", url]];
+                    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                                                       message:[NSString stringWithFormat:@"📍 Radar API retrying after lost connection | url = %@", url]];
                     NSURLSessionDataTask *retryTask = [session dataTaskWithRequest:req completionHandler:dataTaskCompletionHandler];
                     [retryTask resume];
                 } else {

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -11,6 +11,26 @@
 #import "RadarSettings.h"
 #import "RadarUtils.h"
 
+#import <math.h>
+
+static NSTimeInterval RadarAPIHelperStandardNetworkTimeoutInterval(void) {
+    RadarInitializeOptions *opts = [RadarSettings initializeOptions];
+    NSTimeInterval t = opts ? opts.networkTimeoutInterval : 10;
+    if (t <= 0 || isnan(t) || isinf(t)) {
+        t = 10;
+    }
+    if (t < 1) {
+        t = 1;
+    } else if (t > 300) {
+        t = 300;
+    }
+    return t;
+}
+
+static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterval standard) {
+    return MAX(25, standard * 2.5);
+}
+
 @interface RadarAPIHelper ()
 
 @property (strong, nonatomic) dispatch_queue_t queue;
@@ -29,14 +49,17 @@
         _queue = dispatch_queue_create("io.radar.api", DISPATCH_QUEUE_SERIAL);
         _semaphore = dispatch_semaphore_create(1);
 
+        NSTimeInterval standardTimeout = RadarAPIHelperStandardNetworkTimeoutInterval();
+        NSTimeInterval extendedTimeout = RadarAPIHelperExtendedNetworkTimeoutInterval(standardTimeout);
+
         NSURLSessionConfiguration *standardConfig = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-        standardConfig.timeoutIntervalForRequest = 10;
-        standardConfig.timeoutIntervalForResource = 10;
+        standardConfig.timeoutIntervalForRequest = standardTimeout;
+        standardConfig.timeoutIntervalForResource = standardTimeout;
         _standardSession = [NSURLSession sessionWithConfiguration:standardConfig];
 
         NSURLSessionConfiguration *extendedConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
-        extendedConfig.timeoutIntervalForRequest = 25;
-        extendedConfig.timeoutIntervalForResource = 25;
+        extendedConfig.timeoutIntervalForRequest = extendedTimeout;
+        extendedConfig.timeoutIntervalForResource = extendedTimeout;
         _extendedTimeoutSession = [NSURLSession sessionWithConfiguration:extendedConfig];
     }
     return self;

--- a/RadarSDK/RadarInitializeOptions.m
+++ b/RadarSDK/RadarInitializeOptions.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <math.h>
 #import "RadarInitializeOptions.h"
 
 
@@ -19,6 +20,7 @@
         _autoHandleNotificationDeepLinks = NO;
         _silentPush = NO;
         _trackVerifiedAutoFailover = NO;
+        _networkTimeoutInterval = 10;
     }
     return self;
 }
@@ -29,6 +31,7 @@
     dict[@"autoHandleNotificationDeepLinks"] = @(_autoHandleNotificationDeepLinks);
     dict[@"silentPush"] = @(_silentPush);
     dict[@"trackVerifiedAutoFailover"] = @(_trackVerifiedAutoFailover);
+    dict[@"networkTimeoutInterval"] = @(_networkTimeoutInterval);
     return dict;
 }
 
@@ -39,6 +42,11 @@
         _autoHandleNotificationDeepLinks = [dict[@"autoHandleNotificationDeepLinks"] boolValue];
         _silentPush = [dict[@"silentPush"] boolValue];
         _trackVerifiedAutoFailover = [dict[@"trackVerifiedAutoFailover"] boolValue];
+        NSNumber *networkTimeout = dict[@"networkTimeoutInterval"];
+        _networkTimeoutInterval = networkTimeout ? [networkTimeout doubleValue] : 10;
+        if (_networkTimeoutInterval <= 0 || isnan(_networkTimeoutInterval) || isinf(_networkTimeoutInterval)) {
+            _networkTimeoutInterval = 10;
+        }
     }
     return self;
 }

--- a/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
+++ b/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
@@ -180,7 +180,8 @@ final class RadarVerifiedHostOverrideTests: XCTestCase {
         options.networkTimeoutInterval = 45
 
         let dict = options.dictionaryValue()
-        XCTAssertEqual((dict["networkTimeoutInterval"] as? NSNumber)?.doubleValue, 45, accuracy: 0.001)
+        let value = dict["networkTimeoutInterval"] as? NSNumber
+        XCTAssertEqual(value?.doubleValue ?? 0, 45, accuracy: 0.001)
 
         let restored = RadarInitializeOptions(dict: dict)
         XCTAssertEqual(restored.networkTimeoutInterval, 45, accuracy: 0.001)

--- a/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
+++ b/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
@@ -170,6 +170,22 @@ final class RadarVerifiedHostOverrideTests: XCTestCase {
         XCTAssertTrue(restored.trackVerifiedAutoFailover)
     }
 
+    func test_initializeOptions_networkTimeoutInterval_defaultsToTen() {
+        let options = RadarInitializeOptions()
+        XCTAssertEqual(options.networkTimeoutInterval, 10, accuracy: 0.001)
+    }
+
+    func test_initializeOptions_networkTimeoutInterval_roundtripsThroughDictionary() {
+        let options = RadarInitializeOptions()
+        options.networkTimeoutInterval = 45
+
+        let dict = options.dictionaryValue()
+        XCTAssertEqual((dict["networkTimeoutInterval"] as? NSNumber)?.doubleValue, 45, accuracy: 0.001)
+
+        let restored = RadarInitializeOptions(dict: dict)
+        XCTAssertEqual(restored.networkTimeoutInterval, 45, accuracy: 0.001)
+    }
+
     // MARK: - Secondary host constant
 
     func test_defaultVerifiedHostSecondary_isExpected() {


### PR DESCRIPTION
- Adds a new initialization option, `networkTimeoutInterval`, that allows consumers to override the default 10 second timeout.
- Sets the extended timeout to 2.5x the network timeout instead of hardcoding 25 seconds.