### PR TITLE
Harden Swift beacon syncing: guard major/minor + log skipped syncs

### DIFF
--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -91,8 +91,17 @@ final class RadarLocationManagerSwift: NSObject {
                 continue
             }
 
-            let major = CLBeaconMajorValue(truncatingIfNeeded: Int(beacon.major) ?? 0)
-            let minor = CLBeaconMinorValue(truncatingIfNeeded: Int(beacon.minor) ?? 0)
+            // A non-numeric major/minor would otherwise silently monitor a 0/0 region, which
+            // collides with other beacons. Skip the beacon instead of syncing bad values.
+            guard let majorInt = Int(beacon.major), let minorInt = Int(beacon.minor) else {
+                RadarLogger.shared.debug(
+                    "🦅 Error syncing beacon | identifier = \(identifier); uuid = \(beacon.uuid); major = \(beacon.major); minor = \(beacon.minor)"
+                )
+                continue
+            }
+
+            let major = CLBeaconMajorValue(truncatingIfNeeded: majorInt)
+            let minor = CLBeaconMinorValue(truncatingIfNeeded: minorInt)
             let region = CLBeaconRegion(
                 proximityUUID: proximityUUID,
                 major: major,

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -92,8 +92,6 @@ final class RadarLocationManagerSwift: NSObject {
                 continue
             }
 
-            // A non-numeric major/minor would otherwise silently monitor a 0/0 region, which
-            // collides with other beacons. Skip the beacon instead of syncing bad values.
             guard let majorInt = Int(beacon.major), let minorInt = Int(beacon.minor) else {
                 RadarLogger.shared.debug(
                     "🦅 Error syncing beacon | identifier = \(identifier); uuid = \(beacon.uuid); major = \(beacon.major); minor = \(beacon.minor)"

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -69,6 +69,7 @@ final class RadarLocationManagerSwift: NSObject {
     @objc(replaceSyncedBeaconsOnLocationManager:beacons:)
     static func replaceSyncedBeacons(locationManager: CLLocationManager, beacons: [RadarBeacon]?) {
         if RadarSettings.useRadarModifiedBeacon {
+            RadarLogger.shared.debug("🦅 Skipping replacing synced beacons | useRadarModifiedBeacon = true")
             return
         }
 
@@ -121,6 +122,7 @@ final class RadarLocationManagerSwift: NSObject {
     @objc(replaceSyncedBeaconUUIDsOnLocationManager:uuids:)
     static func replaceSyncedBeaconUUIDs(locationManager: CLLocationManager, uuids: [String]?) {
         if RadarSettings.useRadarModifiedBeacon {
+            RadarLogger.shared.debug("🦅 Skipping replacing synced beacon UUIDs | useRadarModifiedBeacon = true")
             return
         }
 
@@ -128,6 +130,7 @@ final class RadarLocationManagerSwift: NSObject {
 
         let options = Radar.getTrackingOptions()
         guard RadarSettings.tracking, options.beacons, let uuids else {
+            RadarLogger.shared.debug("🦅 Skipping replacing synced beacon UUIDs")
             return
         }
 
@@ -152,6 +155,7 @@ final class RadarLocationManagerSwift: NSObject {
     @objc(removeSyncedBeaconsOnLocationManager:)
     static func removeSyncedBeacons(locationManager: CLLocationManager) {
         if RadarSettings.useRadarModifiedBeacon {
+            RadarLogger.shared.debug("🦅 Skipping removing synced beacons | useRadarModifiedBeacon = true")
             return
         }
 


### PR DESCRIPTION
## Summary

Follow-up to [#607](https://github.com/radarlabs/radar-sdk-ios/pull/607) addressing review feedback from @nickdonnelly on [#615](https://github.com/radarlabs/radar-sdk-ios/pull/615). Two small hardening fixes to the ported Swift beacon-sync methods in `RadarLocationManager+Swift.swift`.

## Changes

1. **Guard against non-numeric beacon `major`/`minor`** ([#615 comment](https://github.com/radarlabs/radar-sdk-ios/pull/615#discussion_r3358227506))
   - `RadarBeacon.major`/`.minor` are `String`s. The previous `Int(beacon.major) ?? 0` silently fell back to a `0/0` `CLBeaconRegion` when a value wasn't a parseable integer — monitoring the wrong region. Now a malformed major/minor skips the beacon and logs an error, mirroring the existing `proximityUUID` guard.

2. **Log skipped syncs** ([#615 comment](https://github.com/radarlabs/radar-sdk-ios/pull/615#discussion_r3358241374))
   - The three `useRadarModifiedBeacon` early returns and the tracking/options guard in `replaceSyncedBeaconUUIDs` returned silently. Added debug logs so it's clear when/why beacon syncing is skipped, matching the existing log in `replaceSyncedBeacons`.

## Notes
- Behavior change is limited to the malformed-input path (previously synced a bogus `0/0` region; now skips it). Valid input is unchanged.