### PR TITLE
Add new swift `RadarLocationManager`, stub methods, use behind FF

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		0107AB17262201DE008AB52F /* RadarDelegateHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4C104925D87E3E009C2E36 /* RadarDelegateHolder.m */; };
 		0107AB1A262201E2008AB52F /* RadarLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DD236D67230A0D6700EB88F9 /* RadarLogger.m */; };
 		0107AB1D262201E5008AB52F /* RadarLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DD236CF823088F8400EB88F9 /* RadarLocationManager.m */; };
+		F6A6A1013000000000ABC001 /* RadarLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A6A1003000000000ABC001 /* RadarLocationManager.swift */; };
 		0107AB20262201E9008AB52F /* RadarPermissionsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DD633EC6237C5B9C0026C91A /* RadarPermissionsHelper.m */; };
 		0107AB26262201F0008AB52F /* RadarState.m in Sources */ = {isa = PBXBuildFile; fileRef = DD236D0F2309B3FE00EB88F9 /* RadarState.m */; };
 		0107AB29262201F4008AB52F /* RadarTrackingOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DD236CEB2308821600EB88F9 /* RadarTrackingOptions.m */; };
@@ -214,6 +215,7 @@
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
 		F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */; };
 		F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */; };
+		F6A6A1113000000000ABC001 /* RadarLocationManagerMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A6A1103000000000ABC001 /* RadarLocationManagerMigrationTests.swift */; };
 		F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */; };
 		F6B7E3492F745E49006A5A24 /* RadarNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3482F745E44006A5A24 /* RadarNotification.swift */; };
 		F6B7E3BD2F758A13006A5A24 /* MockRadarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */; };
@@ -372,6 +374,8 @@
 		DD236CEB2308821600EB88F9 /* RadarTrackingOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarTrackingOptions.m; sourceTree = "<group>"; };
 		DD236CF723088F8400EB88F9 /* RadarLocationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarLocationManager.h; sourceTree = "<group>"; };
 		DD236CF823088F8400EB88F9 /* RadarLocationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarLocationManager.m; sourceTree = "<group>"; };
+		F6A6A0FF3000000000ABC001 /* RadarLocationManager+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RadarLocationManager+Internal.h"; sourceTree = "<group>"; };
+		F6A6A1003000000000ABC001 /* RadarLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManager.swift; sourceTree = "<group>"; };
 		DD236CFB230895D400EB88F9 /* RadarSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarSettings.h; sourceTree = "<group>"; };
 		DD236D0323099B8400EB88F9 /* RadarUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarUtils.h; sourceTree = "<group>"; };
 		DD236D0423099B8400EB88F9 /* RadarUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarUtils.m; sourceTree = "<group>"; };
@@ -441,6 +445,7 @@
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
 		F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSettingsTest.swift; sourceTree = "<group>"; };
 		F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarVerifiedHostOverrideTests.swift; sourceTree = "<group>"; };
+		F6A6A1103000000000ABC001 /* RadarLocationManagerMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerMigrationTests.swift; sourceTree = "<group>"; };
 		F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationHelperTest.swift; sourceTree = "<group>"; };
 		F6B7E3482F745E44006A5A24 /* RadarNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotification.swift; sourceTree = "<group>"; };
 		F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRadarState.swift; sourceTree = "<group>"; };
@@ -617,6 +622,8 @@
 				E6B93B732C90E5B8003CB858 /* RadarInitializeOptions.m */,
 				DD236CF723088F8400EB88F9 /* RadarLocationManager.h */,
 				DD236CF823088F8400EB88F9 /* RadarLocationManager.m */,
+				F6A6A0FF3000000000ABC001 /* RadarLocationManager+Internal.h */,
+				F6A6A1003000000000ABC001 /* RadarLocationManager.swift */,
 				96A5A11527ADA02E007B960B /* RadarLog.h */,
 				96A5A11427ADA02E007B960B /* RadarLog.m */,
 				96A5A11627ADA02E007B960B /* RadarLogBuffer.h */,
@@ -675,6 +682,7 @@
 				BA46C16B2F4E0CEC00031891 /* RadarTripLegTest.m */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
+				F6A6A1103000000000ABC001 /* RadarLocationManagerMigrationTests.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
 				F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */,
 				96B465BB27D6732500D7119B /* CLLocation+RadarTests.m */,
@@ -1054,6 +1062,7 @@
 				F6EFF1952F71972000E48CE1 /* RadarSdkConfiguration.swift in Sources */,
 				828D1A472E29599500663787 /* RadarTripOrder.m in Sources */,
 				0107AB1D262201E5008AB52F /* RadarLocationManager.m in Sources */,
+				F6A6A1013000000000ABC001 /* RadarLocationManager.swift in Sources */,
 				BA8647AB2F6C4CD800F1A199 /* RadarFileStorage.swift in Sources */,
 				0107AAB02622016B008AB52F /* RadarPlace.m in Sources */,
 				BA353F8D2F89A17500E553A1 /* RadarRemoteTrackingOptions.swift in Sources */,
@@ -1100,6 +1109,7 @@
 			files = (
 				F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */,
 				F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */,
+				F6A6A1113000000000ABC001 /* RadarLocationManagerMigrationTests.swift in Sources */,
 				DD8E2F7424018C17002D51AB /* RadarPermissionsHelperMock.m in Sources */,
 				BA46C16C2F4E0CFA00031891 /* RadarTripLegTest.m in Sources */,
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,

--- a/RadarSDK/RadarLocationManager+Internal.h
+++ b/RadarSDK/RadarLocationManager+Internal.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit;
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading;
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager;
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
 
 @end

--- a/RadarSDK/RadarLocationManager+Internal.h
+++ b/RadarSDK/RadarLocationManager+Internal.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol RadarLocationManagerBackend <NSObject>
+@protocol RadarLocationManagerRouting <NSObject>
 
 @property (nullable, nonatomic, weak) RadarLocationManager *owner;
 

--- a/RadarSDK/RadarLocationManager+Internal.h
+++ b/RadarSDK/RadarLocationManager+Internal.h
@@ -1,0 +1,46 @@
+//
+//  RadarLocationManager+Internal.h
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+#import "RadarLocationManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RadarLocationManagerBackend <NSObject>
+
+@property (nullable, nonatomic, weak) RadarLocationManager *owner;
+
+- (void)didUpdateInjectedDependencies;
+
+- (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
+- (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy
+                     completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
+- (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions;
+- (void)stopTracking;
+- (void)replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences;
+- (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons;
+- (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids;
+- (void)updateTracking;
+- (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta;
+- (void)updateTrackingFromInitialize;
+- (void)performIndoorScanIfConfigured:(CLLocation *)location
+                              beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                    completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler;
+- (void)restartPreviousTrackingOptions;
+- (void)callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location;
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
+- (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region;
+- (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region;
+- (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region;
+- (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit;
+- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
+- (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading;
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -72,8 +72,8 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
  Callbacks for sending events.
  */
 @property (nonnull, strong, nonatomic) NSMutableArray<RadarLocationCompletionHandler> *completionHandlers;
-@property (nonnull, strong, nonatomic) id<RadarLocationManagerBackend> legacyBackend;
-@property (nonnull, strong, nonatomic) id<RadarLocationManagerBackend> swiftBackend;
+@property (nonnull, strong, nonatomic) id<RadarLocationManagerRouting> legacyImplementation;
+@property (nonnull, strong, nonatomic) id<RadarLocationManagerRouting> implementation;
 
 - (void)legacy_callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location;
 - (void)legacy_getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
@@ -102,13 +102,13 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 
 @end
 
-@interface RadarLocationManagerLegacyBackend : NSObject <RadarLocationManagerBackend>
+@interface RadarLocationManagerLegacyAdapter : NSObject <RadarLocationManagerRouting>
 
 @property (nullable, nonatomic, weak) RadarLocationManager *owner;
 
 @end
 
-@implementation RadarLocationManagerLegacyBackend
+@implementation RadarLocationManagerLegacyAdapter
 
 - (void)didUpdateInjectedDependencies {
 }
@@ -202,29 +202,29 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 
 @end
 
-@interface RadarLocationManagerSwiftBackendAdapter : NSObject <RadarLocationManagerBackend>
+@interface RadarLocationManagerAdapter : NSObject <RadarLocationManagerRouting>
 
 @property (nullable, nonatomic, weak) RadarLocationManager *owner;
-@property (nonnull, nonatomic, strong) RadarLocationManagerSwiftBackend *backend;
+@property (nonnull, nonatomic, strong) RadarLocationManagerImplementation *implementation;
 
 @end
 
-@implementation RadarLocationManagerSwiftBackendAdapter
+@implementation RadarLocationManagerAdapter
 
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _backend = [RadarLocationManagerSwiftBackend new];
+        _implementation = [RadarLocationManagerImplementation new];
     }
     return self;
 }
 
 - (void)didUpdateInjectedDependencies {
-    [self.backend didUpdateInjectedDependencies];
+    [self.implementation didUpdateInjectedDependencies];
 }
 
 - (void)failFastForSelector:(SEL)selector {
-    [self.backend failFastWithMethod:NSStringFromSelector(selector)];
+    [self.implementation failFastWithMethod:NSStringFromSelector(selector)];
 }
 
 - (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler {
@@ -323,7 +323,7 @@ static NSString *const kBubbleGeofenceIdentifierPrefix = @"radar_bubble_";
 static NSString *const kSyncGeofenceIdentifierPrefix = @"radar_geofence_";
 static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
 static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
-static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplementedCapabilities = 0;
+static const RadarLocationManagerCapability kRadarLocationManagerImplementedCapabilities = 0;
 
 + (instancetype)sharedInstance {
     static dispatch_once_t once;
@@ -346,10 +346,10 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     self = [super init];
     if (self) {
         _completionHandlers = [NSMutableArray new];
-        _legacyBackend = [RadarLocationManagerLegacyBackend new];
-        _legacyBackend.owner = self;
-        _swiftBackend = [RadarLocationManagerSwiftBackendAdapter new];
-        _swiftBackend.owner = self;
+        _legacyImplementation = [RadarLocationManagerLegacyAdapter new];
+        _legacyImplementation.owner = self;
+        _implementation = [RadarLocationManagerAdapter new];
+        _implementation.owner = self;
 
         _locationManager = [CLLocationManager new];
         _locationManager.delegate = self;
@@ -368,19 +368,19 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     return self;
 }
 
-- (BOOL)useSwiftBackendForCapability:(RadarLocationManagerCapability)capability {
+- (BOOL)usesImplementationForCapability:(RadarLocationManagerCapability)capability {
     return RadarSettings.locationManagerSwiftMigrationEnabled &&
-           (kRadarLocationManagerSwiftImplementedCapabilities & capability) == capability;
+           (kRadarLocationManagerImplementedCapabilities & capability) == capability;
 }
 
-- (id<RadarLocationManagerBackend>)backendForCapability:(RadarLocationManagerCapability)capability {
-    return [self useSwiftBackendForCapability:capability] ? self.swiftBackend : self.legacyBackend;
+- (id<RadarLocationManagerRouting>)implementationForCapability:(RadarLocationManagerCapability)capability {
+    return [self usesImplementationForCapability:capability] ? self.implementation : self.legacyImplementation;
 }
 
 - (void)didUpdateInjectedDependencies {
     self.locationManager.delegate = self;
-    [self.legacyBackend didUpdateInjectedDependencies];
-    [self.swiftBackend didUpdateInjectedDependencies];
+    [self.legacyImplementation didUpdateInjectedDependencies];
+    [self.implementation didUpdateInjectedDependencies];
 }
 
 - (void)setLocationManager:(CLLocationManager *)locationManager {
@@ -404,7 +404,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
-    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] callCompletionHandlersWithStatus:status location:location];
+    [[self implementationForCapability:RadarLocationManagerCapabilityOneShotLocation] callCompletionHandlersWithStatus:status location:location];
 }
 
 - (void)legacy_callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
@@ -418,7 +418,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                  message:[NSString stringWithFormat:@"Calling completion handlers | self.completionHandlers.count = %lu", (unsigned long)self.completionHandlers.count]];
 
         for (RadarLocationCompletionHandler completionHandler in self.completionHandlers) {
-            [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeoutWithCompletionHandler:) object:completionHandler];
+            [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(legacy_timeoutWithCompletionHandler:) object:completionHandler];
 
             completionHandler(status, location, [RadarState stopped]);
         }
@@ -427,7 +427,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 }
 
-- (void)addCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
+- (void)legacy_addCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
     if (!completionHandler) {
         return;
     }
@@ -436,28 +436,28 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         RadarLocationCompletionHandler completionHandlerCopy = [completionHandler copy];
         [self.completionHandlers addObject:completionHandlerCopy];
 
-        [self performSelector:@selector(timeoutWithCompletionHandler:) withObject:completionHandlerCopy afterDelay:20];
+        [self performSelector:@selector(legacy_timeoutWithCompletionHandler:) withObject:completionHandlerCopy afterDelay:20];
     }
 }
 
-- (void)cancelTimeouts {
+- (void)legacy_cancelTimeouts {
     @synchronized(self) {
         for (RadarLocationCompletionHandler completionHandler in self.completionHandlers) {
-            [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeoutWithCompletionHandler:) object:completionHandler];
+            [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(legacy_timeoutWithCompletionHandler:) object:completionHandler];
         }
     }
 }
 
-- (void)timeoutWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
+- (void)legacy_timeoutWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
     @synchronized(self) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Location timeout"];
 
-        [self callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
+        [self legacy_callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
     }
 }
 
 - (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
-    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithCompletionHandler:completionHandler];
+    [[self implementationForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithCompletionHandler:completionHandler];
 }
 
 - (void)legacy_getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
@@ -465,7 +465,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy completionHandler:(RadarLocationCompletionHandler)completionHandler {
-    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithDesiredAccuracy:desiredAccuracy completionHandler:completionHandler];
+    [[self implementationForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithDesiredAccuracy:desiredAccuracy completionHandler:completionHandler];
 }
 
 - (void)legacy_getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy completionHandler:(RadarLocationCompletionHandler)completionHandler {
@@ -479,7 +479,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         return;
     }
 
-    [self addCompletionHandler:completionHandler];
+    [self legacy_addCompletionHandler:completionHandler];
 
     CLLocationAccuracy accuracy;
     switch (desiredAccuracy) {
@@ -497,11 +497,11 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 
     self.locationManager.desiredAccuracy = accuracy;
-    [self requestLocation];
+    [self legacy_requestLocation];
 }
 
 - (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] startTrackingWithOptions:trackingOptions];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] startTrackingWithOptions:trackingOptions];
 }
 
 - (void)legacy_startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
@@ -513,11 +513,11 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 
     [RadarSettings setTracking:YES];
     [RadarSettings setTrackingOptions:trackingOptions];
-    [self updateTracking];
+    [self legacy_updateTracking];
 }
 
 - (void)stopTracking {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] stopTracking];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] stopTracking];
 }
 
 - (void)legacy_stopTracking {
@@ -549,14 +549,14 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     trackingOptions.stopTrackingAfter = nil;
     [RadarSettings setTrackingOptions:trackingOptions];
 
-    [self updateTracking];
+    [self legacy_updateTracking];
 }
 
