### PR TITLE
Fix flaky RadarLoggerTests by making delivery deterministic

### DIFF
--- a/RadarSDK/RadarLogger.swift
+++ b/RadarSDK/RadarLogger.swift
@@ -26,6 +26,14 @@ final class RadarLogger: NSObject, @unchecked Sendable {
         logLevelOverride ?? RadarSettings.logLevel
     }
 
+    // Test-only bookkeeping: each `log(...)` call spawns a detached Task that delivers the
+    // message to the delegate asynchronously. Tests need to deterministically await that
+    // delivery instead of racing a wall-clock timeout (which is flaky under CI load). When
+    // `logLevelOverride` is set (test mode) we retain the in-flight tasks so `awaitPendingLogs()`
+    // can await them. In production `logLevelOverride` is nil, so this stays a no-op.
+    private let pendingLogTasksLock = NSLock()
+    private var pendingLogTasks = [Task<Void, Never>]()
+
     @MainActor
     let device = {
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -65,7 +73,7 @@ final class RadarLogger: NSObject, @unchecked Sendable {
             return
         }
 
-        Task {
+        let task = Task {
             let log = RadarLog(level: level, message: message, type: type, createdAt: Date(), includeDate: includeDate, battery: includeBattery ? await self.device.batteryLevel : nil)
 
             await RadarLogBuffer.shared.log(log)
@@ -82,6 +90,32 @@ final class RadarLogger: NSObject, @unchecked Sendable {
                 self.delegate?.didLog?(message: logMessage)
             }
         }
+
+        // Only retain tasks in test mode to keep production allocation-free.
+        if logLevelOverride != nil {
+            pendingLogTasksLock.lock()
+            pendingLogTasks.append(task)
+            pendingLogTasksLock.unlock()
+        }
+    }
+
+    /// Test hook: awaits every log task spawned so far, guaranteeing their delegate
+    /// callbacks have run. Lets tests assert on delivered messages deterministically
+    /// instead of polling against a wall-clock timeout.
+    func awaitPendingLogs() async {
+        // Drain under the lock in a synchronous helper so the lock is never held across an
+        // `await` (NSLock.lock/unlock are unavailable from async contexts).
+        for task in drainPendingLogTasks() {
+            await task.value
+        }
+    }
+
+    private func drainPendingLogTasks() -> [Task<Void, Never>] {
+        pendingLogTasksLock.lock()
+        defer { pendingLogTasksLock.unlock() }
+        let tasks = pendingLogTasks
+        pendingLogTasks.removeAll()
+        return tasks
     }
 
     // ObjC interface, which will be deprecated

--- a/RadarSDKTests/RadarLoggerTests.swift
+++ b/RadarSDKTests/RadarLoggerTests.swift
@@ -9,14 +9,6 @@ import Testing
 
 @testable import RadarSDK
 
-private func waitUntil(timeout: TimeInterval = 5.0, _ check: () async -> Bool) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-        if await check() { return }
-        try? await Task.sleep(nanoseconds: 25_000_000)  // poll every 25ms
-    }
-}
-
 final class MockRadarDelegate: NSObject, RadarDelegate, @unchecked Sendable {
     var messages = [String]()
     func didLog(message: String) {
@@ -39,8 +31,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        await waitUntil { delegate.messages.count >= 4 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 4)
     }
 
@@ -56,7 +47,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 0)
     }
 
@@ -71,8 +62,7 @@ struct RadarLoggerTests {
         logger.info("infoLog")
         logger.warning("warningLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -87,8 +77,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -103,8 +92,7 @@ struct RadarLoggerTests {
         logger.debug("debugLog")
         logger.info("infoLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -121,8 +109,7 @@ struct RadarLoggerTests {
         logger.log(level: .info, type: .none, message: "hello", includeDate: false, includeBattery: false)
         logger.log(level: .info, type: .none, message: "hello", includeDate: false, includeBattery: false, append: false)
 
-        await waitUntil { delegate.messages.count >= 4 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 4)
     }
 }


### PR DESCRIPTION
## Problem

`RadarLoggerTests` fails intermittently on the GitHub Actions `macos-15` runner (`delegate.messages.count == 0` when expecting 1 or 4), while passing locally and on CircleCI's faster `m4pro` runner. This blocks unrelated PRs (e.g. #608) whose diffs don't touch logging.

Failing run: https://github.com/radarlabs/radar-sdk-ios/actions/runs/26772030880/job/78913745205

## Root cause

The tests asserted that async, **MainActor-delivered** `didLog` callbacks arrived within a 5s `waitUntil` poll. `RadarLogger.log()` spawns a detached `Task` that hops through the `RadarLogBuffer` actor and the MainActor before invoking the delegate — so the assertion was really a race against the cooperative thread pool. On the slower runner that pool is saturated under parallel test load, the callbacks landed after the 5s budget, and the tests saw `count == 0`.

(An earlier attempt to fix this by moving the suite into the isolated `ci-test-swift` bundle failed: that bundle has its own ~110s stall because `InAppMessageTest` fetches a real image over the network, which also starves the MainActor. Bundle placement doesn't address the root cause — the timing race does.)

## Fix

Make log delivery **deterministically awaitable** in tests instead of racing a wall-clock timeout:

- `RadarLogger` retains its in-flight log `Task`s while in test mode (`logLevelOverride != nil`) and exposes `awaitPendingLogs()`, which awaits them so the delegate callbacks are guaranteed to have run. **Production is unaffected** — `logLevelOverride` is nil in production, so no tasks are retained and the logging path is unchanged. All entry points (`debug`/`info`/`warning`/`error` and the `@objc log` overloads) funnel through the core `log()`, so the hook covers them uniformly, including `objectiveCInterfaceWorks`.
- `RadarLoggerTests` now `await logger.awaitPendingLogs()` instead of polling + sleeping.

The tests are now timing-independent and immune to runner speed.