### PR TITLE
FENCE-2857: Add NSError parameter to ipGeocode callback

### DIFF
--- a/Example/Example/TestsView.swift
+++ b/Example/Example/TestsView.swift
@@ -259,9 +259,9 @@ struct TestsView: View {
             }
 
             StyledButton("ipGeocode") {
-                Radar.ipGeocode { (status, address, proxy) in
+                Radar.ipGeocode { (status, address, proxy, error) in
                     print(
-                        "IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy); full address: \(String(describing: address?.dictionaryValue()))"
+                        "IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy); full address: \(String(describing: address?.dictionaryValue())); error = \(String(describing: error?.localizedDescription))"
                     )
                 }
             }

--- a/Example/Example/TestsView.swift
+++ b/Example/Example/TestsView.swift
@@ -261,7 +261,7 @@ struct TestsView: View {
             StyledButton("ipGeocode") {
                 Radar.ipGeocode { (status, address, proxy, error) in
                     print(
-                        "IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy); full address: \(String(describing: address?.dictionaryValue())); error = \(String(describing: error?.localizedDescription))"
+                        "IP geocode: status = \(Radar.stringForStatus(status)); country = \(String(describing: address?.countryCode)); city = \(String(describing: address?.city)); proxy = \(proxy); full address: \(String(describing: address?.dictionaryValue())); error = \(error?.localizedDescription ?? "nil")"
                     )
                 }
             }

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -285,6 +285,15 @@ typedef void (^_Nonnull RadarGeocodeCompletionHandler)(RadarStatus status, NSArr
 typedef void (^_Nonnull RadarIPGeocodeCompletionHandler)(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy);
 
 /**
+ Called when an IP geocoding request succeeds, fails, or times out.
+
+ Receives the request status and, if successful, the geocoding result (a partial address) and a boolean indicating whether the IP address is a known proxy. Also receives the underlying NSError when the failure originated from a caught network, parse, or exception error — forward it to an error collector (Sentry, Crashlytics, etc.) to capture diagnostics.
+
+ @see https://radar.com/documentation/api#ip-geocode
+ */
+typedef void (^_Nonnull RadarIPGeocodeWithErrorCompletionHandler)(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error);
+
+/**
  Called when an address validation request succeeds, fails, or times out.
 
  Receives the request status and, if successful, the address and a verification status.
@@ -1314,7 +1323,17 @@ typedef void (^_Nonnull RadarIndoorsScanCompletionHandler)(NSString *_Nullable r
 
  @see https://radar.com/documentation/api#ip-geocode
  */
-+ (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeCompletionHandler)completionHandler NS_SWIFT_NAME(ipGeocode(completionHandler:));
++ (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeCompletionHandler)completionHandler
+    __attribute__((deprecated("Use ipGeocodeWithErrorCompletionHandler: to also receive the underlying NSError on network/parse errors.")));
+
+/**
+ Geocodes the device's current IP address, converting IP address to partial address. The completion handler also receives the underlying NSError when the failure originated from a caught network, parse, or exception error — forward it to an error collector (Sentry, Crashlytics, etc.) to capture diagnostics.
+
+ @param completionHandler A completion handler.
+
+ @see https://radar.com/documentation/api#ip-geocode
+ */
++ (void)ipGeocodeWithErrorCompletionHandler:(RadarIPGeocodeWithErrorCompletionHandler)completionHandler NS_SWIFT_NAME(ipGeocode(completionHandler:));
 
 
 /**

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1297,11 +1297,19 @@ BOOL _initialized = NO;
 }
 
 + (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeCompletionHandler)completionHandler {
+    [Radar ipGeocodeWithErrorCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error) {
+        if (completionHandler) {
+            completionHandler(status, address, proxy);
+        }
+    }];
+}
+
++ (void)ipGeocodeWithErrorCompletionHandler:(RadarIPGeocodeWithErrorCompletionHandler)completionHandler {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"ipGeocode()"];
-    [[RadarAPIClient sharedInstance] ipGeocodeWithCompletionHandler:^(RadarStatus status, NSDictionary *_Nullable res, RadarAddress *_Nullable address, BOOL proxy) {
+    [[RadarAPIClient sharedInstance] ipGeocodeWithCompletionHandler:^(RadarStatus status, NSDictionary *_Nullable res, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error) {
         if (completionHandler) {
             [RadarUtilsDeprecated runOnMainThread:^{
-                completionHandler(status, address, proxy);
+                completionHandler(status, address, proxy, error);
             }];
         }
     }];

--- a/RadarSDK/RadarAPIClient.h
+++ b/RadarSDK/RadarAPIClient.h
@@ -52,7 +52,7 @@ typedef void (^_Nonnull RadarGeocodeAPICompletionHandler)(RadarStatus status, NS
 
 typedef void (^_Nonnull RadarValidateAddressAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, RadarAddress *_Nullable address, RadarAddressVerificationStatus verificationStatus);
 
-typedef void (^_Nonnull RadarIPGeocodeAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, RadarAddress *_Nullable address, BOOL proxy);
+typedef void (^_Nonnull RadarIPGeocodeAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error);
 
 typedef void (^_Nonnull RadarDistanceAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, RadarRoutes *_Nullable routes);
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -147,7 +147,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (!res) {
                             completionHandler(status, nil);
                             return;
@@ -184,7 +184,7 @@
                                 sleep:NO
                            logPayload:NO
                       extendedTimeout:YES
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                             id eventsObj = res[@"events"];
                             id userObj = res[@"user"];
 
@@ -581,7 +581,7 @@
                                     sleep:YES
                             logPayload:YES
                         extendedTimeout:NO
-                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                        completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                             if (status != RadarStatusSuccess || !res) {
                                 if (options.replay == RadarTrackingOptionsReplayAll) {
                                     // create a copy of params that we can use to write to the buffer in case of request failure
@@ -776,7 +776,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res){
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error){
 
                     }];
 }
@@ -836,7 +836,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -907,7 +907,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -954,7 +954,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, nil);
                         }
@@ -1002,7 +1002,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1041,7 +1041,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1107,7 +1107,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1167,7 +1167,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1207,7 +1207,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, nil);
                         }
@@ -1286,7 +1286,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1342,7 +1342,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1387,7 +1387,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1451,7 +1451,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil, RadarAddressVerificationStatusNone);
                         }
@@ -1511,7 +1511,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1553,7 +1553,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1571,7 +1571,7 @@
 - (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeAPICompletionHandler)completionHandler {
     NSString *publishableKey = [RadarSettings publishableKey];
     if (!publishableKey) {
-        return completionHandler(RadarStatusErrorPublishableKey, nil, nil, NO);
+        return completionHandler(RadarStatusErrorPublishableKey, nil, nil, NO, nil);
     }
 
     NSString *host = [RadarSettings host];
@@ -1586,9 +1586,9 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
-                            return completionHandler(status, nil, nil, NO);
+                            return completionHandler(status, nil, nil, NO, error);
                         }
 
                         id addressObj = res[@"address"];
@@ -1601,10 +1601,10 @@
                         }
 
                         if (address) {
-                            return completionHandler(RadarStatusSuccess, res, address, proxy);
+                            return completionHandler(RadarStatusSuccess, res, address, proxy, nil);
                         }
 
-                        completionHandler(RadarStatusErrorServer, nil, nil, NO);
+                        completionHandler(RadarStatusErrorServer, nil, nil, NO, nil);
                     }];
 }
 
@@ -1664,7 +1664,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1740,7 +1740,7 @@
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }
@@ -1787,7 +1787,7 @@ completionHandler:(RadarSendEventAPICompletionHandler _Nonnull)completionHandler
                                 sleep:NO
                            logPayload:YES
                       extendedTimeout:NO
-                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res) {
+                    completionHandler:^(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error) {
                         if (status != RadarStatusSuccess || !res) {
                             return completionHandler(status, nil, nil);
                         }

--- a/RadarSDK/RadarAPIHelper.h
+++ b/RadarSDK/RadarAPIHelper.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^_Nullable RadarAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res);
+typedef void (^_Nullable RadarAPICompletionHandler)(RadarStatus status, NSDictionary *_Nullable res, NSError *_Nullable error);
 
 @interface RadarAPIHelper : NSObject
 

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -165,14 +165,7 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                 NSError *deserializationError = nil;
                 id resObj = [NSJSONSerialization JSONObjectWithData:data options:0 error:&deserializationError];
                 if (deserializationError || ![resObj isKindOfClass:[NSDictionary class]]) {
-                    long elapsedMs = (long)(latency * 1000);
-                    NSString *host = req.URL.host ?: @"unknown";
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        [[RadarLogger sharedInstance]
-                            logWithLevel:RadarLogLevelError
-                                    type:RadarLogTypeSDKError
-                                 message:[NSString stringWithFormat:@"JSON parse error | host = %@; errorDomain = %@; errorCode = %ld; errorDescription = %@; elapsedMs = %ld",
-                                          host, deserializationError.domain ?: @"RadarSDK", (long)deserializationError.code, deserializationError.localizedDescription ?: @"response was not a JSON dictionary", elapsedMs]];
                         completionHandler(RadarStatusErrorServer, nil, deserializationError);
                     });
 
@@ -258,10 +251,6 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                                                           @"NSException": exception
                                                       }];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [[RadarLogger sharedInstance]
-                    logWithLevel:RadarLogLevelError
-                            type:RadarLogTypeSDKError
-                         message:[NSString stringWithFormat:@"Request exception | name = %@; reason = %@", exception.name, exception.reason]];
                 completionHandler(RadarStatusErrorBadRequest, nil, exceptionError);
             });
             return;

--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -151,7 +151,7 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                                     type:RadarLogTypeSDKError
                                  message:[NSString stringWithFormat:@"Network error | host = %@; errorDomain = %@; errorCode = %ld; errorDescription = %@; elapsedMs = %ld",
                                           host, error.domain, (long)error.code, error.localizedDescription, elapsedMs]];
-                        completionHandler(RadarStatusErrorNetwork, nil);
+                        completionHandler(RadarStatusErrorNetwork, nil, error);
                     });
 
                     if (sleep) {
@@ -165,8 +165,15 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                 NSError *deserializationError = nil;
                 id resObj = [NSJSONSerialization JSONObjectWithData:data options:0 error:&deserializationError];
                 if (deserializationError || ![resObj isKindOfClass:[NSDictionary class]]) {
+                    long elapsedMs = (long)(latency * 1000);
+                    NSString *host = req.URL.host ?: @"unknown";
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        completionHandler(RadarStatusErrorServer, nil);
+                        [[RadarLogger sharedInstance]
+                            logWithLevel:RadarLogLevelError
+                                    type:RadarLogTypeSDKError
+                                 message:[NSString stringWithFormat:@"JSON parse error | host = %@; errorDomain = %@; errorCode = %ld; errorDescription = %@; elapsedMs = %ld",
+                                          host, deserializationError.domain ?: @"RadarSDK", (long)deserializationError.code, deserializationError.localizedDescription ?: @"response was not a JSON dictionary", elapsedMs]];
+                        completionHandler(RadarStatusErrorServer, nil, deserializationError);
                     });
 
                     if (sleep) {
@@ -218,7 +225,7 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                 }
 
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completionHandler(status, res);
+                    completionHandler(status, res, nil);
                 });
 
                 if (sleep) {
@@ -244,8 +251,18 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
             if (sleep) {
                 dispatch_semaphore_signal(self.semaphore);
             }
+            NSError *exceptionError = [NSError errorWithDomain:@"RadarSDK"
+                                                          code:0
+                                                      userInfo:@{
+                                                          NSLocalizedDescriptionKey: exception.reason ?: exception.name ?: @"NSException",
+                                                          @"NSException": exception
+                                                      }];
             dispatch_async(dispatch_get_main_queue(), ^{
-                completionHandler(RadarStatusErrorBadRequest, nil);
+                [[RadarLogger sharedInstance]
+                    logWithLevel:RadarLogLevelError
+                            type:RadarLogTypeSDKError
+                         message:[NSString stringWithFormat:@"Request exception | name = %@; reason = %@", exception.name, exception.reason]];
+                completionHandler(RadarStatusErrorBadRequest, nil, exceptionError);
             });
             return;
         }

--- a/RadarSDK/RadarLogger.swift
+++ b/RadarSDK/RadarLogger.swift
@@ -26,6 +26,14 @@ final class RadarLogger: NSObject, @unchecked Sendable {
         logLevelOverride ?? RadarSettings.logLevel
     }
 
+    // Test-only bookkeeping: each `log(...)` call spawns a detached Task that delivers the
+    // message to the delegate asynchronously. Tests need to deterministically await that
+    // delivery instead of racing a wall-clock timeout (which is flaky under CI load). When
+    // `logLevelOverride` is set (test mode) we retain the in-flight tasks so `awaitPendingLogs()`
+    // can await them. In production `logLevelOverride` is nil, so this stays a no-op.
+    private let pendingLogTasksLock = NSLock()
+    private var pendingLogTasks = [Task<Void, Never>]()
+
     @MainActor
     let device = {
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -65,7 +73,7 @@ final class RadarLogger: NSObject, @unchecked Sendable {
             return
         }
 
-        Task {
+        let task = Task {
             let log = RadarLog(level: level, message: message, type: type, createdAt: Date(), includeDate: includeDate, battery: includeBattery ? await self.device.batteryLevel : nil)
 
             await RadarLogBuffer.shared.log(log)
@@ -82,6 +90,32 @@ final class RadarLogger: NSObject, @unchecked Sendable {
                 self.delegate?.didLog?(message: logMessage)
             }
         }
+
+        // Only retain tasks in test mode to keep production allocation-free.
+        if logLevelOverride != nil {
+            pendingLogTasksLock.lock()
+            pendingLogTasks.append(task)
+            pendingLogTasksLock.unlock()
+        }
+    }
+
+    /// Test hook: awaits every log task spawned so far, guaranteeing their delegate
+    /// callbacks have run. Lets tests assert on delivered messages deterministically
+    /// instead of polling against a wall-clock timeout.
+    func awaitPendingLogs() async {
+        // Drain under the lock in a synchronous helper so the lock is never held across an
+        // `await` (NSLock.lock/unlock are unavailable from async contexts).
+        for task in drainPendingLogTasks() {
+            await task.value
+        }
+    }
+
+    private func drainPendingLogTasks() -> [Task<Void, Never>] {
+        pendingLogTasksLock.lock()
+        defer { pendingLogTasksLock.unlock() }
+        let tasks = pendingLogTasks
+        pendingLogTasks.removeAll()
+        return tasks
     }
 
     // ObjC interface, which will be deprecated

--- a/RadarSDKTests/RadarAPIHelperMock.h
+++ b/RadarSDKTests/RadarAPIHelperMock.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) RadarStatus mockStatus;
 @property (nonnull, strong, nonatomic) NSDictionary *mockResponse;
+@property (nonatomic, strong, nullable) NSError *mockError;
 
 // Properties to capture last request for testing
 @property (nonatomic, strong, nullable) NSString *lastMethod;

--- a/RadarSDKTests/RadarAPIHelperMock.m
+++ b/RadarSDKTests/RadarAPIHelperMock.m
@@ -53,7 +53,7 @@
         status = self.mockStatus;
     }
     
-    completionHandler(status, response);
+    completionHandler(status, response, self.mockError);
 }
 
 - (void)setMockResponse:(NSDictionary *)response forMethod:(NSString *)urlString {

--- a/RadarSDKTests/RadarLoggerTests.swift
+++ b/RadarSDKTests/RadarLoggerTests.swift
@@ -9,14 +9,6 @@ import Testing
 
 @testable import RadarSDK
 
-private func waitUntil(timeout: TimeInterval = 5.0, _ check: () async -> Bool) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-        if await check() { return }
-        try? await Task.sleep(nanoseconds: 25_000_000)  // poll every 25ms
-    }
-}
-
 final class MockRadarDelegate: NSObject, RadarDelegate, @unchecked Sendable {
     var messages = [String]()
     func didLog(message: String) {
@@ -39,8 +31,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        await waitUntil { delegate.messages.count >= 4 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 4)
     }
 
@@ -56,7 +47,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 0)
     }
 
@@ -71,8 +62,7 @@ struct RadarLoggerTests {
         logger.info("infoLog")
         logger.warning("warningLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -87,8 +77,7 @@ struct RadarLoggerTests {
         logger.warning("warningLog")
         logger.error("errorLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -103,8 +92,7 @@ struct RadarLoggerTests {
         logger.debug("debugLog")
         logger.info("infoLog")
 
-        await waitUntil { delegate.messages.count >= 1 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 1)
     }
 
@@ -121,8 +109,7 @@ struct RadarLoggerTests {
         logger.log(level: .info, type: .none, message: "hello", includeDate: false, includeBattery: false)
         logger.log(level: .info, type: .none, message: "hello", includeDate: false, includeBattery: false, append: false)
 
-        await waitUntil { delegate.messages.count >= 4 }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        await logger.awaitPendingLogs()
         #expect(delegate.messages.count == 4)
     }
 }

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -1989,7 +1989,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy) {
+    [Radar ipGeocodeWithErrorCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error) {
         XCTAssertEqual(status, RadarStatusErrorServer);
         XCTAssertNil(address);
         XCTAssertFalse(proxy);
@@ -2012,15 +2012,69 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-    [Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy) {
+    [Radar ipGeocodeWithErrorCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error) {
         XCTAssertEqual(status, RadarStatusSuccess);
         AssertAddressOk(address);
         XCTAssertNotNil(address.dma);
         XCTAssertNotNil(address.dmaCode);
         XCTAssertTrue(proxy);
+        XCTAssertNil(error);
 
         [expectation fulfill];
     }];
+
+    [self waitForExpectationsWithTimeout:30
+                                 handler:^(NSError *_Nullable error) {
+                                     if (error) {
+                                         XCTFail();
+                                     }
+                                 }];
+}
+
+- (void)test_Radar_ipGeocode_onComplete_receives_error {
+    self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
+    self.apiHelperMock.mockStatus = RadarStatusErrorNetwork;
+    NSError *mockError = [NSError errorWithDomain:NSURLErrorDomain
+                                              code:NSURLErrorNotConnectedToInternet
+                                          userInfo:@{NSLocalizedDescriptionKey: @"simulated network failure"}];
+    self.apiHelperMock.mockError = mockError;
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+
+    [Radar ipGeocodeWithErrorCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy, NSError *_Nullable error) {
+        XCTAssertEqual(status, RadarStatusErrorNetwork);
+        XCTAssertEqualObjects(error, mockError);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:30
+                                 handler:^(NSError *_Nullable error) {
+                                     if (error) {
+                                         XCTFail();
+                                     }
+                                 }];
+}
+
+- (void)test_Radar_ipGeocode_legacy_three_arg_callback_still_called {
+    // Backward-compat: integrators using the deprecated 3-arg
+    // +ipGeocodeWithCompletionHandler: must still receive callbacks.
+    self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
+    self.apiHelperMock.mockStatus = RadarStatusErrorNetwork;
+    self.apiHelperMock.mockError = [NSError errorWithDomain:NSURLErrorDomain
+                                                       code:NSURLErrorNotConnectedToInternet
+                                                   userInfo:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy) {
+        XCTAssertEqual(status, RadarStatusErrorNetwork);
+
+        [expectation fulfill];
+    }];
+#pragma clang diagnostic pop
 
     [self waitForExpectationsWithTimeout:30
                                  handler:^(NSError *_Nullable error) {


### PR DESCRIPTION
Non-broken version of #608 

Ports [radarlabs/radar-sdk-android#525](https://github.com/radarlabs/radar-sdk-android/pull/525) to iOS.

## Summary

- Adds a new four-arg `+ipGeocodeWithErrorCompletionHandler:` (typedef `RadarIPGeocodeWithErrorCompletionHandler`) that exposes the underlying `NSError` when the failure originated from a caught network/parse/exception error, so integrators can forward it to error collectors (Sentry, Crashlytics, Datadog).
- Threads the caught `NSError` through `RadarAPIHelper`'s three error paths (`NSURLSession` error, `NSJSONSerialization` error, `@catch NSException`) and through the internal `RadarIPGeocodeAPICompletionHandler`. The parse and exception paths also gain a `RadarLogger` error log that they were previously missing.
- Swift consumers see only the new four-arg block under the existing `Radar.ipGeocode { ... }` call site (via `NS_SWIFT_NAME`).

## Backwards compatibility

- The legacy three-arg `+ipGeocodeWithCompletionHandler:` is preserved, marked `__attribute__((deprecated))`, and routes through the new method (ignoring the error). Existing ObjC integrators keep compiling and keep receiving callbacks.
- The internal generic `RadarAPICompletionHandler` block typedef gains an `NSError *` (third arg). Every callsite in `RadarAPIClient.m` was updated to take and pass-through the new parameter even though only `ipGeocode` consumes it — mirrors the Android PR and primes future extension to other callbacks.
- A `test_Radar_ipGeocode_legacy_three_arg_callback_still_called` test locks the BC behavior in.

Scope is intentionally limited to `ipGeocode` as the pilot. Version bump / MIGRATION will be handled in a separate PR.

## Test plan

- [ ] Manually: airplane-mode the Example app, tap `ipGeocode`, confirm the console prints `error = The Internet connection appears to be offline.`