-- (void)startUpdates:(int)interval blueBar:(BOOL)blueBar {
+- (void)legacy_startUpdates:(int)interval blueBar:(BOOL)blueBar {
     if (!self.started || interval != self.startedInterval) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:[NSString stringWithFormat:@"Starting timer | interval = %d", interval]];
 
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(shutDown) object:nil];
+        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(legacy_shutDown) object:nil];
 
         if (self.timer) {
             [self.timer invalidate];
@@ -567,7 +567,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                                        block:^(NSTimer *_Nonnull timer) {
                                                            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Timer fired"];
 
-                                                           [self requestLocation];
+                                                           [self legacy_requestLocation];
                                                        }];
 
         [self.lowPowerLocationManager startUpdatingLocation];
@@ -584,7 +584,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 }
 
-- (void)stopUpdates {
+- (void)legacy_stopUpdates {
     if (!self.timer) {
         return;
     }
@@ -603,44 +603,44 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Scheduling shutdown"];
 
-        [self performSelector:@selector(shutDown) withObject:nil afterDelay:delay];
+        [self performSelector:@selector(legacy_shutDown) withObject:nil afterDelay:delay];
     }
 }
 
-- (void)shutDown {
+- (void)legacy_shutDown {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Shutting down"];
 
     [self.locationManager stopUpdatingLocation];
     [self.lowPowerLocationManager stopUpdatingLocation];
 }
 
-- (void)requestLocation {
+- (void)legacy_requestLocation {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Requesting location"];
 
     [self.locationManager requestLocation];
 }
 
 - (void)updateTracking {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTracking];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTracking];
 }
 
 - (void)legacy_updateTracking {
-    [self updateTracking:nil fromInitialize:NO];
+    [self legacy_updateTracking:nil fromInitialize:NO];
 }
 
 - (void)updateTrackingFromInitialize {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromInitialize];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromInitialize];
 }
 
 - (void)legacy_updateTrackingFromInitialize {
-    [self updateTracking:nil fromInitialize:YES];
+    [self legacy_updateTracking:nil fromInitialize:YES];
 }
 
-- (void)updateTracking:(CLLocation *)location {
-    [self updateTracking:location fromInitialize:NO];
+- (void)legacy_updateTracking:(CLLocation *)location {
+    [self legacy_updateTracking:location fromInitialize:NO];
 }
 
-- (void)updateTracking:(CLLocation *)location fromInitialize:(BOOL)fromInitialize {
+- (void)legacy_updateTracking:(CLLocation *)location fromInitialize:(BOOL)fromInitialize {
     dispatch_async(dispatch_get_main_queue(), ^{
         BOOL tracking = [RadarSettings tracking];
         RadarTrackingOptions *options = [Radar getTrackingOptions];
@@ -772,33 +772,33 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
             BOOL stopped = [RadarState stopped];
             if (stopped) {
                 if (options.desiredStoppedUpdateInterval == 0) {
-                    [self stopUpdates];
+                    [self legacy_stopUpdates];
                 } else if (startUpdates) {
-                    [self startUpdates:options.desiredStoppedUpdateInterval blueBar:options.showBlueBar];
+                    [self legacy_startUpdates:options.desiredStoppedUpdateInterval blueBar:options.showBlueBar];
                 }
                 if (options.useStoppedGeofence) {
                     if (location) {
-                        [self replaceBubbleGeofence:location radius:options.stoppedGeofenceRadius];
+                        [self legacy_replaceBubbleGeofence:location radius:options.stoppedGeofenceRadius];
                     }
                 } else {
-                    [self removeBubbleGeofence];
+                    [self legacy_removeBubbleGeofence];
                 }
             } else {
                 if (options.desiredMovingUpdateInterval == 0) {
-                    [self stopUpdates];
+                    [self legacy_stopUpdates];
                 } else if (startUpdates) {
-                    [self startUpdates:options.desiredMovingUpdateInterval blueBar:options.showBlueBar];
+                    [self legacy_startUpdates:options.desiredMovingUpdateInterval blueBar:options.showBlueBar];
                 }
                 if (options.useMovingGeofence) {
                     if (location) {
-                        [self replaceBubbleGeofence:location radius:options.movingGeofenceRadius];
+                        [self legacy_replaceBubbleGeofence:location radius:options.movingGeofenceRadius];
                     }
                 } else {
-                    [self removeBubbleGeofence];
+                    [self legacy_removeBubbleGeofence];
                 }
             }
             if (!options.syncGeofences) {
-                [self removeSyncedGeofences];
+                [self legacy_removeSyncedGeofences];
             }
             if (options.useVisits) {
                 [self.locationManager startMonitoringVisits];
@@ -811,11 +811,11 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                 [self.locationManager stopMonitoringSignificantLocationChanges];
             }
             if (!options.beacons) {
-                [self removeSyncedBeacons];
+                [self legacy_removeSyncedBeacons];
             }
         } else {
-            [self stopUpdates];
-            [self removeAllRegions];
+            [self legacy_stopUpdates];
+            [self legacy_removeAllRegions];
 
             // If updateTracking() was called from the RadarLocationManager
             // initializer, don't tell the CLLocationManager to stop, because
@@ -833,7 +833,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromMeta:meta];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromMeta:meta];
 }
 
 - (void)legacy_updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
@@ -848,12 +848,12 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                                message:[NSString stringWithFormat:@"Removed remote tracking options | trackingOptions = %@", Radar.getTrackingOptions]];
         }
     }
-    [self updateTrackingFromInitialize];
+    [self legacy_updateTrackingFromInitialize];
 
 }
 
 - (void)restartPreviousTrackingOptions {
-    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] restartPreviousTrackingOptions];
+    [[self implementationForCapability:RadarLocationManagerCapabilityTrackingLifecycle] restartPreviousTrackingOptions];
 }
 
 - (void)legacy_restartPreviousTrackingOptions {
@@ -869,8 +869,8 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     [RadarSettings setPreviousTrackingOptions:nil];
 }
 
-- (void)replaceBubbleGeofence:(CLLocation *)location radius:(int)radius {
-    [self removeBubbleGeofence];
+- (void)legacy_replaceBubbleGeofence:(CLLocation *)location radius:(int)radius {
+    [self legacy_removeBubbleGeofence];
 
     BOOL tracking = [RadarSettings tracking];
     if (!tracking) {
@@ -885,7 +885,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                                                           location.coordinate.latitude, location.coordinate.longitude, radius, identifier]];
 }
 
-- (void)removeBubbleGeofence {
+- (void)legacy_removeBubbleGeofence {
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kBubbleGeofenceIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -895,7 +895,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
-    [[self backendForCapability:RadarLocationManagerCapabilitySyncedGeofences] replaceSyncedGeofences:geofences];
+    [[self implementationForCapability:RadarLocationManagerCapabilitySyncedGeofences] replaceSyncedGeofences:geofences];
 }
 
 - (void)legacy_replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
@@ -914,7 +914,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         return;
     }
     
-    [self removeSyncedGeofences];
+    [self legacy_removeSyncedGeofences];
 
     RadarTrackingOptions *options = [Radar getTrackingOptions];
     NSUInteger numGeofences = MIN(geofences.count, options.beacons ? 9 : 19);
@@ -982,7 +982,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     [RadarNotificationHelper updateClientSideCampaignsWithPrefix:kSyncGeofenceIdentifierPrefix notificationRequests:requests];
 }
 
