### PR TITLE
FENCE-2804: Port region/beacon sync and lifecycle methods to Swift (3/N)

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -158,6 +158,10 @@
 		BA3540222F90020F00E553A1 /* RadarOfflineEventManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BA3540212F90020900E553A1 /* RadarOfflineEventManager.h */; };
 		BA3540242F9033A900E553A1 /* RadarSerializedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */; };
 		B0A0F0032FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0072FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift */; };
+		B0A0F00C2FBC000100111111 /* TrackingCLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F00D2FBC000100111111 /* TrackingCLLocationManager.swift */; };
+		B0A0F00E2FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F00F2FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */; };
+		B0A0F0102FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0112FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */; };
+		B0A0F0122FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0132FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift */; };
 		BA46C1662F4CF3F200031891 /* RadarTripLeg.h in Headers */ = {isa = PBXBuildFile; fileRef = BA46C1652F4CF3E900031891 /* RadarTripLeg.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BA46C1682F4CF46600031891 /* RadarTripLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = BA46C1672F4CF45600031891 /* RadarTripLeg.m */; };
 		BA46C16A2F4E0A9000031891 /* trip_with_legs.json in Resources */ = {isa = PBXBuildFile; fileRef = BA46C1692F4E0A8300031891 /* trip_with_legs.json */; };
@@ -336,6 +340,10 @@
 		BA3540232F90339F00E553A1 /* RadarSerializedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSerializedTests.swift; sourceTree = "<group>"; };
 		B0A0F0062FBC000100111111 /* RadarLocationManager+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RadarLocationManager+Swift.swift"; sourceTree = "<group>"; };
 		B0A0F0072FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftSeamTests.swift; sourceTree = "<group>"; };
+		B0A0F00D2FBC000100111111 /* TrackingCLLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingCLLocationManager.swift; sourceTree = "<group>"; };
+		B0A0F00F2FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftRegionTests.swift; sourceTree = "<group>"; };
+		B0A0F0112FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftBeaconSyncTests.swift; sourceTree = "<group>"; };
+		B0A0F0132FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftTestHelpers.swift; sourceTree = "<group>"; };
 		B0A0F0092FBC000100111111 /* RadarLocationManagerSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarLocationManagerSwift.h; sourceTree = "<group>"; };
 		BA46C1652F4CF3E900031891 /* RadarTripLeg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarTripLeg.h; sourceTree = "<group>"; };
 		BA46C1672F4CF45600031891 /* RadarTripLeg.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RadarTripLeg.m; sourceTree = "<group>"; };
@@ -682,6 +690,10 @@
 				BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */,
 				BA46C16B2F4E0CEC00031891 /* RadarTripLegTest.m */,
 				B0A0F0072FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift */,
+				B0A0F00D2FBC000100111111 /* TrackingCLLocationManager.swift */,
+				B0A0F00F2FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */,
+				B0A0F0112FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */,
+				B0A0F0132FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
@@ -1111,6 +1123,10 @@
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,
 				DD8E2F7724018C25002D51AB /* RadarAPIHelperMock.m in Sources */,
 				B0A0F0032FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift in Sources */,
+				B0A0F00C2FBC000100111111 /* TrackingCLLocationManager.swift in Sources */,
+				B0A0F00E2FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift in Sources */,
+				B0A0F0102FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */,
+				B0A0F0122FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift in Sources */,
 				BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */,
 				96B465BC27D6732500D7119B /* CLLocation+RadarTests.m in Sources */,
 				DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */,

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+import CoreLocation
 import Foundation
 
 // Swift port of `RadarLocationManager` methods, added one at a time as the class
@@ -16,10 +17,19 @@ import Foundation
 // `RadarLocationManager.h` is a project-visibility header and is not in the framework's
 // auto-synthesized Swift module, so we cannot extend `RadarLocationManager` from Swift.
 // Static methods on this class are called from `RadarLocationManager.m` via
