### PR TITLE
consolidate geofence swift

### DIFF
--- a/RadarSDK/RadarCoordinate.swift
+++ b/RadarSDK/RadarCoordinate.swift
@@ -9,7 +9,7 @@
 import CoreLocation
 import Foundation
 
-struct RadarCoordinateSwift: Codable, Sendable {
+struct RadarCoordinateSwift: Codable, Sendable, Equatable {
     let latitude: Double
     let longitude: Double
 

--- a/RadarSDK/RadarGeofence.swift
+++ b/RadarSDK/RadarGeofence.swift
@@ -149,42 +149,6 @@ private struct GeoJSONPolygon: Codable, Sendable {
     let coordinates: [[[Double]]]
 }
 
-// MARK: - ObjC Bridge Types
-
-struct RadarCoordinateCodable: Codable, Sendable, Equatable {
-    static func == (lhs: RadarCoordinateCodable, rhs: RadarCoordinateCodable) -> Bool {
-        return lhs.coordinate.latitude == rhs.coordinate.latitude && lhs.coordinate.longitude == rhs.coordinate.longitude
-    }
-
-    let coordinate: CLLocationCoordinate2D
-
-    private enum CodingKeys: String, CodingKey {
-        case coordinates
-    }
-
-    init(coordinate: CLLocationCoordinate2D) {
-        self.coordinate = coordinate
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let pair = try container.decode([Double].self, forKey: .coordinates)
-        guard pair.count == 2 else {
-            throw DecodingError.dataCorruptedError(
-                forKey: .coordinates,
-                in: container,
-                debugDescription: "Expected [longitude, latitude]")
-        }
-        self.coordinate = CLLocationCoordinate2D(latitude: pair[1], longitude: pair[0])
-
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode([coordinate.longitude, coordinate.latitude], forKey: .coordinates)
-    }
-}
-
 enum RadarMetadataValue: Codable, Sendable, Hashable {
     case string(String)
     case int(Int)

--- a/RadarSDK/RadarGeofence.swift
+++ b/RadarSDK/RadarGeofence.swift
@@ -27,19 +27,19 @@ enum RadarGeofenceGeometrySwift: Codable, Sendable, Equatable {
         case .polygon(_, _, let radius): return radius
         }
     }
-    
+
     static func == (lhs: RadarGeofenceGeometrySwift, rhs: RadarGeofenceGeometrySwift) -> Bool {
         if case .circle(let lhsCenter, let lhsRadius) = lhs,
            case .circle(let rhsCenter, let rhsRadius) = rhs {
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
         }
-        
+
         // maybe this should check for coordinates match as well, but for notification purposes, center + radius is enough
         if case .polygon(_, let lhsCenter, let lhsRadius) = lhs,
            case .polygon(_, let rhsCenter, let rhsRadius) = rhs {
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
         }
-        
+
         // types don't match, not both circular or both polygonal
         return false
     }
@@ -96,7 +96,7 @@ struct RadarGeofenceSwift: Codable, Sendable, Equatable {
         default:
             geometry = .circle(center: center, radius: radius)
         }
-        
+
         metadata = try container.decodeIfPresent([String: RadarMetadataValue].self, forKey: .metadata)
     }
 
@@ -136,7 +136,7 @@ struct RadarGeofenceSwift: Codable, Sendable, Equatable {
             let ring = coords.map { [$0.longitude, $0.latitude] }
             try container.encode(GeoJSONPolygon(coordinates: [ring]), forKey: .geometry)
         }
-        
+
         try container.encode(metadata, forKey: .metadata)
     }
 }

--- a/RadarSDK/RadarGeofence.swift
+++ b/RadarSDK/RadarGeofence.swift
@@ -29,19 +29,17 @@ enum RadarGeofenceGeometrySwift: Codable, Sendable, Equatable {
     }
 
     static func == (lhs: RadarGeofenceGeometrySwift, rhs: RadarGeofenceGeometrySwift) -> Bool {
-        if case .circle(let lhsCenter, let lhsRadius) = lhs,
-           case .circle(let rhsCenter, let rhsRadius) = rhs {
+        switch (lhs, rhs) {
+        case let (.circle(lhsCenter, lhsRadius),
+                  .circle(rhsCenter, rhsRadius)):
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
-        }
-
-        // maybe this should check for coordinates match as well, but for notification purposes, center + radius is enough
-        if case .polygon(_, let lhsCenter, let lhsRadius) = lhs,
-           case .polygon(_, let rhsCenter, let rhsRadius) = rhs {
+        case let (.polygon(_, lhsCenter, lhsRadius),
+                  .polygon(_, rhsCenter, rhsRadius)):
+            // maybe this should check for coordinates match as well, but for notification purposes, center + radius is enough
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
+        default:
+            return false
         }
-
-        // types don't match, not both circular or both polygonal
-        return false
     }
 }
 