-- (void)removeSyncedGeofences {
+- (void)legacy_removeSyncedGeofences {
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kSyncGeofenceIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -992,7 +992,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Removed synced geofences"];
 }
 
-- (NSArray<NSString *> *)matchBeaconIds:(NSArray<RadarBeacon *> *)rangedBeacons syncedBeacons:(NSArray<RadarBeacon *> *)syncedBeacons {
+- (NSArray<NSString *> *)legacy_matchBeaconIds:(NSArray<RadarBeacon *> *)rangedBeacons syncedBeacons:(NSArray<RadarBeacon *> *)syncedBeacons {
     NSMutableDictionary<NSString *, NSString *> *syncedMap = [NSMutableDictionary dictionary];
     for (RadarBeacon *sb in syncedBeacons) {
         NSString *key = [NSString stringWithFormat:@"%@|%@|%@", [sb.uuid lowercaseString] ?: @"", sb.major ?: @"", sb.minor ?: @""];
@@ -1013,7 +1013,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
-    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeacons:beacons];
+    [[self implementationForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeacons:beacons];
 }
 
 - (void)legacy_replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
@@ -1021,7 +1021,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         return;
     }
     
-    [self removeSyncedBeacons];
+    [self legacy_removeSyncedBeacons];
 
     BOOL tracking = [RadarSettings tracking];
     RadarTrackingOptions *options = [Radar getTrackingOptions];
@@ -1058,7 +1058,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
-    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeaconUUIDs:uuids];
+    [[self implementationForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeaconUUIDs:uuids];
 }
 
 - (void)legacy_replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
@@ -1066,7 +1066,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         return;
     }
     
-    [self removeSyncedBeacons];
+    [self legacy_removeSyncedBeacons];
 
     BOOL tracking = [RadarSettings tracking];
     RadarTrackingOptions *options = [Radar getTrackingOptions];
@@ -1093,7 +1093,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 }
 
-- (void)removeSyncedBeacons {
+- (void)legacy_removeSyncedBeacons {
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
@@ -1107,7 +1107,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 }
 
-- (void)removeAllRegions {
+- (void)legacy_removeAllRegions {
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -1117,21 +1117,21 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 
 #pragma mark - handlers
 
-- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
-    [self handleLocation:location source:source beacons:nil];
+- (void)legacy_handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
+    [self legacy_handleLocation:location source:source beacons:nil];
 }
 
-- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source beacons:(NSArray<RadarBeacon *> *)beacons {
+- (void)legacy_handleLocation:(CLLocation *)location source:(RadarLocationSource)source beacons:(NSArray<RadarBeacon *> *)beacons {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                        message:[NSString stringWithFormat:@"Handling location | source = %@; location = %@", [Radar stringForLocationSource:source], location]];
 
-    [self cancelTimeouts];
+    [self legacy_cancelTimeouts];
 
     if (!location.isValid) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                            message:[NSString stringWithFormat:@"Invalid location | source = %@; location = %@", [Radar stringForLocationSource:source], location]];
 
-        [self callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
+        [self legacy_callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
 
         return;
     }
@@ -1146,7 +1146,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                            message:[NSString stringWithFormat:@"Skipping location: inaccurate | accuracy = %f", location.horizontalAccuracy]];
 
-        [self updateTracking:location];
+        [self legacy_updateTracking:location];
 
         return;
     }
@@ -1211,10 +1211,10 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     [[RadarDelegateHolder sharedInstance] didUpdateClientLocation:location stopped:stopped source:source];
 
     if (source != RadarLocationSourceManualLocation) {
-        [self updateTracking:location];
+        [self legacy_updateTracking:location];
     }
 
-    [self callCompletionHandlersWithStatus:RadarStatusSuccess location:location];
+    [self legacy_callCompletionHandlersWithStatus:RadarStatusSuccess location:location];
     
     if ([RadarSettings sdkConfiguration].useSyncRegion) {
         if (![RadarSyncManager hasSyncedRegion]) {
@@ -1303,12 +1303,12 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         
         if (geofenceOrPlaceChanged) {
             [RadarState updateLastSentAt];
-            [self sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:YES];
+            [self legacy_sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:YES];
             return;
         }
         
         if (options.beacons) {
-            [self sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:NO];
+            [self legacy_sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:NO];
             return;
         }
         
@@ -1323,13 +1323,13 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         return;
     }
 
-    [self sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:YES];
+    [self legacy_sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:YES];
 }
 
 - (void)performIndoorScanIfConfigured:(CLLocation *)location
                                beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
                      completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler {
-    [[self backendForCapability:RadarLocationManagerCapabilitySendPipeline] performIndoorScanIfConfigured:location
+    [[self implementationForCapability:RadarLocationManagerCapabilitySendPipeline] performIndoorScanIfConfigured:location
                                                                                                   beacons:beacons
                                                                                         completionHandler:completionHandler];
 }
@@ -1361,7 +1361,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 }
 
-- (void)sendLocation:(CLLocation *)location stopped:(BOOL)stopped source:(RadarLocationSource)source replayed:(BOOL)replayed beacons:(NSArray<RadarBeacon *> *_Nullable)beacons forceTrack:(BOOL)forceTrack {
+- (void)legacy_sendLocation:(CLLocation *)location stopped:(BOOL)stopped source:(RadarLocationSource)source replayed:(BOOL)replayed beacons:(NSArray<RadarBeacon *> *_Nullable)beacons forceTrack:(BOOL)forceTrack {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                        message:[NSString stringWithFormat:@"Sending location | source = %@; location = %@; stopped = %d; replayed = %d; beacons = %@; forceTrack = %d",
                                                                           [Radar stringForLocationSource:source], location, stopped, replayed, beacons, forceTrack]];
@@ -1372,9 +1372,9 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     
     if ([RadarSettings useRadarModifiedBeacon]) {
         void (^callTrackAPI)(NSArray<RadarBeacon *> *_Nullable) = ^(NSArray<RadarBeacon *> *_Nullable beacons) {
-            [self performIndoorScanIfConfigured:location 
-                                        beacons:beacons 
-                              completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
+            [self legacy_performIndoorScanIfConfigured:location
+                                               beacons:beacons
+                                     completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
                 [[RadarAPIClient sharedInstance] trackWithLocation:location
                                                            stopped:stopped
                                                         foreground:[RadarUtilsDeprecated foreground]
@@ -1400,8 +1400,8 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                         }
                     }
                     
-                    [self updateTrackingFromMeta:config.meta];
-                    [self replaceSyncedGeofences:nearbyGeofences];
+                    [self legacy_updateTrackingFromMeta:config.meta];
+                    [self legacy_replaceSyncedGeofences:nearbyGeofences];
                 }];
             }];
         };
@@ -1420,7 +1420,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                 
                 NSArray<RadarBeacon *> *syncedBeacons = [RadarSyncManager getObjCBeaconsFor:location];
                 if (syncedBeacons.count > 0) {
-                    [self replaceSyncedBeacons:syncedBeacons];
+                    [self legacy_replaceSyncedBeacons:syncedBeacons];
                     [RadarUtilsDeprecated runOnMainThread:^{
                         [[RadarBeaconManager sharedInstance] rangeBeacons:syncedBeacons
                                                         completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
@@ -1432,7 +1432,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                 }
                                 return;
                             }
-                            NSArray<NSString *> *matchedIds = [self matchBeaconIds:beacons syncedBeacons:syncedBeacons];
+                            NSArray<NSString *> *matchedIds = [self legacy_matchBeaconIds:beacons syncedBeacons:syncedBeacons];
                             if (forceTrack) {
                                 [RadarSyncManager saveBeaconStateWithBeaconIds:matchedIds];
                                 callTrackAPI(beacons);
@@ -1463,7 +1463,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                  limit:10
                  completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons, NSArray<NSString *> *_Nullable beaconUUIDs) {
                     if (beaconUUIDs && beaconUUIDs.count) {
-                        [self replaceSyncedBeaconUUIDs:beaconUUIDs];
+                        [self legacy_replaceSyncedBeaconUUIDs:beaconUUIDs];
                         [RadarUtilsDeprecated runOnMainThread:^{
                             [[RadarBeaconManager sharedInstance] rangeBeaconUUIDs:beaconUUIDs
                                                                 completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
@@ -1476,7 +1476,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                             }];
                         }];
                     } else if (beacons && beacons.count) {
-                        [self replaceSyncedBeacons:beacons];
+                        [self legacy_replaceSyncedBeacons:beacons];
                         [RadarUtilsDeprecated runOnMainThread:^{
                             [[RadarBeaconManager sharedInstance] rangeBeacons:beacons
                                                             completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable beacons) {
@@ -1509,7 +1509,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                     
                     NSArray<RadarBeacon *> *syncedBeacons = [RadarSyncManager getObjCBeaconsFor:location];
                     if (syncedBeacons.count > 0) {
-                        [self replaceSyncedBeacons:syncedBeacons];
+                        [self legacy_replaceSyncedBeacons:syncedBeacons];
                         
                         if (!forceTrack) {
                             [RadarUtilsDeprecated runOnMainThread:^{
@@ -1519,14 +1519,14 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                         self.sending = NO;
                                         return;
                                     }
-                                    NSArray<NSString *> *matchedIds2 = [self matchBeaconIds:rangedBeacons syncedBeacons:syncedBeacons];
+                                    NSArray<NSString *> *matchedIds2 = [self legacy_matchBeaconIds:rangedBeacons syncedBeacons:syncedBeacons];
                                     NSSet<NSString *> *rangedIds = [NSSet setWithArray:matchedIds2];
                                     if ([RadarSyncManager hasBeaconStateChangedWithRangedBeaconIds:rangedIds]) {
                                         [RadarState updateLastSentAt];
                                         [RadarSyncManager saveBeaconStateWithBeaconIds:matchedIds2];
-                                        [self performIndoorScanIfConfigured:location
-                                                                    beacons:rangedBeacons
-                                                          completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
+                                        [self legacy_performIndoorScanIfConfigured:location
+                                                                           beacons:rangedBeacons
+                                                                 completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
                                             [[RadarAPIClient sharedInstance] trackWithLocation:location
                                                                                        stopped:stopped
                                                                                     foreground:[RadarUtilsDeprecated foreground]
@@ -1551,8 +1551,8 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                                     }
                                                 }
                                                 if (status != RadarStatusSuccess || !config) { return; }
-                                                [self updateTrackingFromMeta:config.meta];
-                                                [self replaceSyncedGeofences:nearbyGeofences];
+                                                [self legacy_updateTrackingFromMeta:config.meta];
+                                                [self legacy_replaceSyncedGeofences:nearbyGeofences];
                                             }];
                                         }];
                                     } else {
@@ -1571,18 +1571,18 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                                     limit:10
                         completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSArray<RadarBeacon *> *_Nullable beacons, NSArray<NSString *> *_Nullable beaconUUIDs) {
                             if (beaconUUIDs && beaconUUIDs.count) {
-                                [self replaceSyncedBeaconUUIDs:beaconUUIDs];
+                                [self legacy_replaceSyncedBeaconUUIDs:beaconUUIDs];
                             } else if (beacons && beacons.count) {
-                                [self replaceSyncedBeacons:beacons];
+                                [self legacy_replaceSyncedBeacons:beacons];
                             }
                         }];
                 }
             }
         }
 
-        [self performIndoorScanIfConfigured:location
-                                    beacons:beacons
-                          completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
+        [self legacy_performIndoorScanIfConfigured:location
+                                           beacons:beacons
+                                 completionHandler:^(NSArray<RadarBeacon *> *_Nullable beacons, NSString *_Nullable indoorScan) {
             [[RadarAPIClient sharedInstance] trackWithLocation:location
                                                        stopped:stopped
                                                     foreground:[RadarUtilsDeprecated foreground]
@@ -1612,8 +1612,8 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
                     return;
                 }
 
-                [self updateTrackingFromMeta:config.meta];
-                [self replaceSyncedGeofences:nearbyGeofences];
+                [self legacy_updateTrackingFromMeta:config.meta];
+                [self legacy_replaceSyncedGeofences:nearbyGeofences];
             }];
         }];
     }
