### PR TITLE
trigger release on beta as well

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -93,7 +93,6 @@ jobs:
         run: echo "checksum=$(shasum -a 256 RadarSDKIndoors.xcframework.zip | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - name: Repository Dispatch
-        if: ${{ !github.event.release.prerelease }}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.SUBMODULESTOKEN }}


### PR DESCRIPTION
I believe originally we didn't trigger SPM release on beta because it was fully automated, and most of the time beta testing don't need to go on SPM, we just needed a pod release to test with RN to make sure things are working. 

But now the SPM release is semi automated, this is safe to trigger automatically for beta.