### PR TITLE
Add `useSwiftLocationManager` server config flag (1/N)

### DIFF
--- a/RadarSDK/RadarSdkConfiguration.h
+++ b/RadarSDK/RadarSdkConfiguration.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)skipForegroundCheck;
 - (BOOL)useOfflineRTOUpdates;
 - (BOOL)offlineEventGenerationEnabled;
+- (BOOL)useSwiftLocationManager;
 - (NSArray<RadarRemoteTrackingOptions *> *_Nullable)remoteTrackingOptions;
 - (instancetype)initWithDict:(NSDictionary *_Nullable)dict;
 - (NSDictionary *)dictionaryValue;

--- a/RadarSDK/RadarSdkConfiguration.swift
+++ b/RadarSDK/RadarSdkConfiguration.swift
@@ -68,6 +68,7 @@ class RadarSdkConfiguration: NSObject {
     let skipForegroundCheck: Bool
     let useOfflineRTOUpdates: Bool
     let offlineEventGenerationEnabled: Bool
+    let useSwiftLocationManager: Bool
     let remoteTrackingOptions: [RadarRemoteTrackingOptions]?
     
     public init(dict: [String: Any]?) {
@@ -92,6 +93,7 @@ class RadarSdkConfiguration: NSObject {
         skipForegroundCheck = dict?["skipForegroundCheck"] as? Bool ?? true
         useOfflineRTOUpdates = dict?["useOfflineRTOUpdates"] as? Bool ?? false
         offlineEventGenerationEnabled = dict?["offlineEventGenerationEnabled"] as? Bool ?? false
+        useSwiftLocationManager = dict?["useSwiftLocationManager"] as? Bool ?? false
         remoteTrackingOptions = RadarRemoteTrackingOptions.from(array: dict?["remoteTrackingOptions"] as? [[String: Any]])
     }
     
@@ -120,6 +122,7 @@ class RadarSdkConfiguration: NSObject {
             "skipForegroundCheck": skipForegroundCheck,
             "useOfflineRTOUpdates": useOfflineRTOUpdates,
             "offlineEventGenerationEnabled": offlineEventGenerationEnabled,
+            "useSwiftLocationManager": useSwiftLocationManager,
             "remoteTrackingOptions": RadarRemoteTrackingOptions.toDictionaries(remoteTrackingOptions) as Any
         ]
     }

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -2336,10 +2336,28 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
         @"skipForegroundCheck": @(NO)
     }];
     XCTAssertFalse(explicitFalse.skipForegroundCheck);
-    
+
     RadarSdkConfiguration *explicitTrue = [[RadarSdkConfiguration alloc] initWithDict:@{
         @"skipForegroundCheck": @(YES)
     }];
     XCTAssertTrue(explicitTrue.skipForegroundCheck);
+}
+
+- (void)test_RadarSdkConfiguration_useSwiftLocationManagerDefault {
+    RadarSdkConfiguration *defaults = [[RadarSdkConfiguration alloc] initWithDict:@{}];
+    XCTAssertFalse(defaults.useSwiftLocationManager, @"useSwiftLocationManager should default to false");
+
+    RadarSdkConfiguration *explicitTrue = [[RadarSdkConfiguration alloc] initWithDict:@{
+        @"useSwiftLocationManager": @(YES)
+    }];
+    XCTAssertTrue(explicitTrue.useSwiftLocationManager);
+
+    RadarSdkConfiguration *explicitFalse = [[RadarSdkConfiguration alloc] initWithDict:@{
+        @"useSwiftLocationManager": @(NO)
+    }];
+    XCTAssertFalse(explicitFalse.useSwiftLocationManager);
+
+    NSDictionary *roundTrip = [explicitTrue dictionaryValue];
+    XCTAssertEqualObjects(roundTrip[@"useSwiftLocationManager"], @(YES), @"flag should round-trip through dictionaryValue");
 }
 @end


### PR DESCRIPTION
## Summary

https://linear.app/radarlabs/issue/FENCE-2804/convert-radarlocationmanagerm-to-swift

First PR in a multi-step migration of `RadarLocationManager` from Objective-C to Swift with modernized CoreLocation APIs (`CLLocationUpdate.liveUpdates`, `CLMonitor`, `CLBackgroundActivitySession`).

This PR is **plumbing only** — adds a server-driven feature flag in `RadarSdkConfiguration` that future PRs will use to route between the existing ObjC manager and a new Swift implementation. No behavior change.

### Changes
- `RadarSdkConfiguration.swift` — add `useSwiftLocationManager: Bool` (defaults to `false`), parse from dict, include in `dictionaryValue()`
- `RadarSdkConfiguration.h` — declare the property so ObjC consumers can read it
- `RadarSDKTests.m` — `test_RadarSdkConfiguration_useSwiftLocationManagerDefault` covers default, explicit-true, explicit-false, and dictionary round-trip

### Why server-controlled
Matches the pattern already used by `useSyncRegion`, `useOfflineRTOUpdates`, etc. Lets us stage rollout (0% → small % → 100%) and revert instantly without an SDK release if the new Swift path regresses.

### What comes next

**[See the full implementation plan in Notion](https://www.notion.so/radarlabs/Migrate-RadarLocationManager-to-Swift-modernize-CoreLocation-APIs-359e42b18f9680ccb0a5c425e4d210bb?source=copy_link)** **Please look at this, this is what I would like the most feedback on.**

The Swift implementation will be gated on `#available(iOS 17, *)` AND the flag; iOS <17 keeps the existing ObjC manager until we bump the min version to iOS 17.