@@ -1625,10 +1625,10 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
     BOOL shouldRouteForegroundOneShot =
         self.completionHandlers.count && (sdkConfiguration.skipForegroundCheck || [RadarUtilsDeprecated foreground]);
-    id<RadarLocationManagerBackend> backend = shouldRouteForegroundOneShot
-        ? [self backendForCapability:RadarLocationManagerCapabilityDelegateForegroundLocation]
-        : self.legacyBackend;
-    [backend locationManager:manager didUpdateLocations:locations];
+    id<RadarLocationManagerRouting> implementation = shouldRouteForegroundOneShot
+        ? [self implementationForCapability:RadarLocationManagerCapabilityDelegateForegroundLocation]
+        : self.legacyImplementation;
+    [implementation locationManager:manager didUpdateLocations:locations];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
@@ -1639,7 +1639,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     CLLocation *location = [locations lastObject];
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
     if (self.completionHandlers.count && (sdkConfiguration.skipForegroundCheck || [RadarUtilsDeprecated foreground])) {
-        [self handleLocation:location source:RadarLocationSourceForegroundLocation];
+        [self legacy_handleLocation:location source:RadarLocationSourceForegroundLocation];
     } else {
         BOOL tracking = [RadarSettings tracking];
         if (!tracking) {
@@ -1648,12 +1648,12 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
             return;
         }
 
-        [self handleLocation:location source:RadarLocationSourceBackgroundLocation];
+        [self legacy_handleLocation:location source:RadarLocationSourceBackgroundLocation];
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
-    [self.legacyBackend locationManager:manager didEnterRegion:region];
+    [self.legacyImplementation locationManager:manager didEnterRegion:region];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
@@ -1680,20 +1680,20 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
         [[RadarBeaconManager sharedInstance] handleBeaconUUIDEntryForRegion:(CLBeaconRegion *)region
                                                           completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                              [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
+                                                              [self legacy_handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
                                                           }];
     } else if ([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix]) {
         [[RadarBeaconManager sharedInstance] handleBeaconEntryForRegion:(CLBeaconRegion *)region
                                                       completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                          [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
+                                                          [self legacy_handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
                                                       }];
     } else if (manager.location) {
-        [self handleLocation:manager.location source:RadarLocationSourceGeofenceEnter];
+        [self legacy_handleLocation:manager.location source:RadarLocationSourceGeofenceEnter];
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
-    [self.legacyBackend locationManager:manager didExitRegion:region];
+    [self.legacyImplementation locationManager:manager didExitRegion:region];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
@@ -1720,20 +1720,20 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
         [[RadarBeaconManager sharedInstance] handleBeaconUUIDExitForRegion:(CLBeaconRegion *)region
                                                          completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                             [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
+                                                             [self legacy_handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
                                                          }];
     } else if ([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix]) {
         [[RadarBeaconManager sharedInstance] handleBeaconExitForRegion:(CLBeaconRegion *)region
                                                      completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                         [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
+                                                         [self legacy_handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
                                                      }];
     } else if (manager.location) {
-        [self handleLocation:manager.location source:RadarLocationSourceGeofenceExit];
+        [self legacy_handleLocation:manager.location source:RadarLocationSourceGeofenceExit];
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
-    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] locationManager:manager didDetermineState:state forRegion:region];
+    [[self implementationForCapability:RadarLocationManagerCapabilityBeaconSync] locationManager:manager didDetermineState:state forRegion:region];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
@@ -1754,12 +1754,12 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
             [[RadarBeaconManager sharedInstance] handleBeaconUUIDEntryForRegion:(CLBeaconRegion *)region
                                                               completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                                  [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
+                                                                  [self legacy_handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
                                                               }];
         } else if ([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix]) {
             [[RadarBeaconManager sharedInstance] handleBeaconEntryForRegion:(CLBeaconRegion *)region
                                                           completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                              [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
+                                                              [self legacy_handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
                                                           }];
         }
     } else {
@@ -1768,19 +1768,19 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
         if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
             [[RadarBeaconManager sharedInstance] handleBeaconUUIDExitForRegion:(CLBeaconRegion *)region
                                                              completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                                 [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
+                                                                 [self legacy_handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
                                                              }];
         } else if ([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix]) {
             [[RadarBeaconManager sharedInstance] handleBeaconExitForRegion:(CLBeaconRegion *)region
                                                          completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
-                                                             [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
+                                                             [self legacy_handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
                                                          }];
         }
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
-    [self.legacyBackend locationManager:manager didVisit:visit];
+    [self.legacyImplementation locationManager:manager didVisit:visit];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
@@ -1800,25 +1800,25 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
     }
 
     if ([visit.departureDate isEqualToDate:[NSDate distantFuture]]) {
-        [self handleLocation:manager.location source:RadarLocationSourceVisitArrival];
+        [self legacy_handleLocation:manager.location source:RadarLocationSourceVisitArrival];
     } else {
-        [self handleLocation:manager.location source:RadarLocationSourceVisitDeparture];
+        [self legacy_handleLocation:manager.location source:RadarLocationSourceVisitDeparture];
     }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
-    [[self backendForCapability:RadarLocationManagerCapabilityDelegateFailure] locationManager:manager didFailWithError:error];
+    [[self implementationForCapability:RadarLocationManagerCapabilityDelegateFailure] locationManager:manager didFailWithError:error];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:[NSString stringWithFormat:@"CLLocation manager error | error = %@", error]];
     [[RadarDelegateHolder sharedInstance] didFailWithStatus:RadarStatusErrorLocation];
 
-    [self callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
+    [self legacy_callCompletionHandlersWithStatus:RadarStatusErrorLocation location:nil];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
-    [self.legacyBackend locationManager:manager didUpdateHeading:newHeading];
+    [self.legacyImplementation locationManager:manager didUpdateHeading:newHeading];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
@@ -1834,7 +1834,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplemente
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    [self.legacyBackend locationManager:manager didChangeAuthorizationStatus:status];
+    [self.legacyImplementation locationManager:manager didChangeAuthorizationStatus:status];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -220,6 +220,10 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 }
 
 - (void)didUpdateInjectedDependencies {
+    if (self.owner) {
+        [self.implementation configureWithLocationManager:self.owner.locationManager
+                                 lowPowerLocationManager:self.owner.lowPowerLocationManager];
+    }
     [self.implementation didUpdateInjectedDependencies];
 }
 
@@ -379,6 +383,7 @@ static const RadarLocationManagerCapability kRadarLocationManagerImplementedCapa
 
 - (void)didUpdateInjectedDependencies {
     self.locationManager.delegate = self;
+    self.lowPowerLocationManager.delegate = self;
     [self.legacyImplementation didUpdateInjectedDependencies];
     [self.implementation didUpdateInjectedDependencies];
 }

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -14,6 +14,7 @@
 #import "RadarCircleGeometry.h"
 #import "RadarDelegateHolder.h"
 #import "RadarLocationManager.h"
+#import "RadarLocationManager+Internal.h"
 #import "RadarLogger.h"
 #import "RadarMeta.h"
 #import "RadarPolygonGeometry.h"
@@ -32,6 +33,16 @@
 #elif __has_include("RadarSDK-Swift.h")
 #import "RadarSDK-Swift.h"
 #endif
+
+typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
+    RadarLocationManagerCapabilityOneShotLocation = 1 << 0,
+    RadarLocationManagerCapabilityTrackingLifecycle = 1 << 1,
+    RadarLocationManagerCapabilitySyncedGeofences = 1 << 2,
+    RadarLocationManagerCapabilityBeaconSync = 1 << 3,
+    RadarLocationManagerCapabilitySendPipeline = 1 << 4,
+    RadarLocationManagerCapabilityDelegateForegroundLocation = 1 << 5,
+    RadarLocationManagerCapabilityDelegateFailure = 1 << 6,
+};
 
 @interface RadarLocationManager ()
 
@@ -61,6 +72,247 @@
  Callbacks for sending events.
  */
 @property (nonnull, strong, nonatomic) NSMutableArray<RadarLocationCompletionHandler> *completionHandlers;
+@property (nonnull, strong, nonatomic) id<RadarLocationManagerBackend> legacyBackend;
+@property (nonnull, strong, nonatomic) id<RadarLocationManagerBackend> swiftBackend;
+
+- (void)legacy_callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location;
+- (void)legacy_getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
+- (void)legacy_getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy
+                            completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
+- (void)legacy_startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions;
+- (void)legacy_stopTracking;
+- (void)legacy_replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences;
+- (void)legacy_replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons;
+- (void)legacy_replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids;
+- (void)legacy_updateTracking;
+- (void)legacy_updateTrackingFromMeta:(RadarMeta *_Nullable)meta;
+- (void)legacy_updateTrackingFromInitialize;
+- (void)legacy_performIndoorScanIfConfigured:(CLLocation *)location
+                                     beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                           completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler;
+- (void)legacy_restartPreviousTrackingOptions;
+- (void)legacy_locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
+- (void)legacy_locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region;
+- (void)legacy_locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region;
+- (void)legacy_locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region;
+- (void)legacy_locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit;
+- (void)legacy_locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
+- (void)legacy_locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading;
+- (void)legacy_locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
+
+@end
+
+@interface RadarLocationManagerLegacyBackend : NSObject <RadarLocationManagerBackend>
+
+@property (nullable, nonatomic, weak) RadarLocationManager *owner;
+
+@end
+
+@implementation RadarLocationManagerLegacyBackend
+
+- (void)didUpdateInjectedDependencies {
+}
+
+- (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler {
+    [self.owner legacy_getLocationWithCompletionHandler:completionHandler];
+}
+
+- (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy
+                     completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler {
+    [self.owner legacy_getLocationWithDesiredAccuracy:desiredAccuracy completionHandler:completionHandler];
+}
+
+- (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
+    [self.owner legacy_startTrackingWithOptions:trackingOptions];
+}
+
+- (void)stopTracking {
+    [self.owner legacy_stopTracking];
+}
+
+- (void)replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
+    [self.owner legacy_replaceSyncedGeofences:geofences];
+}
+
+- (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
+    [self.owner legacy_replaceSyncedBeacons:beacons];
+}
+
+- (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
+    [self.owner legacy_replaceSyncedBeaconUUIDs:uuids];
+}
+
+- (void)updateTracking {
+    [self.owner legacy_updateTracking];
+}
+
+- (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
+    [self.owner legacy_updateTrackingFromMeta:meta];
+}
+
+- (void)updateTrackingFromInitialize {
+    [self.owner legacy_updateTrackingFromInitialize];
+}
+
+- (void)performIndoorScanIfConfigured:(CLLocation *)location
+                              beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                    completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler {
+    [self.owner legacy_performIndoorScanIfConfigured:location beacons:beacons completionHandler:completionHandler];
+}
+
+- (void)restartPreviousTrackingOptions {
+    [self.owner legacy_restartPreviousTrackingOptions];
+}
+
+- (void)callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
+    [self.owner legacy_callCompletionHandlersWithStatus:status location:location];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    [self.owner legacy_locationManager:manager didUpdateLocations:locations];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
+    [self.owner legacy_locationManager:manager didEnterRegion:region];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    [self.owner legacy_locationManager:manager didExitRegion:region];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
+    [self.owner legacy_locationManager:manager didDetermineState:state forRegion:region];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
+    [self.owner legacy_locationManager:manager didVisit:visit];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
+    [self.owner legacy_locationManager:manager didFailWithError:error];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
+    [self.owner legacy_locationManager:manager didUpdateHeading:newHeading];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    [self.owner legacy_locationManager:manager didChangeAuthorizationStatus:status];
+}
+
+@end
+
+@interface RadarLocationManagerSwiftBackendAdapter : NSObject <RadarLocationManagerBackend>
+
+@property (nullable, nonatomic, weak) RadarLocationManager *owner;
+@property (nonnull, nonatomic, strong) RadarLocationManagerSwiftBackend *backend;
+
+@end
+
+@implementation RadarLocationManagerSwiftBackendAdapter
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _backend = [RadarLocationManagerSwiftBackend new];
+    }
+    return self;
+}
+
+- (void)didUpdateInjectedDependencies {
+    [self.backend didUpdateInjectedDependencies];
+}
+
+- (void)failFastForSelector:(SEL)selector {
+    [self.backend failFastWithMethod:NSStringFromSelector(selector)];
+}
+
+- (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy
+                     completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)stopTracking {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)updateTracking {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)updateTrackingFromInitialize {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)performIndoorScanIfConfigured:(CLLocation *)location
+                              beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                    completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)restartPreviousTrackingOptions {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    [self failFastForSelector:_cmd];
+}
 
 @end
 