-// `RadarSDK-Swift.h`. When a method needs state from the manager instance, pass it in
-// via a small @objc protocol.
+// `RadarSDK-Swift.h`. Methods that need access to the manager's CLLocationManager(s)
+// receive them as explicit arguments — once the porting cluster grows enough to share
+// more instance state (timer, completion handlers), we can introduce a host protocol.
 @objc(RadarLocationManagerSwift)
 final class RadarLocationManagerSwift: NSObject {
+
+    // Mirror of the identifier prefix constants in RadarLocationManager.m. Kept in sync by
+    // hand until that file is fully ported.
+    private static let identifierPrefix = "radar_"
+    private static let bubbleGeofenceIdentifierPrefix = "radar_bubble_"
+    private static let syncGeofenceIdentifierPrefix = "radar_geofence_"
+    private static let syncBeaconIdentifierPrefix = "radar_beacon_"
+    private static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
 
     @objc static func restartPreviousTrackingOptions() {
         let previousTrackingOptions = RadarSettings.previousTrackingOptions
@@ -32,5 +42,170 @@ final class RadarLocationManagerSwift: NSObject {
         }
 
         RadarSettings.previousTrackingOptions = nil
+    }
+
+    @objc(matchBeaconIdsWithRanged:synced:)
+    static func matchBeaconIds(ranged: [RadarBeacon], synced: [RadarBeacon]) -> [String] {
+        var syncedMap: [String: String] = [:]
+        for beacon in synced {
+            let key = "\(beacon.uuid.lowercased())|\(beacon.major)|\(beacon.minor)"
+            if let id = beacon._id {
+                syncedMap[key] = id
+            }
+        }
+
+        var matched: [String] = []
+        for beacon in ranged {
+            let key = "\(beacon.uuid.lowercased())|\(beacon.major)|\(beacon.minor)"
+            if let matchedId = syncedMap[key] {
+                matched.append(matchedId)
+            }
+        }
+
+        RadarLogger.shared.log(
+            level: .info,
+            message: "Beacon ID matching | synced=\(syncedMap.count), ranged=\(ranged.count), matchedIds=\(matched)"
+        )
+        return matched
+    }
+
+    @objc(replaceBubbleGeofenceOnLocationManager:location:radius:)
+    static func replaceBubbleGeofence(locationManager: CLLocationManager, location: CLLocation, radius: Int32) {
+        removeBubbleGeofence(locationManager: locationManager)
+
+        guard RadarSettings.tracking else {
+            return
+        }
+
+        let identifier = "\(bubbleGeofenceIdentifierPrefix)\(UUID().uuidString)"
+        let region = CLCircularRegion(center: location.coordinate, radius: CLLocationDistance(radius), identifier: identifier)
+        locationManager.startMonitoring(for: region)
+        RadarLogger.shared.debug(
+            "Successfully added bubble geofence | latitude = \(location.coordinate.latitude); longitude = \(location.coordinate.longitude); radius = \(radius); identifier = \(identifier)"
+        )
+    }
+
+    @objc(removeBubbleGeofenceOnLocationManager:)
+    static func removeBubbleGeofence(locationManager: CLLocationManager) {
+        stopMonitoringRegions(on: locationManager, withIdentifierPrefix: bubbleGeofenceIdentifierPrefix)
+        RadarLogger.shared.debug("Removed bubble geofences")
+    }
+
+    @objc(removeSyncedGeofencesOnLocationManager:)
+    static func removeSyncedGeofences(locationManager: CLLocationManager) {
+        stopMonitoringRegions(on: locationManager, withIdentifierPrefix: syncGeofenceIdentifierPrefix)
+        RadarLogger.shared.debug("Removed synced geofences")
+    }
+
+    @objc(replaceSyncedBeaconsOnLocationManager:beacons:)
+    static func replaceSyncedBeacons(locationManager: CLLocationManager, beacons: [RadarBeacon]?) {
+        if RadarSettings.useRadarModifiedBeacon {
+            return
+        }
+
+        removeSyncedBeacons(locationManager: locationManager)
+
+        let options = Radar.getTrackingOptions()
+        guard RadarSettings.tracking, options.beacons, let beacons else {
+            RadarLogger.shared.debug("Skipping replacing synced beacons")
+            return
+        }
+
+        let numBeacons = min(beacons.count, 9)
+
+        for beacon in beacons.prefix(numBeacons) {
+            let identifier = "\(syncBeaconIdentifierPrefix)\(beacon._id ?? "")"
+            guard let proximityUUID = UUID(uuidString: beacon.uuid) else {
+                RadarLogger.shared.debug(
+                    "Error syncing beacon | identifier = \(identifier); uuid = \(beacon.uuid); major = \(beacon.major); minor = \(beacon.minor)"
+                )
+                continue
+            }
+
+            let major = CLBeaconMajorValue(truncatingIfNeeded: Int(beacon.major) ?? 0)
+            let minor = CLBeaconMinorValue(truncatingIfNeeded: Int(beacon.minor) ?? 0)
+            let region = CLBeaconRegion(
+                proximityUUID: proximityUUID,
+                major: major,
+                minor: minor,
+                identifier: identifier
+            )
+            region.notifyEntryStateOnDisplay = true
+            locationManager.startMonitoring(for: region)
+            locationManager.requestState(for: region)
+
+            RadarLogger.shared.debug(
+                "Synced beacon | identifier = \(identifier); uuid = \(beacon.uuid); major = \(beacon.major); minor = \(beacon.minor)"
+            )
+        }
+    }
+
+    @objc(replaceSyncedBeaconUUIDsOnLocationManager:uuids:)
+    static func replaceSyncedBeaconUUIDs(locationManager: CLLocationManager, uuids: [String]?) {
+        if RadarSettings.useRadarModifiedBeacon {
+            return
+        }
+
+        removeSyncedBeacons(locationManager: locationManager)
+
+        let options = Radar.getTrackingOptions()
+        guard RadarSettings.tracking, options.beacons, let uuids else {
+            return
+        }
+
+        let numUUIDs = min(uuids.count, 9)
+
+        for uuid in uuids.prefix(numUUIDs) {
+            let identifier = "\(syncBeaconUUIDIdentifierPrefix)\(uuid)"
+            guard let proximityUUID = UUID(uuidString: uuid) else {
+                RadarLogger.shared.debug("Error syncing UUID | identifier = \(identifier); uuid = \(uuid)")
+                continue
+            }
+
+            let region = CLBeaconRegion(proximityUUID: proximityUUID, identifier: identifier)
+            region.notifyEntryStateOnDisplay = true
+            locationManager.startMonitoring(for: region)
+            locationManager.requestState(for: region)
+
+            RadarLogger.shared.debug("Synced UUID | identifier = \(identifier); uuid = \(uuid)")
+        }
+    }
+
+    @objc(removeSyncedBeaconsOnLocationManager:)
+    static func removeSyncedBeacons(locationManager: CLLocationManager) {
+        if RadarSettings.useRadarModifiedBeacon {
+            return
+        }
+
+        for region in locationManager.monitoredRegions
+        where region.identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix)
+            || region.identifier.hasPrefix(syncBeaconIdentifierPrefix)
+        {
+            locationManager.stopMonitoring(for: region)
+        }
+    }
+
+    @objc(removeAllRegionsOnLocationManager:)
+    static func removeAllRegions(locationManager: CLLocationManager) {
+        stopMonitoringRegions(on: locationManager, withIdentifierPrefix: identifierPrefix)
+    }
+
+    @objc(requestLocationOnLocationManager:)
+    static func requestLocation(locationManager: CLLocationManager) {
+        RadarLogger.shared.debug("Requesting location")
+        locationManager.requestLocation()
+    }
+
+    @objc(shutDownWithLocationManager:lowPowerLocationManager:)
+    static func shutDown(locationManager: CLLocationManager, lowPowerLocationManager: CLLocationManager) {
+        RadarLogger.shared.debug("Shutting down")
+        locationManager.stopUpdatingLocation()
+        lowPowerLocationManager.stopUpdatingLocation()
+    }
+
+    private static func stopMonitoringRegions(on manager: CLLocationManager, withIdentifierPrefix prefix: String) {
+        for region in manager.monitoredRegions where region.identifier.hasPrefix(prefix) {
+            manager.stopMonitoring(for: region)
+        }
     }
 }

--- a/RadarSDK/RadarLocationManager.h
+++ b/RadarSDK/RadarLocationManager.h
@@ -5,14 +5,14 @@
 //  Copyright © 2019 Radar Labs, Inc. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <CoreMotion/CoreMotion.h>
+#import <Foundation/Foundation.h>
 
 #import "Radar.h"
+#import "RadarActivityManager.h"
 #import "RadarDelegate.h"
 #import "RadarMeta.h"
 #import "RadarPermissionsHelper.h"
