### PR TITLE
FENCE-2834: Update release actions for Node 24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULESTOKEN }}

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULESTOKEN }}
@@ -82,15 +82,15 @@ jobs:
       # get sha256 checksum of the XCFramework
       - name: Get SHA256 checksum (RadarSDK)
         id: checksum_radarsdk
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDK.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "checksum=$(shasum -a 256 RadarSDK.xcframework.zip | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
       
       - name: Get SHA256 checksum (RadarSDKMotion)
         id: checksum_radarsdkmotion
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDKMotion.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "checksum=$(shasum -a 256 RadarSDKMotion.xcframework.zip | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - name: Get SHA256 checksum (RadarSDKIndoors)
         id: checksum_radarsdkindoors
-        run: echo "::set-output name=checksum::$(shasum -a 256 RadarSDKIndoors.xcframework.zip | cut -d ' ' -f 1)"
+        run: echo "checksum=$(shasum -a 256 RadarSDKIndoors.xcframework.zip | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - name: Repository Dispatch
         if: ${{ !github.event.release.prerelease }}

--- a/.github/workflows/sync-to-linear.yml
+++ b/.github/workflows/sync-to-linear.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Linear Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow pins from Node 20-era majors to Node 24-compatible versions
- replace deprecated set-output usage in the iOS release workflow
- keep the change scoped to workflow maintenance for FENCE-2834