--- a/RadarSDK/RadarGeofence.swift
+++ b/RadarSDK/RadarGeofence.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - Sync Region Types
 
-enum RadarGeofenceGeometrySwift: Codable, Sendable {
+enum RadarGeofenceGeometrySwift: Codable, Sendable, Equatable {
     case circle(center: RadarCoordinateSwift, radius: Double)
     case polygon(coordinates: [RadarCoordinateSwift], center: RadarCoordinateSwift, radius: Double)
 
@@ -27,9 +27,25 @@ enum RadarGeofenceGeometrySwift: Codable, Sendable {
         case .polygon(_, _, let radius): return radius
         }
     }
+    
+    static func == (lhs: RadarGeofenceGeometrySwift, rhs: RadarGeofenceGeometrySwift) -> Bool {
+        if case .circle(let lhsCenter, let lhsRadius) = lhs,
+           case .circle(let rhsCenter, let rhsRadius) = rhs {
+            return lhsCenter == rhsCenter && lhsRadius == rhsRadius
+        }
+        
+        // maybe this should check for coordinates match as well, but for notification purposes, center + radius is enough
+        if case .polygon(_, let lhsCenter, let lhsRadius) = lhs,
+           case .polygon(_, let rhsCenter, let rhsRadius) = rhs {
+            return lhsCenter == rhsCenter && lhsRadius == rhsRadius
+        }
+        
+        // types don't match, not both circular or both polygonal
+        return false
+    }
 }
 