-#import "RadarActivityManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateTracking;
 - (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta;
 - (void)updateTrackingFromInitialize;
-- (void)performIndoorScanIfConfigured:(CLLocation *)location 
-                               beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
-                     completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler;
+- (void)performIndoorScanIfConfigured:(CLLocation *)location
+                              beacons:(NSArray<RadarBeacon *> *_Nullable)beacons
+                    completionHandler:(void (^)(NSArray<RadarBeacon *> *_Nullable, NSString *_Nullable))completionHandler;
 
 /**
  If `[RadarSettings previousTrackingOptions]` is not `nil`, remove them and

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -296,6 +296,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)shutDown {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift shutDownWithLocationManager:self.locationManager lowPowerLocationManager:self.lowPowerLocationManager];
+        return;
+    }
+
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Shutting down"];
 
     [self.locationManager stopUpdatingLocation];
@@ -303,6 +308,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)requestLocation {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift requestLocationOnLocationManager:self.locationManager];
+        return;
+    }
+
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Requesting location"];
 
     [self.locationManager requestLocation];
@@ -547,6 +557,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceBubbleGeofence:(CLLocation *)location radius:(int)radius {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift replaceBubbleGeofenceOnLocationManager:self.locationManager location:location radius:radius];
+        return;
+    }
+
     [self removeBubbleGeofence];
 
     BOOL tracking = [RadarSettings tracking];
@@ -563,6 +578,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)removeBubbleGeofence {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift removeBubbleGeofenceOnLocationManager:self.locationManager];
+        return;
+    }
+
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kBubbleGeofenceIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -651,6 +671,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)removeSyncedGeofences {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift removeSyncedGeofencesOnLocationManager:self.locationManager];
+        return;
+    }
+
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kSyncGeofenceIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -661,6 +686,10 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (NSArray<NSString *> *)matchBeaconIds:(NSArray<RadarBeacon *> *)rangedBeacons syncedBeacons:(NSArray<RadarBeacon *> *)syncedBeacons {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        return [RadarLocationManagerSwift matchBeaconIdsWithRanged:rangedBeacons synced:syncedBeacons];
+    }
+
     NSMutableDictionary<NSString *, NSString *> *syncedMap = [NSMutableDictionary dictionary];
     for (RadarBeacon *sb in syncedBeacons) {
         NSString *key = [NSString stringWithFormat:@"%@|%@|%@", [sb.uuid lowercaseString] ?: @"", sb.major ?: @"", sb.minor ?: @""];
@@ -681,10 +710,15 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceSyncedBeacons:(NSArray<RadarBeacon *> *)beacons {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift replaceSyncedBeaconsOnLocationManager:self.locationManager beacons:beacons];
+        return;
+    }
+
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
-    
+
     [self removeSyncedBeacons];
 
     BOOL tracking = [RadarSettings tracking];
@@ -722,10 +756,15 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)replaceSyncedBeaconUUIDs:(NSArray<NSString *> *)uuids {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift replaceSyncedBeaconUUIDsOnLocationManager:self.locationManager uuids:uuids];
+        return;
+    }
+
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
-    
+
     [self removeSyncedBeacons];
 
     BOOL tracking = [RadarSettings tracking];
@@ -754,10 +793,15 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)removeSyncedBeacons {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift removeSyncedBeaconsOnLocationManager:self.locationManager];
+        return;
+    }
+
     if ([RadarSettings useRadarModifiedBeacon]) {
         return;
     }
-    
+
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];
@@ -768,6 +812,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)removeAllRegions {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift removeAllRegionsOnLocationManager:self.locationManager];
+        return;
+    }
+
     for (CLRegion *region in self.locationManager.monitoredRegions) {
         if ([region.identifier hasPrefix:kIdentifierPrefix]) {
             [self.locationManager stopMonitoringForRegion:region];

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -9,13 +9,39 @@
 //  imports this header and dispatches to these methods when useSwiftLocationManager is set.
 //
 
+#import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
+
+#import "RadarBeacon.h"
+#import "RadarGeofence.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RadarLocationManagerSwift : NSObject
 
 + (void)restartPreviousTrackingOptions;
+
++ (NSArray<NSString *> *)matchBeaconIdsWithRanged:(NSArray<RadarBeacon *> *)rangedBeacons
+                                           synced:(NSArray<RadarBeacon *> *)syncedBeacons;
+
++ (void)replaceBubbleGeofenceOnLocationManager:(CLLocationManager *)locationManager
+                                      location:(CLLocation *)location
+                                        radius:(int)radius;
++ (void)removeBubbleGeofenceOnLocationManager:(CLLocationManager *)locationManager;
+
++ (void)removeSyncedGeofencesOnLocationManager:(CLLocationManager *)locationManager;
+
++ (void)replaceSyncedBeaconsOnLocationManager:(CLLocationManager *)locationManager
+                                      beacons:(nullable NSArray<RadarBeacon *> *)beacons;
++ (void)replaceSyncedBeaconUUIDsOnLocationManager:(CLLocationManager *)locationManager
+                                            uuids:(nullable NSArray<NSString *> *)uuids;
++ (void)removeSyncedBeaconsOnLocationManager:(CLLocationManager *)locationManager;
+
++ (void)removeAllRegionsOnLocationManager:(CLLocationManager *)locationManager;
+
++ (void)requestLocationOnLocationManager:(CLLocationManager *)locationManager;
++ (void)shutDownWithLocationManager:(CLLocationManager *)locationManager
+              lowPowerLocationManager:(CLLocationManager *)lowPowerLocationManager;
 
 @end
 

--- a/RadarSDKTests/RadarLocationManagerSwiftBeaconSyncTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftBeaconSyncTests.swift
@@ -1,0 +1,263 @@
+//
+//  RadarLocationManagerSwiftBeaconSyncTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    actor RadarLocationManagerSwiftBeaconSyncTests {
+
+        // MARK: - replaceSyncedBeacons
+
+        @Test("replaceSyncedBeacons no-ops when useRadarModifiedBeacon is enabled")
+        func replaceSyncedBeaconsNoOpsWhenUseRadarModifiedBeacon() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": true
+            ])
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_beacon_existing"])
+            let beacons = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"
+                )
+            ]
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: beacons)
+
+            // Short-circuit before remove or add, so existing region is preserved untouched.
+            #expect(manager.trackedRegions.count == 1)
+        }
+
+        @Test("replaceSyncedBeacons removes existing beacons but skips adding when tracking is false")
+        func replaceSyncedBeaconsSkipsAddWhenNotTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = false
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_beacon_existing", "radar_uuid_existing"])
+            let beacons = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"
+                )
+            ]
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: beacons)
+
+            #expect(manager.trackedRegions.isEmpty)
+        }
+
+        @Test("replaceSyncedBeacons skips adding when options.beacons is false")
+        func replaceSyncedBeaconsSkipsAddWhenBeaconsOptionDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: false)
+
+            let manager = TrackingCLLocationManager()
+            let beacons = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"
+                )
+            ]
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: beacons)
+
+            #expect(manager.trackedRegions.isEmpty)
+        }
+
+        @Test("replaceSyncedBeacons skips adding when beacons is nil")
+        func replaceSyncedBeaconsSkipsAddWhenNilBeacons() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: nil)
+
+            #expect(manager.trackedRegions.isEmpty)
+        }
+
+        @Test("replaceSyncedBeacons adds one region per beacon (capped at 9) and requests state for each")
+        func replaceSyncedBeaconsAddsAndRequestsState() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            // 10 beacons — the implementation caps at 9.
+            let beacons = (0..<10).map { idx in
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "synced\(idx)",
+                    uuid: "1111111\(idx)-1111-1111-1111-111111111111",
+                    major: "1",
+                    minor: "\(idx)"
+                )
+            }
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: beacons)
+
+            let beaconRegions = manager.trackedRegions.filter { $0.identifier.hasPrefix("radar_beacon_") }
+            #expect(beaconRegions.count == 9)
+            #expect(manager.requestStateRegions.count == 9)
+        }
+
+        @Test("replaceSyncedBeacons skips beacons with an invalid UUID and continues with the rest")
+        func replaceSyncedBeaconsSkipsInvalidUUID() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            let beacons = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "valid", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"
+                ),
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "broken", uuid: "not-a-uuid", major: "1", minor: "2"
+                ),
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(
+                    id: "alsoValid", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"
+                ),
+            ]
+
+            RadarLocationManagerSwift.replaceSyncedBeacons(locationManager: manager, beacons: beacons)
+
+            let beaconRegions = manager.trackedRegions.filter { $0.identifier.hasPrefix("radar_beacon_") }
+            #expect(beaconRegions.count == 2)
+            #expect(beaconRegions.contains(where: { $0.identifier == "radar_beacon_valid" }))
+            #expect(beaconRegions.contains(where: { $0.identifier == "radar_beacon_alsoValid" }))
+        }
+
+        @Test("Public replaceSyncedBeacons routes to Swift twin when flag enabled")
+        func publicReplaceSyncedBeaconsRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useSwiftLocationManager": true,
+                "useRadarModifiedBeacon": true
+            ])
+
+            RadarLocationManager.sharedInstance().replaceSyncedBeacons([])
+        }
+
+        // MARK: - replaceSyncedBeaconUUIDs
+
+        @Test("replaceSyncedBeaconUUIDs no-ops when useRadarModifiedBeacon is enabled")
+        func replaceSyncedBeaconUUIDsNoOpsWhenUseRadarModifiedBeacon() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": true
+            ])
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_uuid_existing"])
+
+            RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(
+                locationManager: manager,
+                uuids: ["11111111-1111-1111-1111-111111111111"]
+            )
+
+            #expect(manager.trackedRegions.count == 1)
+        }
+
+        @Test("replaceSyncedBeaconUUIDs adds one region per UUID (capped at 9)")
+        func replaceSyncedBeaconUUIDsAddsAndCapsAtNine() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            let uuids = (0..<10).map { "1111111\($0)-1111-1111-1111-111111111111" }
+
+            RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(locationManager: manager, uuids: uuids)
+
+            let uuidRegions = manager.trackedRegions.filter { $0.identifier.hasPrefix("radar_uuid_") }
+            #expect(uuidRegions.count == 9)
+            #expect(manager.requestStateRegions.count == 9)
+        }
+
+        @Test("replaceSyncedBeaconUUIDs skips invalid UUIDs and continues")
+        func replaceSyncedBeaconUUIDsSkipsInvalidUUID() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            let uuids = [
+                "11111111-1111-1111-1111-111111111111",
+                "not-a-uuid",
+                "22222222-2222-2222-2222-222222222222"
+            ]
+
+            RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(locationManager: manager, uuids: uuids)
+
+            let uuidRegions = manager.trackedRegions.filter { $0.identifier.hasPrefix("radar_uuid_") }
+            #expect(uuidRegions.count == 2)
+        }
+
+        @Test("replaceSyncedBeaconUUIDs skips adding when not tracking")
+        func replaceSyncedBeaconUUIDsSkipsAddWhenNotTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = false
+            RadarSettings.trackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_uuid_existing"])
+
+            RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(
+                locationManager: manager,
+                uuids: ["11111111-1111-1111-1111-111111111111"]
+            )
+
+            // Existing removed, none added.
+            #expect(manager.trackedRegions.isEmpty)
+        }
+
+        // MARK: - requestLocation / shutDown
+
+        @Test("requestLocation forwards to the underlying location manager")
+        func requestLocationForwards() {
+            let manager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.requestLocation(locationManager: manager)
+
+            #expect(manager.requestLocationCallCount == 1)
+        }
+
+        @Test("shutDown stops updates on both the location manager and the low-power location manager")
+        func shutDownStopsUpdatesOnBothManagers() {
+            let manager = TrackingCLLocationManager()
+            let lowPowerManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.shutDown(
+                locationManager: manager,
+                lowPowerLocationManager: lowPowerManager
+            )
+
+            #expect(manager.stopUpdatingLocationCallCount == 1)
+            #expect(lowPowerManager.stopUpdatingLocationCallCount == 1)
+        }
+    }
+}

--- a/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
@@ -1,0 +1,160 @@
+//
+//  RadarLocationManagerSwiftRegionTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    actor RadarLocationManagerSwiftRegionTests {
+
+        // MARK: - replaceBubbleGeofence
+
+        @Test("replaceBubbleGeofence adds a radar_bubble_* region when tracking is true")
+        func replaceBubbleGeofenceAddsRegionWhenTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+
+            let manager = TrackingCLLocationManager()
+            let location = CLLocation(latitude: 40.0, longitude: -74.0)
+
+            RadarLocationManagerSwift.replaceBubbleGeofence(locationManager: manager, location: location, radius: 250)
+
+            #expect(manager.trackedRegions.count == 1)
+            let region = manager.trackedRegions.first
+            #expect(region?.identifier.hasPrefix("radar_bubble_") == true)
+            if let circle = region as? CLCircularRegion {
+                #expect(circle.radius == 250)
+                #expect(abs(circle.center.latitude - 40.0) < 0.0001)
+                #expect(abs(circle.center.longitude - -74.0) < 0.0001)
+            } else {
+                Issue.record("Expected CLCircularRegion")
+            }
+        }
+
+        @Test("replaceBubbleGeofence removes existing bubble but does not add a new one when not tracking")
+        func replaceBubbleGeofenceRemovesButDoesNotAddWhenNotTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = false
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_bubble_existing", "radar_geofence_keep"])
+
+            RadarLocationManagerSwift.replaceBubbleGeofence(
+                locationManager: manager,
+                location: CLLocation(latitude: 0, longitude: 0),
+                radius: 100
+            )
+
+            // Existing bubble removed, no new bubble added, unrelated region preserved.
+            #expect(!manager.trackedRegions.contains(where: { $0.identifier.hasPrefix("radar_bubble_") }))
+            #expect(manager.trackedRegions.contains(where: { $0.identifier == "radar_geofence_keep" }))
+        }
+
+        @Test("replaceBubbleGeofence removes prior bubble before adding a new one")
+        func replaceBubbleGeofenceReplacesPriorBubble() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_bubble_old"])
+
+            RadarLocationManagerSwift.replaceBubbleGeofence(
+                locationManager: manager,
+                location: CLLocation(latitude: 1, longitude: 1),
+                radius: 100
+            )
+
+            let bubbles = manager.trackedRegions.filter { $0.identifier.hasPrefix("radar_bubble_") }
+            #expect(bubbles.count == 1)
+            #expect(bubbles.first?.identifier != "radar_bubble_old")
+        }
+
+        // MARK: - Region removal
+
+        @Test("removeBubbleGeofence removes only radar_bubble_* regions")
+        func removeBubbleGeofenceRemovesOnlyBubblePrefix() {
+            let manager = TrackingCLLocationManager()
+            manager.seed([
+                "radar_bubble_a", "radar_bubble_b",
+                "radar_geofence_keep", "radar_beacon_keep", "radar_uuid_keep", "other_keep"
+            ])
+
+            RadarLocationManagerSwift.removeBubbleGeofence(locationManager: manager)
+
+            let remaining = manager.trackedRegions.map { $0.identifier }.sorted()
+            #expect(remaining == ["other_keep", "radar_beacon_keep", "radar_geofence_keep", "radar_uuid_keep"])
+        }
+
+        @Test("removeSyncedGeofences removes only radar_geofence_* regions")
+        func removeSyncedGeofencesRemovesOnlyGeofencePrefix() {
+            let manager = TrackingCLLocationManager()
+            manager.seed([
+                "radar_geofence_a", "radar_geofence_b",
+                "radar_bubble_keep", "radar_beacon_keep", "radar_uuid_keep"
+            ])
+
+            RadarLocationManagerSwift.removeSyncedGeofences(locationManager: manager)
+
+            #expect(!manager.trackedRegions.contains(where: { $0.identifier.hasPrefix("radar_geofence_") }))
+            #expect(manager.trackedRegions.count == 3)
+        }
+
+        @Test("removeSyncedBeacons removes both radar_beacon_* and radar_uuid_* regions")
+        func removeSyncedBeaconsRemovesBeaconAndUUIDPrefixes() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+
+            let manager = TrackingCLLocationManager()
+            manager.seed([
+                "radar_beacon_a", "radar_uuid_a",
+                "radar_geofence_keep", "radar_bubble_keep"
+            ])
+
+            RadarLocationManagerSwift.removeSyncedBeacons(locationManager: manager)
+
+            let remaining = manager.trackedRegions.map { $0.identifier }.sorted()
+            #expect(remaining == ["radar_bubble_keep", "radar_geofence_keep"])
+        }
+
+        @Test("removeSyncedBeacons no-ops when useRadarModifiedBeacon is enabled")
+        func removeSyncedBeaconsNoOpsWhenUseRadarModifiedBeacon() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": true
+            ])
+
+            let manager = TrackingCLLocationManager()
+            manager.seed(["radar_beacon_a", "radar_uuid_a"])
+
+            RadarLocationManagerSwift.removeSyncedBeacons(locationManager: manager)
+
+            #expect(manager.trackedRegions.count == 2)
+        }
+
+        @Test("removeAllRegions removes anything with the radar_ prefix")
+        func removeAllRegionsRemovesEverythingPrefixedRadar() {
+            let manager = TrackingCLLocationManager()
+            manager.seed([
+                "radar_bubble_a", "radar_geofence_a", "radar_beacon_a", "radar_uuid_a",
+                "other_keep_1", "other_keep_2"
+            ])
+
+            RadarLocationManagerSwift.removeAllRegions(locationManager: manager)
+
+            let remaining = manager.trackedRegions.map { $0.identifier }.sorted()
+            #expect(remaining == ["other_keep_1", "other_keep_2"])
+        }
+    }
+}

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -11,197 +11,116 @@ import Testing
 
 @testable import RadarSDK
 
-@Suite(.serialized)
-actor RadarLocationManagerSwiftSeamTests {
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    actor RadarLocationManagerSwiftSeamTests {
 
-    private func clearState() {
-        RadarSettings.previousTrackingOptions = nil
-        RadarSettings.sdkConfiguration = nil
-    }
+        // MARK: - restartPreviousTrackingOptions
 
-    private func makeBeacon(id: String, uuid: String, major: String, minor: String) -> RadarBeacon {
-        let geometry = RadarCoordinate(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0))!
-        return RadarBeacon(
-            id: id,
-            description: nil,
-            tag: "",
-            externalId: "",
-            uuid: uuid,
-            major: major,
-            minor: minor,
-            metadata: nil,
-            geometry: geometry
-        )!
-    }
+        @Test("Swift twin clears previousTrackingOptions when there are none to restart")
+        func swiftTwinClearsPreviousTrackingOptionsWhenNone() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
 
-    // MARK: - restartPreviousTrackingOptions (existing)
+            RadarLocationManagerSwift.restartPreviousTrackingOptions()
 
-    @Test("Swift twin clears previousTrackingOptions when there are none to restart")
-    func swiftTwinClearsPreviousTrackingOptionsWhenNone() {
-        clearState()
-        defer { clearState() }
+            #expect(RadarSettings.previousTrackingOptions == nil)
+        }
 
-        RadarLocationManagerSwift.restartPreviousTrackingOptions()
+        @Test("Swift twin clears previousTrackingOptions after restarting tracking")
+        func swiftTwinClearsPreviousTrackingOptionsAfterRestart() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
 
-        #expect(RadarSettings.previousTrackingOptions == nil)
-    }
+            RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
 
-    @Test("Swift twin clears previousTrackingOptions after restarting tracking")
-    func swiftTwinClearsPreviousTrackingOptionsAfterRestart() {
-        clearState()
-        defer { clearState() }
+            RadarLocationManagerSwift.restartPreviousTrackingOptions()
 
-        RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
+            #expect(RadarSettings.previousTrackingOptions == nil)
+        }
 
-        RadarLocationManagerSwift.restartPreviousTrackingOptions()
+        @Test("Public method routes to Swift twin when useSwiftLocationManager is enabled")
+        func publicMethodRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
 
-        #expect(RadarSettings.previousTrackingOptions == nil)
-    }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useSwiftLocationManager": true
+            ])
+            RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
 
-    @Test("Public method routes to Swift twin when useSwiftLocationManager is enabled")
-    func publicMethodRoutesToSwiftTwinWhenFlagEnabled() {
-        clearState()
-        defer { clearState() }
+            RadarLocationManager.sharedInstance().restartPreviousTrackingOptions()
 
-        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-            "useSwiftLocationManager": true
-        ])
-        RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
+            #expect(RadarSettings.previousTrackingOptions == nil)
+        }
 
-        RadarLocationManager.sharedInstance().restartPreviousTrackingOptions()
+        @Test("Public method uses ObjC body when useSwiftLocationManager is disabled")
+        func publicMethodUsesObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
 
-        #expect(RadarSettings.previousTrackingOptions == nil)
-    }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useSwiftLocationManager": false
+            ])
+            RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
 
-    @Test("Public method uses ObjC body when useSwiftLocationManager is disabled")
-    func publicMethodUsesObjCBodyWhenFlagDisabled() {
-        clearState()
-        defer { clearState() }
+            RadarLocationManager.sharedInstance().restartPreviousTrackingOptions()
 
-        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-            "useSwiftLocationManager": false
-        ])
-        RadarSettings.previousTrackingOptions = RadarTrackingOptions.presetResponsive
+            #expect(RadarSettings.previousTrackingOptions == nil)
+        }
 
-        RadarLocationManager.sharedInstance().restartPreviousTrackingOptions()
+        // MARK: - matchBeaconIds (pure)
 
-        #expect(RadarSettings.previousTrackingOptions == nil)
-    }
+        @Test("matchBeaconIds returns Radar IDs for beacons whose uuid/major/minor match a synced beacon")
+        func matchBeaconIdsMatchesOnUUIDMajorMinor() {
+            let synced = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "syncedB", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
+            ]
+            let ranged = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "rangedB", uuid: "33333333-3333-3333-3333-333333333333", major: "9", minor: "9"),
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "rangedC", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
+            ]
 
-    // MARK: - matchBeaconIds (pure)
+            let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
 
-    @Test("matchBeaconIds returns Radar IDs for beacons whose uuid/major/minor match a synced beacon")
-    func matchBeaconIdsMatchesOnUUIDMajorMinor() {
-        let synced = [
-            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
-            makeBeacon(id: "syncedB", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
-        ]
-        let ranged = [
-            makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
-            makeBeacon(id: "rangedB", uuid: "33333333-3333-3333-3333-333333333333", major: "9", minor: "9"),
-            makeBeacon(id: "rangedC", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
-        ]
+            #expect(matched == ["syncedA", "syncedB"])
+        }
 
-        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+        @Test("matchBeaconIds returns empty when no ranged beacon matches a synced beacon")
+        func matchBeaconIdsReturnsEmptyWhenNoMatches() {
+            let synced = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2")
+            ]
+            let ranged = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "9", minor: "9")
+            ]
 
-        #expect(matched == ["syncedA", "syncedB"])
-    }
+            let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
 
-    @Test("matchBeaconIds returns empty when no ranged beacon matches a synced beacon")
-    func matchBeaconIdsReturnsEmptyWhenNoMatches() {
-        let synced = [
-            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2")
-        ]
-        let ranged = [
-            makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "9", minor: "9")
-        ]
+            #expect(matched.isEmpty)
+        }
 
-        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+        @Test("matchBeaconIds is case-insensitive on UUID")
+        func matchBeaconIdsLowercasesUUID() {
+            let synced = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "syncedA", uuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", major: "1", minor: "2")
+            ]
+            let ranged = [
+                RadarLocationManagerSwiftTestHelpers.makeBeacon(id: "rangedA", uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", major: "1", minor: "2")
+            ]
 
-        #expect(matched.isEmpty)
-    }
+            let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
 
-    @Test("matchBeaconIds is case-insensitive on UUID")
-    func matchBeaconIdsLowercasesUUID() {
-        let synced = [
-            makeBeacon(id: "syncedA", uuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", major: "1", minor: "2")
-        ]
-        let ranged = [
-            makeBeacon(id: "rangedA", uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", major: "1", minor: "2")
-        ]
+            #expect(matched == ["syncedA"])
+        }
 
-        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+        @Test("matchBeaconIds returns empty for empty inputs")
+        func matchBeaconIdsHandlesEmptyInputs() {
+            let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: [], synced: [])
 
-        #expect(matched == ["syncedA"])
-    }
-
-    @Test("matchBeaconIds returns empty for empty inputs")
-    func matchBeaconIdsHandlesEmptyInputs() {
-        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: [], synced: [])
-
-        #expect(matched.isEmpty)
-    }
-
-    // MARK: - Region removal smoke tests
-
-    @Test("Region removal methods do not crash when called against the shared instance")
-    func regionRemovalMethodsDoNotCrash() {
-        clearState()
-        defer { clearState() }
-
-        let locationManager = RadarLocationManager.sharedInstance().locationManager
-
-        RadarLocationManagerSwift.removeBubbleGeofence(locationManager: locationManager)
-        RadarLocationManagerSwift.removeSyncedGeofences(locationManager: locationManager)
-        RadarLocationManagerSwift.removeSyncedBeacons(locationManager: locationManager)
-        RadarLocationManagerSwift.removeAllRegions(locationManager: locationManager)
-    }
-
-    @Test("Public replaceSyncedBeacons routes to Swift twin when flag enabled")
-    func publicReplaceSyncedBeaconsRoutesToSwiftTwinWhenFlagEnabled() {
-        clearState()
-        defer { clearState() }
-
-        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-            "useSwiftLocationManager": true,
-            "useRadarModifiedBeacon": true
-        ])
-
-        RadarLocationManager.sharedInstance().replaceSyncedBeacons([])
-    }
-
-    // MARK: - replaceSyncedBeacons short-circuits
-
-    @Test("replaceSyncedBeacons no-ops when useRadarModifiedBeacon is enabled")
-    func replaceSyncedBeaconsNoOpsWhenUseRadarModifiedBeacon() {
-        clearState()
-        defer { clearState() }
-
-        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-            "useRadarModifiedBeacon": true
-        ])
-        let beacons = [
-            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2")
-        ]
-
-        RadarLocationManagerSwift.replaceSyncedBeacons(
-            locationManager: RadarLocationManager.sharedInstance().locationManager,
-            beacons: beacons
-        )
-    }
-
-    @Test("replaceSyncedBeaconUUIDs no-ops when useRadarModifiedBeacon is enabled")
-    func replaceSyncedBeaconUUIDsNoOpsWhenUseRadarModifiedBeacon() {
-        clearState()
-        defer { clearState() }
-
-        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-            "useRadarModifiedBeacon": true
-        ])
-
-        RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(
-            locationManager: RadarLocationManager.sharedInstance().locationManager,
-            uuids: ["11111111-1111-1111-1111-111111111111"]
-        )
+            #expect(matched.isEmpty)
+        }
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+import CoreLocation
 import Foundation
 import Testing
 
@@ -17,6 +18,23 @@ actor RadarLocationManagerSwiftSeamTests {
         RadarSettings.previousTrackingOptions = nil
         RadarSettings.sdkConfiguration = nil
     }
+
+    private func makeBeacon(id: String, uuid: String, major: String, minor: String) -> RadarBeacon {
+        let geometry = RadarCoordinate(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0))!
+        return RadarBeacon(
+            id: id,
+            description: nil,
+            tag: "",
+            externalId: "",
+            uuid: uuid,
+            major: major,
+            minor: minor,
+            metadata: nil,
+            geometry: geometry
+        )!
+    }
+
+    // MARK: - restartPreviousTrackingOptions (existing)
 
     @Test("Swift twin clears previousTrackingOptions when there are none to restart")
     func swiftTwinClearsPreviousTrackingOptionsWhenNone() {
@@ -68,5 +86,122 @@ actor RadarLocationManagerSwiftSeamTests {
         RadarLocationManager.sharedInstance().restartPreviousTrackingOptions()
 
         #expect(RadarSettings.previousTrackingOptions == nil)
+    }
+
+    // MARK: - matchBeaconIds (pure)
+
+    @Test("matchBeaconIds returns Radar IDs for beacons whose uuid/major/minor match a synced beacon")
+    func matchBeaconIdsMatchesOnUUIDMajorMinor() {
+        let synced = [
+            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
+            makeBeacon(id: "syncedB", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
+        ]
+        let ranged = [
+            makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2"),
+            makeBeacon(id: "rangedB", uuid: "33333333-3333-3333-3333-333333333333", major: "9", minor: "9"),
+            makeBeacon(id: "rangedC", uuid: "22222222-2222-2222-2222-222222222222", major: "3", minor: "4"),
+        ]
+
+        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+
+        #expect(matched == ["syncedA", "syncedB"])
+    }
+
+    @Test("matchBeaconIds returns empty when no ranged beacon matches a synced beacon")
+    func matchBeaconIdsReturnsEmptyWhenNoMatches() {
+        let synced = [
+            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2")
+        ]
+        let ranged = [
+            makeBeacon(id: "rangedA", uuid: "11111111-1111-1111-1111-111111111111", major: "9", minor: "9")
+        ]
+
+        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+
+        #expect(matched.isEmpty)
+    }
+
+    @Test("matchBeaconIds is case-insensitive on UUID")
+    func matchBeaconIdsLowercasesUUID() {
+        let synced = [
+            makeBeacon(id: "syncedA", uuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", major: "1", minor: "2")
+        ]
+        let ranged = [
+            makeBeacon(id: "rangedA", uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", major: "1", minor: "2")
+        ]
+
+        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: ranged, synced: synced)
+
+        #expect(matched == ["syncedA"])
+    }
+
+    @Test("matchBeaconIds returns empty for empty inputs")
+    func matchBeaconIdsHandlesEmptyInputs() {
+        let matched = RadarLocationManagerSwift.matchBeaconIds(ranged: [], synced: [])
+
+        #expect(matched.isEmpty)
+    }
+
+    // MARK: - Region removal smoke tests
+
+    @Test("Region removal methods do not crash when called against the shared instance")
+    func regionRemovalMethodsDoNotCrash() {
+        clearState()
+        defer { clearState() }
+
+        let locationManager = RadarLocationManager.sharedInstance().locationManager
+
+        RadarLocationManagerSwift.removeBubbleGeofence(locationManager: locationManager)
+        RadarLocationManagerSwift.removeSyncedGeofences(locationManager: locationManager)
+        RadarLocationManagerSwift.removeSyncedBeacons(locationManager: locationManager)
+        RadarLocationManagerSwift.removeAllRegions(locationManager: locationManager)
+    }
+
+    @Test("Public replaceSyncedBeacons routes to Swift twin when flag enabled")
+    func publicReplaceSyncedBeaconsRoutesToSwiftTwinWhenFlagEnabled() {
+        clearState()
+        defer { clearState() }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": true,
+            "useRadarModifiedBeacon": true
+        ])
+
+        RadarLocationManager.sharedInstance().replaceSyncedBeacons([])
+    }
+
+    // MARK: - replaceSyncedBeacons short-circuits
+
+    @Test("replaceSyncedBeacons no-ops when useRadarModifiedBeacon is enabled")
+    func replaceSyncedBeaconsNoOpsWhenUseRadarModifiedBeacon() {
+        clearState()
+        defer { clearState() }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useRadarModifiedBeacon": true
+        ])
+        let beacons = [
+            makeBeacon(id: "syncedA", uuid: "11111111-1111-1111-1111-111111111111", major: "1", minor: "2")
+        ]
+
+        RadarLocationManagerSwift.replaceSyncedBeacons(
+            locationManager: RadarLocationManager.sharedInstance().locationManager,
+            beacons: beacons
+        )
+    }
+
+    @Test("replaceSyncedBeaconUUIDs no-ops when useRadarModifiedBeacon is enabled")
+    func replaceSyncedBeaconUUIDsNoOpsWhenUseRadarModifiedBeacon() {
+        clearState()
+        defer { clearState() }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useRadarModifiedBeacon": true
+        ])
+
+        RadarLocationManagerSwift.replaceSyncedBeaconUUIDs(
+            locationManager: RadarLocationManager.sharedInstance().locationManager,
+            uuids: ["11111111-1111-1111-1111-111111111111"]
+        )
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftTestHelpers.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftTestHelpers.swift
@@ -1,0 +1,53 @@
+//
+//  RadarLocationManagerSwiftTestHelpers.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+//  Shared helpers for the Swift-port test suites in
+//  `RadarLocationManagerSwift*Tests.swift`.
+//
+
+import CoreLocation
+import Foundation
+
+@testable import RadarSDK
+
+enum RadarLocationManagerSwiftTestHelpers {
+
+    /// Reset every `RadarSettings` key the seam tests write so each test starts
+    /// from a known state. Call at the beginning of each test and in a `defer`
+    /// block after.
+    static func clearState() {
+        RadarSettings.previousTrackingOptions = nil
+        RadarSettings.sdkConfiguration = nil
+        RadarSettings.tracking = false
+        RadarSettings.trackingOptions = nil
+        RadarSettings.remoteTrackingOptions = nil
+    }
+
+    /// Construct a `RadarBeacon` with all the fields `matchBeaconIds` and
+    /// `replaceSyncedBeacons` read.
+    static func makeBeacon(id: String, uuid: String, major: String, minor: String) -> RadarBeacon {
+        let geometry = RadarCoordinate(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0))!
+        return RadarBeacon(
+            id: id,
+            description: nil,
+            tag: "",
+            externalId: "",
+            uuid: uuid,
+            major: major,
+            minor: minor,
+            metadata: nil,
+            geometry: geometry
+        )!
+    }
+
+    /// Build `RadarTrackingOptions` with `beacons` toggled as requested.
+    /// Starts from `presetResponsive` to get a valid preset.
+    static func trackingOptions(beacons: Bool) -> RadarTrackingOptions {
+        let options = RadarTrackingOptions.presetResponsive
+        options.beacons = beacons
+        return options
+    }
+}

--- a/RadarSDKTests/TrackingCLLocationManager.swift
+++ b/RadarSDKTests/TrackingCLLocationManager.swift
@@ -1,0 +1,54 @@
+//
+//  TrackingCLLocationManager.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+
+/// Test-only `CLLocationManager` subclass that records `startMonitoring` /
+/// `stopMonitoring` / `requestLocation` / `stopUpdatingLocation` / `requestState`
+/// calls and overrides `monitoredRegions` so Swift twins can be exercised
+/// without touching real Core Location state. Subclassing CLLocationManager
+/// is officially unsupported by Apple, but the existing ObjC test helper
+/// `CLLocationManagerMock` already relies on it for the same purpose.
+final class TrackingCLLocationManager: CLLocationManager, @unchecked Sendable {
+    private(set) var trackedRegions = Set<CLRegion>()
+    private(set) var requestLocationCallCount = 0
+    private(set) var stopUpdatingLocationCallCount = 0
+    private(set) var requestStateRegions: [CLRegion] = []
+
+    override var monitoredRegions: Set<CLRegion> { trackedRegions }
+
+    override func startMonitoring(for region: CLRegion) {
+        trackedRegions.insert(region)
+    }
+
+    override func stopMonitoring(for region: CLRegion) {
+        trackedRegions.remove(region)
+    }
+
+    override func requestLocation() {
+        requestLocationCallCount += 1
+    }
+
+    override func stopUpdatingLocation() {
+        stopUpdatingLocationCallCount += 1
+    }
+
+    override func requestState(for region: CLRegion) {
+        requestStateRegions.append(region)
+    }
+
+    func seed(_ identifiers: [String]) {
+        for identifier in identifiers {
+            trackedRegions.insert(CLCircularRegion(
+                center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                radius: 100,
+                identifier: identifier
+            ))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Ports 10 small `RadarLocationManager` methods to Swift twins on `RadarLocationManagerSwift`, dispatched from `RadarLocationManager.m` when `useSwiftLocationManager` is enabled. ObjC bodies are kept in place; both implementations coexist until the Swift port is trusted.
- Methods: `matchBeaconIds:syncedBeacons:`, `replaceBubbleGeofence:radius:`, `removeBubbleGeofence`, `removeSyncedGeofences`, `replaceSyncedBeacons:`, `replaceSyncedBeaconUUIDs:`, `removeSyncedBeacons`, `removeAllRegions`, `requestLocation`, `shutDown`.
- Swift twins take the relevant `CLLocationManager` (and `lowPowerLocationManager` for `shutDown`) directly. A small `@objc` host protocol was prototyped but couldn't be made visible to Swift inside the framework target without exposing it in the umbrella header — passing managers directly keeps the seam minimal until more shared instance state (timer, completion handlers) makes a protocol worthwhile.
- Mirrors the identifier-prefix constants (`radar_`, `radar_bubble_`, etc.) as `private static let` on `RadarLocationManagerSwift` so the two implementations stay in sync until full cutover.

## Test plan

### Manual smoke in the Example app

Run with `useSwiftLocationManager` first **off** (default) to confirm no regression, then **on** to exercise the new Swift twins. Flip the flag by setting the SDK config in the example app's setup, e.g.:

- [ ] **Region sync (geofences):** Start tracking with `presetResponsive`. While near a synced geofence in the Radar dashboard, inspect `RadarLocationManager.sharedInstance().locationManager.monitoredRegions` in the debugger — should contain `radar_geofence_*` identifiers. Stop tracking, then re-inspect — they should be removed. Repeat with flag both off and on; behavior should be identical.
- [ ] **Bubble geofence:** With `presetResponsive` (which sets up a bubble geofence on stops), wait for stopped state and verify a `radar_bubble_*` region appears in `monitoredRegions`. Move and watch it get replaced.
- [ ] **Beacons:** If you have a synced beacon on your account with `options.beacons = YES`, verify a `radar_beacon_*` region appears in `monitoredRegions` after a track call.
- [ ] **`requestLocation`:** Call any code path that triggers `getLocationWithCompletionHandler:` (e.g. `Radar.trackOnce`) and confirm a `didUpdateLocations` callback fires via `RadarLogger` output.
- [ ] **`shutDown`:** Stop tracking and wait ~10s; logs should show \"Shutting down\" and standard/low-power `CLLocationManager` updates should stop.
- [ ] **`removeAllRegions`:** Call via any path that clears all radar-prefixed regions (e.g. SDK reinit); confirm `monitoredRegions` no longer contains anything with the `radar_` prefix.

Switch the flag back **off** between each step to confirm the ObjC path still works.