### PR TITLE
FRA-2021: Escape non-ascii characters

### DIFF
--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -67,7 +67,7 @@
 
 + (NSDictionary *)headersWithPublishableKey:(NSString *)publishableKey {
     NSDictionary *appInfo = [RadarUtils appInfo];
-    NSString *appInfoJSON = [RadarUtils dictionaryToJson:appInfo];
+    NSString *appInfoJSON = [RadarUtils escapeNonAsciiCharacters:[RadarUtils dictionaryToJson:appInfo]];
     
     NSMutableDictionary *headers = [@{
         @"Authorization": publishableKey,

--- a/RadarSDK/RadarAPIHelper.swift
+++ b/RadarSDK/RadarAPIHelper.swift
@@ -105,7 +105,7 @@ final class RadarAPIHelper: Sendable {
         headers["X-Radar-SDK-Version"] = RadarUtils.sdkVersion
         headers["X-Radar-Mobile-Origin"] = Bundle.main.bundleIdentifier
         headers["X-Radar-Network-Type"] = RadarUtils.networkType.rawValue
-        headers["X-Radar-App-Info"] = RadarUtils.dictionaryToJson(RadarUtils.appInfo)
+        headers["X-Radar-App-Info"] = RadarUtils.escapeNonAsciiCharacters(RadarUtils.dictionaryToJson(RadarUtils.appInfo))
 
         let url = "\(RadarSettings.host)/v1/\(url)"
 

--- a/RadarSDK/RadarUtils.h
+++ b/RadarSDK/RadarUtils.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, RadarConnectionType) {
 
 + (NSDictionary *)appInfo;
 
++ (NSString *)escapeNonAsciiCharacters:(NSString *)string;
 @end
 
 __attribute__((deprecated("Use RadarUtils for swift implementation instead, except deviceOS, deviceId, foreground, backgroundTimeRemaining, and runOnMainThread calls from Objective-C")));

--- a/RadarSDK/RadarUtils.swift
+++ b/RadarSDK/RadarUtils.swift
@@ -230,6 +230,19 @@ class RadarUtils: NSObject {
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()
+    
+    static func escapeNonAsciiCharacters(_ string: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(string.utf16.count)
+        for codeUnit in string.utf16 {
+            if codeUnit < 0x80, let scalar = Unicode.Scalar(codeUnit) {
+                escaped.unicodeScalars.append(scalar)
+            } else {
+                escaped += String(format: "\\u%04x", codeUnit)
+            }
+        }
+        return escaped
+    }
 }
 
 internal extension CLLocation {

--- a/RadarSDK/RadarUtils.swift
+++ b/RadarSDK/RadarUtils.swift
@@ -230,7 +230,7 @@ class RadarUtils: NSObject {
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()
-    
+
     static func escapeNonAsciiCharacters(_ string: String) -> String {
         var escaped = ""
         escaped.reserveCapacity(string.utf16.count)

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -50,4 +50,31 @@ struct RadarUtilsTests {
         let dict: [String: Any] = ["nested": inner]
         #expect(RadarUtils.dictionaryToJson(dict) == "{}")
     }
+    
+    @Test func escapeNonAsciiLeavesAsciiUntouched() {
+        #expect(RadarUtils.escapeNonAsciiCharacters("{\"name\":\"Cafe\"}") == "{\"name\":\"Cafe\"}")
+    }
+    
+    @Test func escapeNonAsciiEscapesAccentedCharacters() {
+        #expect(RadarUtils.escapeNonAsciiCharacters("Café") == "Caf\\u00e9")
+        #expect(RadarUtils.escapeNonAsciiCharacters("Niño") == "Ni\\u00f1o")
+    }
+    
+    @Test func escapeNonAsciiResultIsValidJson() {
+        let json = RadarUtils.escapeNonAsciiCharacters(RadarUtils.dictionaryToJson(["name": "Café"]))
+        // Every character is now ASCII.
+        #expect(json.allSatisfy { $0.isASCII })
+        let data = json.data(using: .utf8)!
+        let decoded = try! JSONSerialization.jsonObject(with: data) as! [String: String]
+        #expect(decoded["name"] == "Café")
+    }
+    
+    @Test func escapeNonAsciiHandlesEmojiSurrogatePairs() {
+        // U+1F600 -> surrogate pair \ud83d\ude00, both valid JSON.
+        let escaped = RadarUtils.escapeNonAsciiCharacters("😀")
+        #expect(escaped == "\\ud83d\\ude00")
+        let json = "\"\(escaped)\"".data(using: .utf8)!
+        let decoded = try! JSONSerialization.jsonObject(with: json) as! String
+        #expect(decoded == "😀")
+    }
 }

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -50,31 +50,29 @@ struct RadarUtilsTests {
         let dict: [String: Any] = ["nested": inner]
         #expect(RadarUtils.dictionaryToJson(dict) == "{}")
     }
-    
+
     @Test func escapeNonAsciiLeavesAsciiUntouched() {
         #expect(RadarUtils.escapeNonAsciiCharacters("{\"name\":\"Cafe\"}") == "{\"name\":\"Cafe\"}")
     }
-    
+
     @Test func escapeNonAsciiEscapesAccentedCharacters() {
         #expect(RadarUtils.escapeNonAsciiCharacters("Café") == "Caf\\u00e9")
         #expect(RadarUtils.escapeNonAsciiCharacters("Niño") == "Ni\\u00f1o")
     }
-    
-    @Test func escapeNonAsciiResultIsValidJson() {
+
+    @Test func escapeNonAsciiResultIsValidJson() throws {
         let json = RadarUtils.escapeNonAsciiCharacters(RadarUtils.dictionaryToJson(["name": "Café"]))
         // Every character is now ASCII.
         #expect(json.allSatisfy { $0.isASCII })
-        let data = json.data(using: .utf8)!
-        let decoded = try! JSONSerialization.jsonObject(with: data) as! [String: String]
-        #expect(decoded["name"] == "Café")
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: String]
+        #expect(decoded?["name"] == "Café")
     }
-    
-    @Test func escapeNonAsciiHandlesEmojiSurrogatePairs() {
+
+    @Test func escapeNonAsciiHandlesEmojiSurrogatePairs() throws {
         // U+1F600 -> surrogate pair \ud83d\ude00, both valid JSON.
         let escaped = RadarUtils.escapeNonAsciiCharacters("😀")
         #expect(escaped == "\\ud83d\\ude00")
-        let json = "\"\(escaped)\"".data(using: .utf8)!
-        let decoded = try! JSONSerialization.jsonObject(with: json) as! String
+        let decoded = try JSONSerialization.jsonObject(with: Data("\"\(escaped)\"".utf8)) as? String
         #expect(decoded == "😀")
     }
 }

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -72,7 +72,7 @@ struct RadarUtilsTests {
         // U+1F600 -> surrogate pair \ud83d\ude00, both valid JSON.
         let escaped = RadarUtils.escapeNonAsciiCharacters("😀")
         #expect(escaped == "\\ud83d\\ude00")
-        let decoded = try JSONSerialization.jsonObject(with: Data("\"\(escaped)\"".utf8)) as? String
+        let decoded = try JSONSerialization.jsonObject(with: Data("\"\(escaped)\"".utf8), options: [.allowFragments]) as? String
         #expect(decoded == "😀")
     }
 }


### PR DESCRIPTION
Escapes any non-ASCII character in the header value to a JSON `\uXXXX` sequence so the value is always ASCII-safe, while remaining valid JSON that the backend decodes identically.