-struct RadarGeofenceSwift: Codable, Sendable {
+struct RadarGeofenceSwift: Codable, Sendable, Equatable {
     let id: String
     let description: String
     let tag: String?
@@ -37,6 +53,7 @@ struct RadarGeofenceSwift: Codable, Sendable {
     let geometry: RadarGeofenceGeometrySwift
     let dwellThreshold: Double?
     let geofenceStopDetection: Bool?
+    let metadata: [String: RadarMetadataValue]?
 
     enum CodingKeys: String, CodingKey {
         case id = "_id"
@@ -49,6 +66,7 @@ struct RadarGeofenceSwift: Codable, Sendable {
         case geometry
         case dwellThreshold
         case stopDetection
+        case metadata
     }
 
     init(from decoder: Decoder) throws {
@@ -78,11 +96,14 @@ struct RadarGeofenceSwift: Codable, Sendable {
         default:
             geometry = .circle(center: center, radius: radius)
         }
+        
+        metadata = try container.decodeIfPresent([String: RadarMetadataValue].self, forKey: .metadata)
     }
 
     init(
         id: String, description: String, tag: String?, externalId: String?,
-        geometry: RadarGeofenceGeometrySwift, dwellThreshold: Double?, geofenceStopDetection: Bool?
+        geometry: RadarGeofenceGeometrySwift, dwellThreshold: Double?, geofenceStopDetection: Bool?,
+        metadata: [String: RadarMetadataValue]?
     ) {
         self.id = id
         self.description = description
@@ -91,6 +112,7 @@ struct RadarGeofenceSwift: Codable, Sendable {
         self.geometry = geometry
         self.dwellThreshold = dwellThreshold
         self.geofenceStopDetection = geofenceStopDetection
+        self.metadata = metadata
     }
 
     func encode(to encoder: Encoder) throws {
@@ -114,6 +136,8 @@ struct RadarGeofenceSwift: Codable, Sendable {
             let ring = coords.map { [$0.longitude, $0.latitude] }
             try container.encode(GeoJSONPolygon(coordinates: [ring]), forKey: .geometry)
         }
+        
+        try container.encode(metadata, forKey: .metadata)
     }
 }
 
@@ -199,28 +223,4 @@ enum RadarMetadataValue: Codable, Sendable, Hashable {
             return nil
         }
     }
-}
-
-/// This is a geofence from the raw dictionary conversion of RadarGeofence in ObjC.
-struct RadarGeofence_Swift: Codable, Sendable, Equatable {
-
-    /// The Radar ID of the geofence.
-    public let _id: String
-
-    /// The description of the geofence. Not to be confused with the `NSObject` `description` property.
-    public let description: String?
-
-    /// The tag of the geofence.
-    public let tag: String?
-
-    /// The external ID of the geofence.
-    public let externalId: String?
-
-    /// The optional set of custom key-value pairs for the geofence.
-    public let metadata: [String: RadarMetadataValue]?
-
-    /// The geometry of the geofence, which can be cast to either `RadarCircleGeometry` or `RadarPolygonGeometry`.
-    public let geometryCenter: RadarCoordinateCodable
-
-    public let geometryRadius: Double
 }

--- a/RadarSDK/RadarGeofence.swift
+++ b/RadarSDK/RadarGeofence.swift
@@ -30,11 +30,15 @@ enum RadarGeofenceGeometrySwift: Codable, Sendable, Equatable {
 
     static func == (lhs: RadarGeofenceGeometrySwift, rhs: RadarGeofenceGeometrySwift) -> Bool {
         switch (lhs, rhs) {
-        case let (.circle(lhsCenter, lhsRadius),
-                  .circle(rhsCenter, rhsRadius)):
+        case let (
+            .circle(lhsCenter, lhsRadius),
+            .circle(rhsCenter, rhsRadius)
+        ):
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
-        case let (.polygon(_, lhsCenter, lhsRadius),
-                  .polygon(_, rhsCenter, rhsRadius)):
+        case let (
+            .polygon(_, lhsCenter, lhsRadius),
+            .polygon(_, rhsCenter, rhsRadius)
+        ):
             // maybe this should check for coordinates match as well, but for notification purposes, center + radius is enough
             return lhsCenter == rhsCenter && lhsRadius == rhsRadius
         default:

--- a/RadarSDK/RadarNotification.swift
+++ b/RadarSDK/RadarNotification.swift
@@ -57,9 +57,9 @@ struct RadarNotificationContent: Sendable, Hashable {
     }
 }
 
-extension RadarGeofence_Swift {
+extension RadarGeofenceSwift {
     func toNotificationRequest(now: Date = Date()) -> UNNotificationRequest? {
-        let identifier = GEOFENCE_NOTIFICATION_PREFIX + _id
+        let identifier = GEOFENCE_NOTIFICATION_PREFIX + id
         // Content
         guard let metadata = metadata,
             let metadataContent = RadarNotificationContent(from: metadata)
@@ -72,15 +72,15 @@ extension RadarGeofence_Swift {
         let userInfo: [String: Any] = [
             "registeredAt": now.timeIntervalSince1970,
             "identifier": identifier,
-            "geofenceId": _id,
+            "geofenceId": id,
             "geofenceData": geofenceData,
         ]
         let content = metadataContent.toNotificationContent(userInfo: userInfo)
 
         // Trigger
-        let latitude = geometryCenter.coordinate.latitude
-        let longitude = geometryCenter.coordinate.longitude
-        let radius = geometryRadius
+        let latitude = geometry.center.latitude
+        let longitude = geometry.center.longitude
+        let radius = geometry.radius
         let center = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
         let region = CLCircularRegion(center: center, radius: radius, identifier: identifier)
         let repeats = if case let .bool(value)? = metadata["radar:notificationRepeats"] { value } else { false }

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -29,7 +29,7 @@ extension UNUserNotificationCenter: NotificationCenterProtocol {
 @objc(RadarNotificationHelper_Swift) @objcMembers
 actor RadarNotificationHelper: NSObject {
 
-    private var currentTask: Task<Void, Never>? = nil
+    private var currentTask: Task<Void, Never>?
     private var isRegistering: Bool = false
 
     public static let shared = RadarNotificationHelper()

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -50,7 +50,7 @@ actor RadarNotificationHelper: NSObject {
         let now = Date()
         let notifications: [UNNotificationRequest] = geofences.compactMap { (geofenceDict) -> UNNotificationRequest? in
             if let json = try? JSONSerialization.data(withJSONObject: geofenceDict),
-                let geofence = try? JSONDecoder().decode(RadarGeofence_Swift.self, from: json),
+                let geofence = try? JSONDecoder().decode(RadarGeofenceSwift.self, from: json),
                 let notification = geofence.toNotificationRequest(now: now)
             {
                 return notification

--- a/RadarSDKTests/RadarOfflineEventManagerTests.swift
+++ b/RadarSDKTests/RadarOfflineEventManagerTests.swift
@@ -97,7 +97,7 @@ extension RadarSerializedTests {
             // offlineGeofenceIds should still be empty since handleTrackFailure was a no-op.
             // Verify by calling generateEvents: it should use baseline IDs (lastSyncedGeofenceIds = []),
             // meaning the geofence is detected as an entry (not suppressed by prior state).
-            RadarOfflineEventManager.generateEvents(location: location) { events, _, _ in
+            RadarOfflineEventManager.generateEvents(location: location) { _, _, _ in
                 // If handleTrackFailure had run, offlineGeofenceIds would contain "test"
                 // and this second call would detect no state change (empty events).
                 // Since it didn't run, we're still using baseline IDs, so entry is detected.
@@ -251,7 +251,7 @@ extension RadarSerializedTests {
             let location = CLLocation(latitude: testLat, longitude: testLng)
 
             await withCheckedContinuation { continuation in
-                RadarOfflineEventManager.generateEvents(location: location) { events, user, loc in
+                RadarOfflineEventManager.generateEvents(location: location) { events, user, _ in
                     #expect(events.count > 0 || user == nil)  // events generated but user/event creation depends on bridge
                     continuation.resume()
                 }
@@ -271,7 +271,7 @@ extension RadarSerializedTests {
             let location = CLLocation(latitude: testLat, longitude: testLng)
 
             await withCheckedContinuation { continuation in
-                RadarOfflineEventManager.generateEvents(location: location) { events, user, loc in
+                RadarOfflineEventManager.generateEvents(location: location) { _, _, _ in
                     continuation.resume()
                 }
             }
@@ -288,7 +288,7 @@ extension RadarSerializedTests {
             let location = CLLocation(latitude: testLat, longitude: testLng)
 
             await withCheckedContinuation { continuation in
-                RadarOfflineEventManager.generateEvents(location: location) { events, user, loc in
+                RadarOfflineEventManager.generateEvents(location: location) { events, _, _ in
                     #expect(events.isEmpty)
                     continuation.resume()
                 }

--- a/RadarSDKTests/RadarOfflineEventManagerTests.swift
+++ b/RadarSDKTests/RadarOfflineEventManagerTests.swift
@@ -34,7 +34,7 @@ extension RadarSerializedTests {
             return RadarGeofenceSwift(
                 id: id, description: "Test Geofence", tag: tag, externalId: id,
                 geometry: .circle(center: center, radius: radius),
-                dwellThreshold: nil, geofenceStopDetection: nil
+                dwellThreshold: nil, geofenceStopDetection: nil, metadata: nil
             )
         }
 

--- a/RadarSDKTests/RadarSyncManagerTests.swift
+++ b/RadarSDKTests/RadarSyncManagerTests.swift
@@ -40,7 +40,7 @@ extension RadarSerializedTests {
             return RadarGeofenceSwift(
                 id: id, description: "Test Geofence", tag: "test", externalId: id,
                 geometry: .circle(center: center, radius: radius),
-                dwellThreshold: dwellThreshold, geofenceStopDetection: stopDetection
+                dwellThreshold: dwellThreshold, geofenceStopDetection: stopDetection, metadata: nil
             )
         }
 
@@ -52,7 +52,7 @@ extension RadarSerializedTests {
             return RadarGeofenceSwift(
                 id: id, description: "Test Polygon", tag: "test", externalId: id,
                 geometry: .polygon(coordinates: coords, center: center, radius: radius),
-                dwellThreshold: nil, geofenceStopDetection: nil
+                dwellThreshold: nil, geofenceStopDetection: nil, metadata: nil
             )
         }
 

--- a/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
+++ b/RadarSDKTests/RadarVerifiedHostOverrideTests.swift
@@ -7,6 +7,7 @@
 
 import CoreLocation
 import XCTest
+
 @testable import RadarSDK
 
 final class RadarVerifiedHostOverrideTests: XCTestCase {


### PR DESCRIPTION
we had RadarGeofenceSwift for event sync and RadarGeofence_Swift for notifications, RadarGeofenceSwift was missing metadata, added that so it can be consolidated.

see https://github.com/radarlabs/radar-sdk-ios/pull/569
The other PR got a little messy with merge conflicts, so I've re-done the consolidation on main.

https://linear.app/radarlabs/issue/FENCE-2853/swift-geofence-clean-up