@@ -71,6 +323,7 @@ static NSString *const kBubbleGeofenceIdentifierPrefix = @"radar_bubble_";
 static NSString *const kSyncGeofenceIdentifierPrefix = @"radar_geofence_";
 static NSString *const kSyncBeaconIdentifierPrefix = @"radar_beacon_";
 static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
+static const RadarLocationManagerCapability kRadarLocationManagerSwiftImplementedCapabilities = 0;
 
 + (instancetype)sharedInstance {
     static dispatch_once_t once;
@@ -93,6 +346,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
     self = [super init];
     if (self) {
         _completionHandlers = [NSMutableArray new];
+        _legacyBackend = [RadarLocationManagerLegacyBackend new];
+        _legacyBackend.owner = self;
+        _swiftBackend = [RadarLocationManagerSwiftBackendAdapter new];
+        _swiftBackend.owner = self;
 
         _locationManager = [CLLocationManager new];
         _locationManager.delegate = self;
@@ -106,11 +363,51 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         _lowPowerLocationManager.allowsBackgroundLocationUpdates = [RadarUtils locationBackgroundMode];
 
         _permissionsHelper = [RadarPermissionsHelper new];
+        [self didUpdateInjectedDependencies];
     }
     return self;
 }
 
+- (BOOL)useSwiftBackendForCapability:(RadarLocationManagerCapability)capability {
+    return RadarSettings.locationManagerSwiftMigrationEnabled &&
+           (kRadarLocationManagerSwiftImplementedCapabilities & capability) == capability;
+}
+
+- (id<RadarLocationManagerBackend>)backendForCapability:(RadarLocationManagerCapability)capability {
+    return [self useSwiftBackendForCapability:capability] ? self.swiftBackend : self.legacyBackend;
+}
+
+- (void)didUpdateInjectedDependencies {
+    self.locationManager.delegate = self;
+    [self.legacyBackend didUpdateInjectedDependencies];
+    [self.swiftBackend didUpdateInjectedDependencies];
+}
+
+- (void)setLocationManager:(CLLocationManager *)locationManager {
+    _locationManager = locationManager;
+    [self didUpdateInjectedDependencies];
+}
+
+- (void)setLowPowerLocationManager:(CLLocationManager *)lowPowerLocationManager {
+    _lowPowerLocationManager = lowPowerLocationManager;
+    [self didUpdateInjectedDependencies];
+}
+
+- (void)setPermissionsHelper:(RadarPermissionsHelper *)permissionsHelper {
+    _permissionsHelper = permissionsHelper;
+    [self didUpdateInjectedDependencies];
+}
+
+- (void)setActivityManager:(RadarActivityManager *)activityManager {
+    _activityManager = activityManager;
+    [self didUpdateInjectedDependencies];
+}
+
 - (void)callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
+    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] callCompletionHandlersWithStatus:status location:location];
+}
+
+- (void)legacy_callCompletionHandlersWithStatus:(RadarStatus)status location:(CLLocation *_Nullable)location {
     @synchronized(self) {
         if (!self.completionHandlers.count){
             return;
@@ -160,10 +457,18 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
-    [self getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyMedium completionHandler:completionHandler];
+    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithCompletionHandler:completionHandler];
+}
+
+- (void)legacy_getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
+    [self legacy_getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyMedium completionHandler:completionHandler];
 }
 
 - (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy completionHandler:(RadarLocationCompletionHandler)completionHandler {
+    [[self backendForCapability:RadarLocationManagerCapabilityOneShotLocation] getLocationWithDesiredAccuracy:desiredAccuracy completionHandler:completionHandler];
+}
+
+- (void)legacy_getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy completionHandler:(RadarLocationCompletionHandler)completionHandler {
     CLAuthorizationStatus authorizationStatus = [self.permissionsHelper locationAuthorizationStatus];
     if (!(authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse || authorizationStatus == kCLAuthorizationStatusAuthorizedAlways)) {
         [[RadarDelegateHolder sharedInstance] didFailWithStatus:RadarStatusErrorPermissions];
@@ -196,6 +501,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] startTrackingWithOptions:trackingOptions];
+}
+
+- (void)legacy_startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions {
     CLAuthorizationStatus authorizationStatus = [self.permissionsHelper locationAuthorizationStatus];
     if (!(authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse || authorizationStatus == kCLAuthorizationStatusAuthorizedAlways)) {
         [[RadarDelegateHolder sharedInstance] didFailWithStatus:RadarStatusErrorPermissions];
@@ -208,6 +517,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)stopTracking {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] stopTracking];
+}
+
+- (void)legacy_stopTracking {
     [RadarSettings setTracking:NO];
 
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
@@ -308,10 +621,18 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)updateTracking {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTracking];
+}
+
+- (void)legacy_updateTracking {
     [self updateTracking:nil fromInitialize:NO];
 }
 
 - (void)updateTrackingFromInitialize {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromInitialize];
+}
+
+- (void)legacy_updateTrackingFromInitialize {
     [self updateTracking:nil fromInitialize:YES];
 }
 
@@ -512,6 +833,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] updateTrackingFromMeta:meta];
+}
+
+- (void)legacy_updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
     if (meta) {
         if ([meta trackingOptions]) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
@@ -528,6 +853,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)restartPreviousTrackingOptions {
+    [[self backendForCapability:RadarLocationManagerCapabilityTrackingLifecycle] restartPreviousTrackingOptions];
+}
+
+- (void)legacy_restartPreviousTrackingOptions {
     RadarTrackingOptions *previousTrackingOptions = [RadarSettings previousTrackingOptions];
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Restarting previous tracking options"];
 
@@ -566,6 +895,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
+    [[self backendForCapability:RadarLocationManagerCapabilitySyncedGeofences] replaceSyncedGeofences:geofences];
+}
+
+- (void)legacy_replaceSyncedGeofences:(NSArray<RadarGeofence *> *)geofences {
     if (@available(iOS 13.0, *)) {
         if ([RadarSettings sdkConfiguration].useNotificationDiffV2) {
             [[RadarNotificationHelper_Swift shared]
@@ -680,6 +1013,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
+    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeacons:beacons];
+}
+
+- (void)legacy_replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
@@ -721,6 +1058,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
+    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] replaceSyncedBeaconUUIDs:uuids];
+}
+
+- (void)legacy_replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
@@ -985,9 +1326,17 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
     [self sendLocation:sendLocation stopped:stopped source:source replayed:replayed beacons:beacons forceTrack:YES];
 }
 
-- (void)performIndoorScanIfConfigured:(CLLocation *)location 
+- (void)performIndoorScanIfConfigured:(CLLocation *)location
                                beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
                      completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler {
+    [[self backendForCapability:RadarLocationManagerCapabilitySendPipeline] performIndoorScanIfConfigured:location
+                                                                                                  beacons:beacons
+                                                                                        completionHandler:completionHandler];
+}
+
+- (void)legacy_performIndoorScanIfConfigured:(CLLocation *)location
+                                     beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                           completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler {
     RadarTrackingOptions *options = [Radar getTrackingOptions];
     Class RadarSDKIndoors = NSClassFromString(@"RadarSDKIndoors");
     
@@ -1273,6 +1622,16 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 #pragma mark - CLLocationManagerDelegate
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
+    BOOL shouldRouteForegroundOneShot =
+        self.completionHandlers.count && (sdkConfiguration.skipForegroundCheck || [RadarUtilsDeprecated foreground]);
+    id<RadarLocationManagerBackend> backend = shouldRouteForegroundOneShot
+        ? [self backendForCapability:RadarLocationManagerCapabilityDelegateForegroundLocation]
+        : self.legacyBackend;
+    [backend locationManager:manager didUpdateLocations:locations];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
     if (!locations || !locations.count) {
         return;
     }
@@ -1294,6 +1653,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
+    [self.legacyBackend locationManager:manager didEnterRegion:region];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
     if (![region.identifier hasPrefix:kIdentifierPrefix]) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region entry: wrong prefix"];
 
@@ -1330,6 +1693,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    [self.legacyBackend locationManager:manager didExitRegion:region];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
     if (![region.identifier hasPrefix:kIdentifierPrefix]) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region exit: wrong prefix"];
 
@@ -1366,6 +1733,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
+    [[self backendForCapability:RadarLocationManagerCapabilityBeaconSync] locationManager:manager didDetermineState:state forRegion:region];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
     if (!([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix] || [region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix])) {
         return;
     }
@@ -1409,6 +1780,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
+    [self.legacyBackend locationManager:manager didVisit:visit];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
     if (!manager.location) {
         return;
     }
@@ -1432,6 +1807,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
+    [[self backendForCapability:RadarLocationManagerCapabilityDelegateFailure] locationManager:manager didFailWithError:error];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:[NSString stringWithFormat:@"CLLocation manager error | error = %@", error]];
     [[RadarDelegateHolder sharedInstance] didFailWithStatus:RadarStatusErrorLocation];
 
@@ -1439,6 +1818,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
+    [self.legacyBackend locationManager:manager didUpdateHeading:newHeading];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
     [RadarState setLastHeadingData:@{
         @"magneticHeading" : @(newHeading.magneticHeading),
         @"trueHeading" : @(newHeading.trueHeading),
@@ -1451,6 +1834,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    [self.legacyBackend locationManager:manager didChangeAuthorizationStatus:status];
+}
+
+- (void)legacy_locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
     CLAuthorizationStatus previousStatus = [RadarState locationAuthorizationStatus];
     [RadarState setLocationAuthorizationStatus:status];
 

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -42,6 +42,7 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
     RadarLocationManagerCapabilitySendPipeline = 1 << 4,
     RadarLocationManagerCapabilityDelegateForegroundLocation = 1 << 5,
     RadarLocationManagerCapabilityDelegateFailure = 1 << 6,
+    RadarLocationManagerCapabilityAuthorization = 1 << 7,
 };
 
 @interface RadarLocationManager ()
@@ -98,6 +99,7 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 - (void)legacy_locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit;
 - (void)legacy_locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
 - (void)legacy_locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading;
+- (void)legacy_locationManagerDidChangeAuthorization:(CLLocationManager *)manager;
 - (void)legacy_locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
 
 @end
@@ -194,6 +196,10 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
     [self.owner legacy_locationManager:manager didUpdateHeading:newHeading];
+}
+
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    [self.owner legacy_locationManagerDidChangeAuthorization:manager];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
@@ -311,6 +317,10 @@ typedef NS_OPTIONS(NSUInteger, RadarLocationManagerCapability) {
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
+    [self failFastForSelector:_cmd];
+}
+
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
     [self failFastForSelector:_cmd];
 }
 
@@ -1838,8 +1848,16 @@ static const RadarLocationManagerCapability kRadarLocationManagerImplementedCapa
     }];
 }
 
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    [[self implementationForCapability:RadarLocationManagerCapabilityAuthorization] locationManagerDidChangeAuthorization:manager];
+}
+
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    [self.legacyImplementation locationManager:manager didChangeAuthorizationStatus:status];
+    [[self implementationForCapability:RadarLocationManagerCapabilityAuthorization] locationManager:manager didChangeAuthorizationStatus:status];
+}
+
+- (void)legacy_locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    [self legacy_locationManager:manager didChangeAuthorizationStatus:manager.authorizationStatus];
 }
 
 - (void)legacy_locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {

--- a/RadarSDK/RadarLocationManager.swift
+++ b/RadarSDK/RadarLocationManager.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
+@objc(RadarLocationManagerImplementation)
 @objcMembers
-final class RadarLocationManagerSwiftBackend: NSObject {
-    func didUpdateInjectedDependencies() {
+public final class RadarLocationManagerImplementation: NSObject {
+    public func didUpdateInjectedDependencies() {
     }
 
-    func failFast(withMethod method: String) -> Never {
-        preconditionFailure("RadarLocationManager Swift backend is not implemented for \(method)")
+    @objc(failFastWithMethod:)
+    public func failFast(withMethod method: String) {
+        preconditionFailure("RadarLocationManager implementation is not implemented for \(method)")
     }
 }

--- a/RadarSDK/RadarLocationManager.swift
+++ b/RadarSDK/RadarLocationManager.swift
@@ -1,0 +1,18 @@
+//
+//  RadarLocationManager.swift
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+
+@objcMembers
+final class RadarLocationManagerSwiftBackend: NSObject {
+    func didUpdateInjectedDependencies() {
+    }
+
+    func failFast(withMethod method: String) -> Never {
+        preconditionFailure("RadarLocationManager Swift backend is not implemented for \(method)")
+    }
+}

--- a/RadarSDK/RadarLocationManager.swift
+++ b/RadarSDK/RadarLocationManager.swift
@@ -16,6 +16,35 @@ enum RadarLocationUpdateSourceKind {
     case liveUpdates
 }
 
+enum RadarLocationMonitoringKind {
+    case locationManager
+    case conditionMonitoring
+}
+
+enum RadarLocationAuthorizationKind {
+    case locationManager
+    case serviceSession
+}
+
+enum RadarLocationBackgroundSessionKind {
+    case none
+    case backgroundActivitySession
+}
+
+enum RadarLocationDiagnosticsKind {
+    case legacy
+    case serviceSession
+}
+
+struct RadarLocationDiagnosticsSnapshot: Equatable {
+    let authorizationDenied: Bool
+    let authorizationDeniedGlobally: Bool
+    let authorizationRestricted: Bool
+    let accuracyLimited: Bool
+    let insufficientlyInUse: Bool
+    let serviceSessionRequired: Bool
+}
+
 protocol RadarLocationUpdateSource: AnyObject {
     func requestSingleUpdate()
     func setStandardUpdatesEnabled(_ isEnabled: Bool)
@@ -28,6 +57,53 @@ protocol RadarLocationUpdateSourceMaking {
         locationManager: CLLocationManager,
         lowPowerLocationManager: CLLocationManager
     ) -> RadarLocationUpdateSource
+}
+
+protocol RadarLocationMonitoring: AnyObject {
+    func startMonitoring(_ region: CLRegion)
+    func stopMonitoring(_ region: CLRegion)
+}
+
+protocol RadarLocationMonitoringMaking {
+    func makeMonitoring(kind: RadarLocationMonitoringKind, locationManager: CLLocationManager) -> RadarLocationMonitoring
+}
+
+protocol RadarLocationAuthorizationControlling: AnyObject {
+    var authorizationStatus: CLAuthorizationStatus { get }
+    var accuracyAuthorization: CLAccuracyAuthorization? { get }
+    func requestWhenInUseAuthorization()
+    func requestAlwaysAuthorization()
+    func requestTemporaryFullAccuracyAuthorization(purposeKey: String)
+}
+
+protocol RadarLocationAuthorizationControllingMaking {
+    func makeAuthorizationController(
+        kind: RadarLocationAuthorizationKind,
+        locationManager: CLLocationManager
+    ) -> RadarLocationAuthorizationControlling
+}
+
+protocol RadarLocationBackgroundSessionControlling: AnyObject {
+    var isActive: Bool { get }
+    func activate()
+    func invalidate()
+}
+
+protocol RadarLocationBackgroundSessionControllingMaking {
+    func makeBackgroundSessionController(
+        kind: RadarLocationBackgroundSessionKind
+    ) -> RadarLocationBackgroundSessionControlling
+}
+
+protocol RadarLocationDiagnosticsProviding: AnyObject {
+    func diagnosticsSnapshot() -> RadarLocationDiagnosticsSnapshot
+}
+
+protocol RadarLocationDiagnosticsProvidingMaking {
+    func makeDiagnosticsProvider(
+        kind: RadarLocationDiagnosticsKind,
+        locationManager: CLLocationManager
+    ) -> RadarLocationDiagnosticsProviding
 }
 
 final class RadarCoreLocationUpdateSource: RadarLocationUpdateSource {
@@ -60,6 +136,98 @@ final class RadarCoreLocationUpdateSource: RadarLocationUpdateSource {
     }
 }
 
+final class RadarLocationManagerMonitoring: RadarLocationMonitoring {
+    private let locationManager: CLLocationManager
+
+    init(locationManager: CLLocationManager) {
+        self.locationManager = locationManager
+    }
+
+    func startMonitoring(_ region: CLRegion) {
+        locationManager.startMonitoring(for: region)
+    }
+
+    func stopMonitoring(_ region: CLRegion) {
+        locationManager.stopMonitoring(for: region)
+    }
+}
+
+final class RadarLocationManagerAuthorizationController: RadarLocationAuthorizationControlling {
+    private let locationManager: CLLocationManager
+
+    init(locationManager: CLLocationManager) {
+        self.locationManager = locationManager
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        CLLocationManager.authorizationStatus()
+    }
+
+    var accuracyAuthorization: CLAccuracyAuthorization? {
+        if #available(iOS 14.0, *) {
+            return locationManager.accuracyAuthorization
+        }
+
+        return nil
+    }
+
+    func requestWhenInUseAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+
+    func requestAlwaysAuthorization() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    func requestTemporaryFullAccuracyAuthorization(purposeKey: String) {
+        guard #available(iOS 14.0, *) else {
+            return
+        }
+
+        locationManager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey)
+    }
+}
+
+final class RadarNoopLocationBackgroundSessionController: RadarLocationBackgroundSessionControlling {
+    private(set) var isActive = false
+
+    func activate() {
+        isActive = true
+    }
+
+    func invalidate() {
+        isActive = false
+    }
+}
+
+final class RadarLegacyLocationDiagnosticsProvider: RadarLocationDiagnosticsProviding {
+    private let locationManager: CLLocationManager
+
+    init(locationManager: CLLocationManager) {
+        self.locationManager = locationManager
+    }
+
+    func diagnosticsSnapshot() -> RadarLocationDiagnosticsSnapshot {
+        let authorizationStatus = CLLocationManager.authorizationStatus()
+        let accuracyLimited: Bool
+
+        if #available(iOS 14.0, *) {
+            accuracyLimited = locationManager.accuracyAuthorization == .reducedAccuracy
+        } else {
+            accuracyLimited = false
+        }
+
+        return RadarLocationDiagnosticsSnapshot(
+            authorizationDenied: authorizationStatus == .denied,
+            authorizationDeniedGlobally: !CLLocationManager.locationServicesEnabled(),
+            authorizationRestricted: authorizationStatus == .restricted,
+            accuracyLimited: accuracyLimited,
+            insufficientlyInUse: false,
+            serviceSessionRequired: false
+        )
+    }
+}
+
 @available(iOS 17.0, *)
 final class RadarLiveLocationUpdateSource: RadarLocationUpdateSource {
     func requestSingleUpdate() {
@@ -72,6 +240,62 @@ final class RadarLiveLocationUpdateSource: RadarLocationUpdateSource {
 
     func setLowPowerUpdatesEnabled(_ isEnabled: Bool) {
         preconditionFailure("Radar liveUpdates source is not implemented for setLowPowerUpdatesEnabled(_:)")
+    }
+}
+
+@available(iOS 17.0, *)
+final class RadarConditionMonitoring: RadarLocationMonitoring {
+    func startMonitoring(_ region: CLRegion) {
+        preconditionFailure("Radar condition monitoring is not implemented for startMonitoring(_:)")
+    }
+
+    func stopMonitoring(_ region: CLRegion) {
+        preconditionFailure("Radar condition monitoring is not implemented for stopMonitoring(_:)")
+    }
+}
+
+@available(iOS 17.0, *)
+final class RadarServiceSessionAuthorizationController: RadarLocationAuthorizationControlling {
+    var authorizationStatus: CLAuthorizationStatus {
+        preconditionFailure("Radar service session authorization is not implemented for authorizationStatus")
+    }
+
+    var accuracyAuthorization: CLAccuracyAuthorization? {
+        preconditionFailure("Radar service session authorization is not implemented for accuracyAuthorization")
+    }
+
+    func requestWhenInUseAuthorization() {
+        preconditionFailure("Radar service session authorization is not implemented for requestWhenInUseAuthorization()")
+    }
+
+    func requestAlwaysAuthorization() {
+        preconditionFailure("Radar service session authorization is not implemented for requestAlwaysAuthorization()")
+    }
+
+    func requestTemporaryFullAccuracyAuthorization(purposeKey: String) {
+        preconditionFailure("Radar service session authorization is not implemented for requestTemporaryFullAccuracyAuthorization(purposeKey:)")
+    }
+}
+
+@available(iOS 17.0, *)
+final class RadarBackgroundActivitySessionController: RadarLocationBackgroundSessionControlling {
+    var isActive: Bool {
+        preconditionFailure("Radar background activity session is not implemented for isActive")
+    }
+
+    func activate() {
+        preconditionFailure("Radar background activity session is not implemented for activate()")
+    }
+
+    func invalidate() {
+        preconditionFailure("Radar background activity session is not implemented for invalidate()")
+    }
+}
+
+@available(iOS 17.0, *)
+final class RadarServiceSessionDiagnosticsProvider: RadarLocationDiagnosticsProviding {
+    func diagnosticsSnapshot() -> RadarLocationDiagnosticsSnapshot {
+        preconditionFailure("Radar service session diagnostics are not implemented for diagnosticsSnapshot()")
     }
 }
 
@@ -100,22 +324,116 @@ final class RadarLocationUpdateSourceFactory: RadarLocationUpdateSourceMaking {
     }
 }
 
+final class RadarLocationMonitoringFactory: RadarLocationMonitoringMaking {
+    func makeMonitoring(kind: RadarLocationMonitoringKind, locationManager: CLLocationManager) -> RadarLocationMonitoring {
+        switch kind {
+        case .locationManager:
+            return RadarLocationManagerMonitoring(locationManager: locationManager)
+        case .conditionMonitoring:
+            if #available(iOS 17.0, *) {
+                return RadarConditionMonitoring()
+            }
+
+            return RadarLocationManagerMonitoring(locationManager: locationManager)
+        }
+    }
+}
+
+final class RadarLocationAuthorizationControllerFactory: RadarLocationAuthorizationControllingMaking {
+    func makeAuthorizationController(
+        kind: RadarLocationAuthorizationKind,
+        locationManager: CLLocationManager
+    ) -> RadarLocationAuthorizationControlling {
+        switch kind {
+        case .locationManager:
+            return RadarLocationManagerAuthorizationController(locationManager: locationManager)
+        case .serviceSession:
+            if #available(iOS 17.0, *) {
+                return RadarServiceSessionAuthorizationController()
+            }
+
+            return RadarLocationManagerAuthorizationController(locationManager: locationManager)
+        }
+    }
+}
+
+final class RadarLocationBackgroundSessionControllerFactory: RadarLocationBackgroundSessionControllingMaking {
+    func makeBackgroundSessionController(
+        kind: RadarLocationBackgroundSessionKind
+    ) -> RadarLocationBackgroundSessionControlling {
+        switch kind {
+        case .none:
+            return RadarNoopLocationBackgroundSessionController()
+        case .backgroundActivitySession:
+            if #available(iOS 17.0, *) {
+                return RadarBackgroundActivitySessionController()
+            }
+
+            return RadarNoopLocationBackgroundSessionController()
+        }
+    }
+}
+
+final class RadarLocationDiagnosticsProviderFactory: RadarLocationDiagnosticsProvidingMaking {
+    func makeDiagnosticsProvider(
+        kind: RadarLocationDiagnosticsKind,
+        locationManager: CLLocationManager
+    ) -> RadarLocationDiagnosticsProviding {
+        switch kind {
+        case .legacy:
+            return RadarLegacyLocationDiagnosticsProvider(locationManager: locationManager)
+        case .serviceSession:
+            if #available(iOS 17.0, *) {
+                return RadarServiceSessionDiagnosticsProvider()
+            }
+
+            return RadarLegacyLocationDiagnosticsProvider(locationManager: locationManager)
+        }
+    }
+}
+
 @objc(RadarLocationManagerImplementation)
 public final class RadarLocationManagerImplementation: NSObject {
     private let sourceFactory: RadarLocationUpdateSourceMaking
+    private let monitoringFactory: RadarLocationMonitoringMaking
+    private let authorizationControllerFactory: RadarLocationAuthorizationControllingMaking
+    private let backgroundSessionControllerFactory: RadarLocationBackgroundSessionControllingMaking
+    private let diagnosticsProviderFactory: RadarLocationDiagnosticsProvidingMaking
     private weak var locationManager: CLLocationManager?
     private weak var lowPowerLocationManager: CLLocationManager?
     private(set) var locationUpdateSourceKind: RadarLocationUpdateSourceKind = .coreLocationManager
+    private(set) var locationMonitoringKind: RadarLocationMonitoringKind = .locationManager
+    private(set) var locationAuthorizationKind: RadarLocationAuthorizationKind = .locationManager
+    private(set) var locationBackgroundSessionKind: RadarLocationBackgroundSessionKind = .none
+    private(set) var locationDiagnosticsKind: RadarLocationDiagnosticsKind = .legacy
     private(set) var locationUpdateSource: RadarLocationUpdateSource?
+    private(set) var locationMonitoring: RadarLocationMonitoring?
+    private(set) var locationAuthorizationController: RadarLocationAuthorizationControlling?
+    private(set) var locationBackgroundSessionController: RadarLocationBackgroundSessionControlling?
+    private(set) var locationDiagnosticsProvider: RadarLocationDiagnosticsProviding?
 
     @objc
     public override init() {
         self.sourceFactory = RadarLocationUpdateSourceFactory()
+        self.monitoringFactory = RadarLocationMonitoringFactory()
+        self.authorizationControllerFactory = RadarLocationAuthorizationControllerFactory()
+        self.backgroundSessionControllerFactory = RadarLocationBackgroundSessionControllerFactory()
+        self.diagnosticsProviderFactory = RadarLocationDiagnosticsProviderFactory()
         super.init()
     }
 
-    init(sourceFactory: RadarLocationUpdateSourceMaking) {
+    init(
+        sourceFactory: RadarLocationUpdateSourceMaking,
+        monitoringFactory: RadarLocationMonitoringMaking,
+        authorizationControllerFactory: RadarLocationAuthorizationControllingMaking,
+        backgroundSessionControllerFactory: RadarLocationBackgroundSessionControllingMaking,
+        diagnosticsProviderFactory: RadarLocationDiagnosticsProvidingMaking
+    ) {
         self.sourceFactory = sourceFactory
+        self.monitoringFactory = monitoringFactory
+        self.authorizationControllerFactory = authorizationControllerFactory
+        self.backgroundSessionControllerFactory = backgroundSessionControllerFactory
+        self.diagnosticsProviderFactory = diagnosticsProviderFactory
         super.init()
     }
 
@@ -123,17 +441,37 @@ public final class RadarLocationManagerImplementation: NSObject {
     public func configure(locationManager: CLLocationManager, lowPowerLocationManager: CLLocationManager) {
         self.locationManager = locationManager
         self.lowPowerLocationManager = lowPowerLocationManager
-        rebuildLocationUpdateSource()
+        rebuildLocationPlatform()
     }
 
     func setLocationUpdateSourceKind(_ kind: RadarLocationUpdateSourceKind) {
         locationUpdateSourceKind = kind
-        rebuildLocationUpdateSource()
+        rebuildLocationPlatform()
+    }
+
+    func setLocationMonitoringKind(_ kind: RadarLocationMonitoringKind) {
+        locationMonitoringKind = kind
+        rebuildLocationPlatform()
+    }
+
+    func setLocationAuthorizationKind(_ kind: RadarLocationAuthorizationKind) {
+        locationAuthorizationKind = kind
+        rebuildLocationPlatform()
+    }
+
+    func setLocationBackgroundSessionKind(_ kind: RadarLocationBackgroundSessionKind) {
+        locationBackgroundSessionKind = kind
+        rebuildLocationPlatform()
+    }
+
+    func setLocationDiagnosticsKind(_ kind: RadarLocationDiagnosticsKind) {
+        locationDiagnosticsKind = kind
+        rebuildLocationPlatform()
     }
 
     @objc
     public func didUpdateInjectedDependencies() {
-        rebuildLocationUpdateSource()
+        rebuildLocationPlatform()
     }
 
     @objc(failFastWithMethod:)
@@ -141,9 +479,13 @@ public final class RadarLocationManagerImplementation: NSObject {
         preconditionFailure("RadarLocationManager implementation is not implemented for \(method)")
     }
 
-    private func rebuildLocationUpdateSource() {
+    private func rebuildLocationPlatform() {
         guard let locationManager, let lowPowerLocationManager else {
             locationUpdateSource = nil
+            locationMonitoring = nil
+            locationAuthorizationController = nil
+            locationBackgroundSessionController = nil
+            locationDiagnosticsProvider = nil
             return
         }
 
@@ -151,6 +493,21 @@ public final class RadarLocationManagerImplementation: NSObject {
             kind: locationUpdateSourceKind,
             locationManager: locationManager,
             lowPowerLocationManager: lowPowerLocationManager
+        )
+        locationMonitoring = monitoringFactory.makeMonitoring(
+            kind: locationMonitoringKind,
+            locationManager: locationManager
+        )
+        locationAuthorizationController = authorizationControllerFactory.makeAuthorizationController(
+            kind: locationAuthorizationKind,
+            locationManager: locationManager
+        )
+        locationBackgroundSessionController = backgroundSessionControllerFactory.makeBackgroundSessionController(
+            kind: locationBackgroundSessionKind
+        )
+        locationDiagnosticsProvider = diagnosticsProviderFactory.makeDiagnosticsProvider(
+            kind: locationDiagnosticsKind,
+            locationManager: locationManager
         )
     }
 }

--- a/RadarSDK/RadarLocationManager.swift
+++ b/RadarSDK/RadarLocationManager.swift
@@ -5,16 +5,152 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+import CoreLocation
 import Foundation
 
+// This boundary keeps "how locations arrive" separate from the state machine that
+// decides what to do with them, so we can adopt new Core Location delivery APIs
+// without reshaping the facade again.
+enum RadarLocationUpdateSourceKind {
+    case coreLocationManager
+    case liveUpdates
+}
+
+protocol RadarLocationUpdateSource: AnyObject {
+    func requestSingleUpdate()
+    func setStandardUpdatesEnabled(_ isEnabled: Bool)
+    func setLowPowerUpdatesEnabled(_ isEnabled: Bool)
+}
+
+protocol RadarLocationUpdateSourceMaking {
+    func makeSource(
+        kind: RadarLocationUpdateSourceKind,
+        locationManager: CLLocationManager,
+        lowPowerLocationManager: CLLocationManager
+    ) -> RadarLocationUpdateSource
+}
+
+final class RadarCoreLocationUpdateSource: RadarLocationUpdateSource {
+    private let locationManager: CLLocationManager
+    private let lowPowerLocationManager: CLLocationManager
+
+    init(locationManager: CLLocationManager, lowPowerLocationManager: CLLocationManager) {
+        self.locationManager = locationManager
+        self.lowPowerLocationManager = lowPowerLocationManager
+    }
+
+    func requestSingleUpdate() {
+        locationManager.requestLocation()
+    }
+
+    func setStandardUpdatesEnabled(_ isEnabled: Bool) {
+        if isEnabled {
+            locationManager.startUpdatingLocation()
+        } else {
+            locationManager.stopUpdatingLocation()
+        }
+    }
+
+    func setLowPowerUpdatesEnabled(_ isEnabled: Bool) {
+        if isEnabled {
+            lowPowerLocationManager.startUpdatingLocation()
+        } else {
+            lowPowerLocationManager.stopUpdatingLocation()
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+final class RadarLiveLocationUpdateSource: RadarLocationUpdateSource {
+    func requestSingleUpdate() {
+        preconditionFailure("Radar liveUpdates source is not implemented for requestSingleUpdate()")
+    }
+
+    func setStandardUpdatesEnabled(_ isEnabled: Bool) {
+        preconditionFailure("Radar liveUpdates source is not implemented for setStandardUpdatesEnabled(_:)")
+    }
+
+    func setLowPowerUpdatesEnabled(_ isEnabled: Bool) {
+        preconditionFailure("Radar liveUpdates source is not implemented for setLowPowerUpdatesEnabled(_:)")
+    }
+}
+
+final class RadarLocationUpdateSourceFactory: RadarLocationUpdateSourceMaking {
+    func makeSource(
+        kind: RadarLocationUpdateSourceKind,
+        locationManager: CLLocationManager,
+        lowPowerLocationManager: CLLocationManager
+    ) -> RadarLocationUpdateSource {
+        switch kind {
+        case .coreLocationManager:
+            return RadarCoreLocationUpdateSource(
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager
+            )
+        case .liveUpdates:
+            if #available(iOS 17.0, *) {
+                return RadarLiveLocationUpdateSource()
+            }
+
+            return RadarCoreLocationUpdateSource(
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager
+            )
+        }
+    }
+}
+
 @objc(RadarLocationManagerImplementation)
-@objcMembers
 public final class RadarLocationManagerImplementation: NSObject {
+    private let sourceFactory: RadarLocationUpdateSourceMaking
+    private weak var locationManager: CLLocationManager?
+    private weak var lowPowerLocationManager: CLLocationManager?
+    private(set) var locationUpdateSourceKind: RadarLocationUpdateSourceKind = .coreLocationManager
+    private(set) var locationUpdateSource: RadarLocationUpdateSource?
+
+    @objc
+    public override init() {
+        self.sourceFactory = RadarLocationUpdateSourceFactory()
+        super.init()
+    }
+
+    init(sourceFactory: RadarLocationUpdateSourceMaking) {
+        self.sourceFactory = sourceFactory
+        super.init()
+    }
+
+    @objc(configureWithLocationManager:lowPowerLocationManager:)
+    public func configure(locationManager: CLLocationManager, lowPowerLocationManager: CLLocationManager) {
+        self.locationManager = locationManager
+        self.lowPowerLocationManager = lowPowerLocationManager
+        rebuildLocationUpdateSource()
+    }
+
+    func setLocationUpdateSourceKind(_ kind: RadarLocationUpdateSourceKind) {
+        locationUpdateSourceKind = kind
+        rebuildLocationUpdateSource()
+    }
+
+    @objc
     public func didUpdateInjectedDependencies() {
+        rebuildLocationUpdateSource()
     }
 
     @objc(failFastWithMethod:)
     public func failFast(withMethod method: String) {
         preconditionFailure("RadarLocationManager implementation is not implemented for \(method)")
+    }
+
+    private func rebuildLocationUpdateSource() {
+        guard let locationManager, let lowPowerLocationManager else {
+            locationUpdateSource = nil
+            return
+        }
+
+        locationUpdateSource = sourceFactory.makeSource(
+            kind: locationUpdateSourceKind,
+            locationManager: locationManager,
+            lowPowerLocationManager: lowPowerLocationManager
+        )
     }
 }

--- a/RadarSDK/RadarSettings.h
+++ b/RadarSDK/RadarSettings.h
@@ -84,6 +84,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setTags:(NSArray<NSString *> * _Nullable)tags;
 + (void)addTags:(NSArray<NSString *> * _Nonnull)tags;
 + (void)removeTags:(NSArray<NSString *> * _Nonnull)tags;
++ (BOOL)locationManagerSwiftMigrationEnabled;
++ (void)setLocationManagerSwiftMigrationEnabled:(BOOL)locationManagerSwiftMigrationEnabled;
 
 @end
 

--- a/RadarSDK/RadarSettings.swift
+++ b/RadarSDK/RadarSettings.swift
@@ -144,6 +144,11 @@ internal class RadarSettings: NSObject {
         get { return RadarUserDefaults.bool(forKey: .Tracking) }
         set { RadarUserDefaults.set(newValue, forKey: .Tracking) }
     }
+
+    static var locationManagerSwiftMigrationEnabled: Bool {
+        get { RadarUserDefaults.bool(forKey: .LocationManagerSwiftMigrationEnabled) }
+        set { RadarUserDefaults.set(newValue, forKey: .LocationManagerSwiftMigrationEnabled) }
+    }
     
     public static var trackingOptions: RadarTrackingOptions! {
         get {

--- a/RadarSDK/RadarUserDefaults.swift
+++ b/RadarSDK/RadarUserDefaults.swift
@@ -45,6 +45,7 @@ class RadarUserDefaults: NSObject {
         case LocationExtensionToken = "radar-locationExtensionToken"
         case InSurveyMode = "radar-inSurveyMode"
         case AppGroup = "radar-appGroup"
+        case LocationManagerSwiftMigrationEnabled = "radar-locationManagerSwiftMigrationEnabled"
         
         // RadarState
         case LastLocation = "radar-lastLocation"

--- a/RadarSDKTests/RadarLocationManagerMigrationTests.swift
+++ b/RadarSDKTests/RadarLocationManagerMigrationTests.swift
@@ -1,0 +1,28 @@
+//
+//  RadarLocationManagerMigrationTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Testing
+@testable import RadarSDK
+
+@Suite(.serialized)
+actor RadarLocationManagerMigrationTests {
+    @Test("Location manager Swift migration flag defaults off")
+    func migrationFlagDefaultsOff() {
+        RadarUserDefaults.set(nil, forKey: .LocationManagerSwiftMigrationEnabled)
+
+        #expect(RadarSettings.locationManagerSwiftMigrationEnabled == false)
+    }
+
+    @Test("Location manager Swift migration flag round trips")
+    func migrationFlagRoundTrips() {
+        RadarSettings.locationManagerSwiftMigrationEnabled = true
+        #expect(RadarSettings.locationManagerSwiftMigrationEnabled == true)
+
+        RadarSettings.locationManagerSwiftMigrationEnabled = false
+        #expect(RadarSettings.locationManagerSwiftMigrationEnabled == false)
+    }
+}

--- a/RadarSDKTests/RadarLocationManagerMigrationTests.swift
+++ b/RadarSDKTests/RadarLocationManagerMigrationTests.swift
@@ -40,6 +40,14 @@ actor RadarLocationManagerMigrationTests {
 
         #expect(implementation.locationUpdateSourceKind == .coreLocationManager)
         #expect(implementation.locationUpdateSource is RadarCoreLocationUpdateSource)
+        #expect(implementation.locationMonitoringKind == .locationManager)
+        #expect(implementation.locationMonitoring is RadarLocationManagerMonitoring)
+        #expect(implementation.locationAuthorizationKind == .locationManager)
+        #expect(implementation.locationAuthorizationController is RadarLocationManagerAuthorizationController)
+        #expect(implementation.locationBackgroundSessionKind == .none)
+        #expect(implementation.locationBackgroundSessionController is RadarNoopLocationBackgroundSessionController)
+        #expect(implementation.locationDiagnosticsKind == .legacy)
+        #expect(implementation.locationDiagnosticsProvider is RadarLegacyLocationDiagnosticsProvider)
     }
 
     @Test("Location manager implementation can select a live updates source")
@@ -59,6 +67,52 @@ actor RadarLocationManagerMigrationTests {
         } else {
             #expect(implementation.locationUpdateSource is RadarCoreLocationUpdateSource)
         }
+    }
+
+    @Test("Location manager implementation can select future location platform collaborators")
+    func implementationCanSelectFutureLocationPlatformCollaborators() {
+        let implementation = RadarLocationManagerImplementation()
+        let locationManager = CLLocationManager()
+        let lowPowerLocationManager = CLLocationManager()
+
+        implementation.configure(
+            locationManager: locationManager,
+            lowPowerLocationManager: lowPowerLocationManager
+        )
+        implementation.setLocationMonitoringKind(.conditionMonitoring)
+        implementation.setLocationAuthorizationKind(.serviceSession)
+        implementation.setLocationBackgroundSessionKind(.backgroundActivitySession)
+        implementation.setLocationDiagnosticsKind(.serviceSession)
+
+        if #available(iOS 17.0, *) {
+            #expect(implementation.locationMonitoring is RadarConditionMonitoring)
+            #expect(implementation.locationAuthorizationController is RadarServiceSessionAuthorizationController)
+            #expect(implementation.locationBackgroundSessionController is RadarBackgroundActivitySessionController)
+            #expect(implementation.locationDiagnosticsProvider is RadarServiceSessionDiagnosticsProvider)
+        } else {
+            #expect(implementation.locationMonitoring is RadarLocationManagerMonitoring)
+            #expect(implementation.locationAuthorizationController is RadarLocationManagerAuthorizationController)
+            #expect(implementation.locationBackgroundSessionController is RadarNoopLocationBackgroundSessionController)
+            #expect(implementation.locationDiagnosticsProvider is RadarLegacyLocationDiagnosticsProvider)
+        }
+    }
+
+    @Test("Location manager legacy diagnostics snapshot reflects current authorization state")
+    func legacyDiagnosticsSnapshotDefaults() {
+        let implementation = RadarLocationManagerImplementation()
+        let locationManager = CLLocationManager()
+        let lowPowerLocationManager = CLLocationManager()
+
+        implementation.configure(
+            locationManager: locationManager,
+            lowPowerLocationManager: lowPowerLocationManager
+        )
+
+        let snapshot = implementation.locationDiagnosticsProvider?.diagnosticsSnapshot()
+
+        #expect(snapshot != nil)
+        #expect(snapshot?.insufficientlyInUse == false)
+        #expect(snapshot?.serviceSessionRequired == false)
     }
 
     @Test("Location manager facade owns both injected CLLocationManager delegates")

--- a/RadarSDKTests/RadarLocationManagerMigrationTests.swift
+++ b/RadarSDKTests/RadarLocationManagerMigrationTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import CoreLocation
 @testable import RadarSDK
 
 @Suite(.serialized)
@@ -24,5 +25,52 @@ actor RadarLocationManagerMigrationTests {
 
         RadarSettings.locationManagerSwiftMigrationEnabled = false
         #expect(RadarSettings.locationManagerSwiftMigrationEnabled == false)
+    }
+
+    @Test("Location manager implementation defaults to a CLLocationManager source")
+    func implementationDefaultsToCoreLocationManagerSource() {
+        let implementation = RadarLocationManagerImplementation()
+        let locationManager = CLLocationManager()
+        let lowPowerLocationManager = CLLocationManager()
+
+        implementation.configure(
+            locationManager: locationManager,
+            lowPowerLocationManager: lowPowerLocationManager
+        )
+
+        #expect(implementation.locationUpdateSourceKind == .coreLocationManager)
+        #expect(implementation.locationUpdateSource is RadarCoreLocationUpdateSource)
+    }
+
+    @Test("Location manager implementation can select a live updates source")
+    func implementationCanSelectLiveUpdatesSource() {
+        let implementation = RadarLocationManagerImplementation()
+        let locationManager = CLLocationManager()
+        let lowPowerLocationManager = CLLocationManager()
+
+        implementation.configure(
+            locationManager: locationManager,
+            lowPowerLocationManager: lowPowerLocationManager
+        )
+        implementation.setLocationUpdateSourceKind(.liveUpdates)
+
+        if #available(iOS 17.0, *) {
+            #expect(implementation.locationUpdateSource is RadarLiveLocationUpdateSource)
+        } else {
+            #expect(implementation.locationUpdateSource is RadarCoreLocationUpdateSource)
+        }
+    }
+
+    @Test("Location manager facade owns both injected CLLocationManager delegates")
+    func facadeOwnsInjectedLocationManagerDelegates() {
+        let locationManager = RadarLocationManager()
+        let standardManager = CLLocationManager()
+        let lowPowerManager = CLLocationManager()
+
+        locationManager.locationManager = standardManager
+        locationManager.lowPowerLocationManager = lowPowerManager
+
+        #expect(standardManager.delegate === locationManager)
+        #expect(lowPowerManager.delegate === locationManager)
     }
 }


### PR DESCRIPTION
## Summary
- add a private backend seam to keep RadarLocationManager as the stable Objective-C facade during the migration
- add the internal-only Swift migration flag and stub Swift backend for future capability routing
- add initial migration flag tests and wire the new files into the Xcode project

## Testing
- attempted xcodebuild -project RadarSDK.xcodeproj -scheme RadarSDK -sdk iphonesimulator -derivedDataPath /private/tmp/radar-sdk-ios-derived CODE_SIGNING_ALLOWED=NO build
- build is currently blocked by an unrelated existing SwiftUI preview macro failure in RadarInAppMessageView.swift