### PR TITLE
FENCE-2887: Add day-of-week scheduling filter to CSGN

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		F64C80D72F64876500943B7A /* RadarSDKFraud.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F64C7FB52F645ABD00943B7A /* RadarSDKFraud.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F6513E792E60A5F600523472 /* LocationPushExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F6513E722E60A5F600523472 /* LocationPushExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F6513F602E6B736200523472 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6513F5F2E6B736200523472 /* MainView.swift */; };
+		F6513F702E6B736200523472 /* CSGNInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6513F712E6B736200523472 /* CSGNInspectorView.swift */; };
 		F65F793E2EF458E600399E84 /* MyIAMDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65F79382EF458E000399E84 /* MyIAMDelegate.swift */; };
 		F66DAD6A2E707F0700896773 /* waypoints.gpx in Sources */ = {isa = PBXBuildFile; fileRef = F66DAD642E707F0300896773 /* waypoints.gpx */; };
 /* End PBXBuildFile section */
@@ -166,6 +167,7 @@
 		F64C7FB52F645ABD00943B7A /* RadarSDKFraud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RadarSDKFraud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6513E722E60A5F600523472 /* LocationPushExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LocationPushExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6513F5F2E6B736200523472 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		F6513F712E6B736200523472 /* CSGNInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSGNInspectorView.swift; sourceTree = "<group>"; };
 		F65F79382EF458E000399E84 /* MyIAMDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyIAMDelegate.swift; sourceTree = "<group>"; };
 		F66DAD642E707F0300896773 /* waypoints.gpx */ = {isa = PBXFileReference; lastKnownFileType = text; path = waypoints.gpx; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -272,6 +274,7 @@
 				DDB861D22385FC3E00770661 /* Default-568h@2x.png */,
 				DD236D26230A006700EB88F9 /* AppDelegate.swift */,
 				F6513F5F2E6B736200523472 /* MainView.swift */,
+				F6513F712E6B736200523472 /* CSGNInspectorView.swift */,
 				F61886C42EA7DC800072E87C /* MapView.swift */,
 				F63DDAD42E746BB0006991F5 /* StyledButton.swift */,
 				F61886C02EA7DB3F0072E87C /* MyRadarDelegate.swift */,
@@ -537,6 +540,7 @@
 				F618871C2EAFC1EE0072E87C /* Test.mm in Sources */,
 				DD236D27230A006700EB88F9 /* AppDelegate.swift in Sources */,
 				F6513F602E6B736200523472 /* MainView.swift in Sources */,
+				F6513F702E6B736200523472 /* CSGNInspectorView.swift in Sources */,
 				F61886C32EA7DB5F0072E87C /* LogsView.swift in Sources */,
 				F61886C12EA7DB440072E87C /* MyRadarDelegate.swift in Sources */,
 				F65F793E2EF458E600399E84 /* MyIAMDelegate.swift in Sources */,

--- a/Example/Example/CSGNInspectorView.swift
+++ b/Example/Example/CSGNInspectorView.swift
@@ -1,0 +1,257 @@
+//
+//  CSGNInspectorView.swift
+//  Example
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import RadarSDK
+import SwiftUI
+import UserNotifications
+
+/// General-purpose inspector for client-side geofence notifications (CSGNs).
+///
+/// Snapshots the live registered state using public APIs only — no campaign-specific
+/// hardcoding — so it works for any CSGN. It surfaces what the pending-notification list
+/// alone can't: each region's geometry, whether the device is currently inside a region
+/// (iOS won't fire an entry trigger until you leave and re-enter), and the location /
+/// notification authorization that gate background delivery.
+///
+/// Pair this with `Radar.setLogLevel(.debug)` + the Debug tab: this view shows what *is*
+/// registered and whether it can fire; the SDK's `CSGN skip <id>: ...` logs explain why a
+/// geofence was *not* registered.
+struct CSGNInspectorView: View {
+
+    /// `radar_geofence_` notifications are the client-side geofence triggers registered by
+    /// the SDK. The prefix is internal to RadarSDK, so it is duplicated here intentionally.
+    private static let radarGeofencePrefix = "radar_geofence_"
+
+    private struct CSGNRow: Identifiable {
+        let id: String
+        let title: String
+        let body: String
+        let campaignId: String
+        let campaignType: String
+        let daysOfWeek: String
+        let startsAt: String
+        let endsAt: String
+        let restrictToOperatingHours: String
+        let repeats: String
+        let center: CLLocationCoordinate2D?
+        let radius: Double?
+        let isInside: Bool?          // nil = no current location to compare against
+        let distanceToCenter: Double?
+    }
+
+    @State private var locationAuth = "—"
+    @State private var notificationAuth = "—"
+    @State private var currentLocationText = "—"
+    @State private var rows: [CSGNRow] = []
+    @State private var lastRefreshed = "never"
+    @State private var showFiringSteps = true
+
+    /// Recommended distance to walk past the edge before re-entering, derived from the
+    /// largest registered region. GPS error is added to the radius, so we suggest the
+    /// greater of 2× the radius or radius + 150 m (≥200 m when nothing is registered yet).
+    private var recommendedOutMeters: Int {
+        guard let maxRadius = rows.compactMap(\.radius).max() else { return 200 }
+        return Int(max(maxRadius * 2, maxRadius + 150).rounded())
+    }
+
+    private var firingSteps: [String] {
+        [
+            "1. Use a large, isolated geofence (≥150–200 m radius). Make it big enough to walk through the center, not just clip the edge — small (<100 m) or overlapping geofences fire inconsistently.",
+            "2. Pick a spot you can reach from well outside, and don't place it where you're already standing (a region you start INSIDE won't fire).",
+            "3. Set Location permission to Always (Settings → this app → Location). Background entries aren't delivered with \"While Using\".",
+            "4. Start OUTSIDE the geofence. Any region marked INSIDE below won't fire until you leave first.",
+            "5. Walk/drive at least ~\(recommendedOutMeters) m past the edge, then stay out ~1–2 min so iOS registers the exit and the SDK re-registers the region while you're outside.",
+            "6. Head back in through the center, and keep moving — iOS detects crossings from motion + cell/Wi-Fi, not constant GPS.",
+            "7. Delivery takes ~20 s to a few minutes. In the foreground, watch for the banner / the \"will present notification!\" console log.",
+        ]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                DisclosureGroup(isExpanded: $showFiringSteps) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(firingSteps.enumerated()), id: \.offset) { _, step in
+                            Text(step)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+                } label: {
+                    Text("How to make a CSGN fire").bold()
+                }
+                .font(.system(.footnote, design: .monospaced))
+                .padding(8)
+                .background(Color(.systemGray5))
+                .cornerRadius(8)
+
+                Group {
+                    Text("Location auth: \(locationAuth)")
+                    Text("Notification auth: \(notificationAuth)")
+                    Text("Current location: \(currentLocationText)")
+                    Text("Registered CSGNs: \(rows.count)  (~20 region/app budget, shared with tracking)")
+                    Text("Refreshed: \(lastRefreshed)")
+                }
+                .font(.system(.footnote, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+
+                if rows.isEmpty {
+                    Text("No radar_geofence_* notifications pending. If a campaign should be here, check the Debug tab for `CSGN skip` logs.")
+                        .font(.system(.footnote, design: .monospaced))
+                }
+
+                ForEach(rows) { row in
+                    rowView(row)
+                }
+            }
+            .padding()
+        }
+        .onAppear { refresh() }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: CSGNRow) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(row.title.isEmpty ? row.id : row.title).bold()
+            Text("body: \(row.body)")
+            Text("geofenceId: \(row.id)")
+            Text("campaignId: \(row.campaignId)  type: \(row.campaignType)")
+            Text("daysOfWeek: \(row.daysOfWeek)")
+            Text("startsAt: \(row.startsAt)")
+            Text("endsAt: \(row.endsAt)")
+            Text("restrictToOperatingHours: \(row.restrictToOperatingHours)  repeats: \(row.repeats)")
+
+            if let center = row.center, let radius = row.radius {
+                Text(String(format: "region: (%.6f, %.6f) r=%.0fm", center.latitude, center.longitude, radius))
+                switch row.isInside {
+                case .some(true):
+                    Text("⚠️ INSIDE this region — iOS won't fire entry until you exit & re-enter")
+                        .foregroundColor(.red)
+                case .some(false):
+                    if let d = row.distanceToCenter {
+                        Text(String(format: "OUTSIDE — %.0fm to center, %.0fm to edge", d, d - radius))
+                            .foregroundColor(.green)
+                    }
+                case .none:
+                    Text("location unknown — can't determine inside/outside")
+                }
+            } else {
+                Text("no location trigger / region")
+            }
+        }
+        .font(.system(.caption, design: .monospaced))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+    }
+
+    private func refresh() {
+        locationAuth = Self.describe(CLLocationManager().authorizationStatus)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let auth = Self.describe(settings.authorizationStatus)
+            DispatchQueue.main.async { notificationAuth = auth }
+        }
+
+        // Fetch a fresh location first, then build the rows relative to it so each region's
+        // inside/outside + distance is accurate.
+        Radar.getLocation { _, location, _ in
+            DispatchQueue.main.async {
+                if let location = location {
+                    currentLocationText = String(
+                        format: "(%.6f, %.6f) ±%.0fm",
+                        location.coordinate.latitude, location.coordinate.longitude, location.horizontalAccuracy
+                    )
+                } else {
+                    currentLocationText = "unavailable"
+                }
+                buildRows(current: location)
+            }
+        }
+    }
+
+    private func buildRows(current: CLLocation?) {
+        UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+            let built: [CSGNRow] = requests
+                .filter { $0.identifier.hasPrefix(Self.radarGeofencePrefix) }
+                .map { request in
+                    let userInfo = request.content.userInfo
+                    let region = (request.trigger as? UNLocationNotificationTrigger)?.region as? CLCircularRegion
+
+                    var isInside: Bool?
+                    var distance: Double?
+                    if let region = region, let current = current {
+                        isInside = region.contains(current.coordinate)
+                        distance = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                            .distance(from: current)
+                    }
+
+                    return CSGNRow(
+                        id: (userInfo["geofenceId"] as? String) ?? request.identifier,
+                        title: request.content.title,
+                        body: request.content.body,
+                        campaignId: Self.str(userInfo["radar:campaignId"]),
+                        campaignType: Self.str(userInfo["radar:campaignType"]),
+                        daysOfWeek: Self.str(userInfo["radar:daysOfWeek"]),
+                        startsAt: Self.str(userInfo["radar:startsAt"]),
+                        endsAt: Self.str(userInfo["radar:endsAt"]),
+                        restrictToOperatingHours: Self.str(userInfo["radar:restrictToOperatingHours"]),
+                        repeats: Self.str(userInfo["radar:notificationRepeats"]),
+                        center: region?.center,
+                        radius: region?.radius,
+                        isInside: isInside,
+                        distanceToCenter: distance
+                    )
+                }
+            DispatchQueue.main.async {
+                rows = built
+                lastRefreshed = Self.timeString()
+            }
+        }
+    }
+
+    private static func str(_ value: Any?) -> String {
+        guard let value = value else { return "—" }
+        return "\(value)"
+    }
+
+    private static func describe(_ status: CLAuthorizationStatus) -> String {
+        switch status {
+        case .authorizedAlways: return "Always"
+        case .authorizedWhenInUse: return "WhenInUse ⚠️ (background CSGNs need Always)"
+        case .denied: return "Denied"
+        case .restricted: return "Restricted"
+        case .notDetermined: return "NotDetermined"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private static func describe(_ status: UNAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "Authorized"
+        case .provisional: return "Provisional"
+        case .ephemeral: return "Ephemeral"
+        case .denied: return "Denied"
+        case .notDetermined: return "NotDetermined"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private static func timeString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: Date())
+    }
+}
+
+#Preview {
+    CSGNInspectorView()
+}

--- a/Example/Example/MainView.swift
+++ b/Example/Example/MainView.swift
@@ -15,6 +15,7 @@ struct MainView: View {
         case Map
         case Logs
         case Tests
+        case CSGN
     }
     
     @State private var selectedTab: TabIdentifier = .Tests;
@@ -32,6 +33,10 @@ struct MainView: View {
             TestsView().tabItem {
                 Text("Tests")
             }.tag(TabIdentifier.Tests)
+
+            CSGNInspectorView().tabItem {
+                Text("CSGN")
+            }.tag(TabIdentifier.CSGN)
         }
     }
 }

--- a/RadarSDK/RadarBeaconManager.m
+++ b/RadarSDK/RadarBeaconManager.m
@@ -154,6 +154,13 @@ static NSString *const kBeaconNotificationIdentifierPrefix = @"radar_beacon_noti
         
         if (region) {
             NSString *notificationId = [NSString stringWithFormat:@"%@%@", kBeaconNotificationIdentifierPrefix, uuid];
+            // Honor the campaign scheduling window / day-of-week filter, mirroring the geofence path, so a
+            // beacon notification isn't scheduled outside its window or on a non-selected day of the week.
+            if (![RadarNotificationHelper isNotificationActiveForMetadata:metadata now:[NSDate date]]) {
+                [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                    message:[NSString stringWithFormat:@"Skipping beacon notification: outside campaign schedule window or day | identifier = %@", notificationId]];
+                continue;
+            }
             // Extract notification content from metadata
             UNMutableNotificationContent *content = [RadarNotificationHelper extractContentFromMetadata:metadata identifier:notificationId];
             if (content) {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -619,59 +619,13 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
             NSDictionary *metadata = geofence.metadata;
             if (metadata) {
-                // "yyyy-MM-dd'T'HH:mm:ss.SSS" is 23 chars; prefix to this length strips any trailing timezone suffix so the string is parsed as wall-clock local time
-                static const NSUInteger kSchedulingWindowDatePrefixLength = 23;
-                static NSDateFormatter *windowFormatter;
-                static dispatch_once_t windowFormatterOnce;
-                dispatch_once(&windowFormatterOnce, ^{
-                    windowFormatter = [[NSDateFormatter alloc] init];
-                    windowFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-                    windowFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS";
-                });
-                NSDate *now = [NSDate date];
-                NSString *startsAtString = [metadata objectForKey:@"radar:startsAt"];
-                // Window is [startsAt, endsAt]: skip when now is before the window opens
-                if ([startsAtString isKindOfClass:[NSString class]] && startsAtString.length >= kSchedulingWindowDatePrefixLength) {
-                    NSDate *startsAt = [windowFormatter dateFromString:[startsAtString substringToIndex:kSchedulingWindowDatePrefixLength]];
-                    if (startsAt && [now compare:startsAt] == NSOrderedAscending) {
-                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
-                            message:[NSString stringWithFormat:@"Skipping notification: before window | geofenceId = %@", geofenceId]];
-                        continue;
-                    }
-                }
-                NSString *endsAtString = [metadata objectForKey:@"radar:endsAt"];
-                // Window is [startsAt, endsAt]: skip when now is strictly past the end (end is inclusive)
-                if ([endsAtString isKindOfClass:[NSString class]] && endsAtString.length >= kSchedulingWindowDatePrefixLength) {
-                    NSDate *endsAt = [windowFormatter dateFromString:[endsAtString substringToIndex:kSchedulingWindowDatePrefixLength]];
-                    if (endsAt && [now compare:endsAt] == NSOrderedDescending) {
-                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
-                            message:[NSString stringWithFormat:@"Skipping notification: after window | geofenceId = %@", geofenceId]];
-                        continue;
-                    }
-                }
-                // `radar:daysOfWeek` is a comma-separated list of day abbreviations ("Sun"…"Sat"); skip when
-                // today (device-local) is not listed. An absent or empty value means every day of the week.
-                NSString *daysOfWeekString = [metadata objectForKey:@"radar:daysOfWeek"];
-                if ([daysOfWeekString isKindOfClass:[NSString class]] && daysOfWeekString.length > 0) {
-                    static NSArray<NSString *> *daysOfWeekAbbr;
-                    static dispatch_once_t daysOfWeekAbbrOnce;
-                    dispatch_once(&daysOfWeekAbbrOnce, ^{
-                        daysOfWeekAbbr = @[ @"sun", @"mon", @"tue", @"wed", @"thu", @"fri", @"sat" ];
-                    });
-                    NSMutableSet<NSString *> *allowedDays = [NSMutableSet set];
-                    for (NSString *day in [daysOfWeekString componentsSeparatedByString:@","]) {
-                        NSString *trimmed = [[day stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
-                        if (trimmed.length > 0) {
-                            [allowedDays addObject:trimmed];
-                        }
-                    }
-                    NSInteger weekdayIndex = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] component:NSCalendarUnitWeekday fromDate:now] - 1;
-                    NSString *today = (weekdayIndex >= 0 && weekdayIndex < (NSInteger)daysOfWeekAbbr.count) ? daysOfWeekAbbr[weekdayIndex] : nil;
-                    if (today && allowedDays.count > 0 && ![allowedDays containsObject:today]) {
-                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
-                            message:[NSString stringWithFormat:@"Skipping notification: day of week not active | geofenceId = %@", geofenceId]];
-                        continue;
-                    }
+                // Skip the notification when outside the campaign's scheduling window or not active on
+                // today's local day of week (region monitoring above still starts). Shared with the
+                // beacon path via RadarNotificationHelper so the evaluation stays in one place.
+                if (![RadarNotificationHelper isNotificationActiveForMetadata:metadata now:[NSDate date]]) {
+                    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                        message:[NSString stringWithFormat:@"Skipping notification: outside campaign schedule window or day | geofenceId = %@", geofenceId]];
+                    continue;
                 }
                 UNMutableNotificationContent *content = [RadarNotificationHelper extractContentFromMetadata:metadata identifier:identifier];
                 if (content) {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -649,6 +649,30 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
                         continue;
                     }
                 }
+                // `radar:daysOfWeek` is a comma-separated list of day abbreviations ("Sun"…"Sat"); skip when
+                // today (device-local) is not listed. An absent or empty value means every day of the week.
+                NSString *daysOfWeekString = [metadata objectForKey:@"radar:daysOfWeek"];
+                if ([daysOfWeekString isKindOfClass:[NSString class]] && daysOfWeekString.length > 0) {
+                    static NSArray<NSString *> *daysOfWeekAbbr;
+                    static dispatch_once_t daysOfWeekAbbrOnce;
+                    dispatch_once(&daysOfWeekAbbrOnce, ^{
+                        daysOfWeekAbbr = @[ @"sun", @"mon", @"tue", @"wed", @"thu", @"fri", @"sat" ];
+                    });
+                    NSMutableSet<NSString *> *allowedDays = [NSMutableSet set];
+                    for (NSString *day in [daysOfWeekString componentsSeparatedByString:@","]) {
+                        NSString *trimmed = [[day stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+                        if (trimmed.length > 0) {
+                            [allowedDays addObject:trimmed];
+                        }
+                    }
+                    NSInteger weekdayIndex = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] component:NSCalendarUnitWeekday fromDate:now] - 1;
+                    NSString *today = (weekdayIndex >= 0 && weekdayIndex < (NSInteger)daysOfWeekAbbr.count) ? daysOfWeekAbbr[weekdayIndex] : nil;
+                    if (today && allowedDays.count > 0 && ![allowedDays containsObject:today]) {
+                        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
+                            message:[NSString stringWithFormat:@"Skipping notification: day of week not active | geofenceId = %@", geofenceId]];
+                        continue;
+                    }
+                }
                 UNMutableNotificationContent *content = [RadarNotificationHelper extractContentFromMetadata:metadata identifier:identifier];
                 if (content) {
 

--- a/RadarSDK/RadarNotification.swift
+++ b/RadarSDK/RadarNotification.swift
@@ -72,6 +72,10 @@ extension RadarGeofenceSwift {
             return nil
         }
 
+        if !isActiveOnDayOfWeek(now: now) {
+            return nil
+        }
+
         let identifier = GEOFENCE_NOTIFICATION_PREFIX + id
         // Content
         guard let metadata = metadata,
@@ -144,6 +148,27 @@ extension RadarGeofenceSwift {
             }
         }
         return true
+    }
+
+    private func isActiveOnDayOfWeek(now: Date) -> Bool {
+        // `radar:daysOfWeek` is a comma-separated list of day abbreviations ("Sun"…"Sat"); the
+        // campaign only fires on the listed days. An absent or empty value means every day.
+        guard let daysOfWeekStr = metadata?["radar:daysOfWeek"]?.string() else {
+            return true
+        }
+        let allowedDays = Set(
+            daysOfWeekStr
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+                .filter { !$0.isEmpty }
+        )
+        if allowedDays.isEmpty {
+            return true
+        }
+        guard let today = RadarOperatingHoursEvaluator.weekdayAbbreviation(for: now)?.lowercased() else {
+            return true
+        }
+        return allowedDays.contains(today)
     }
 }
 

--- a/RadarSDK/RadarNotification.swift
+++ b/RadarSDK/RadarNotification.swift
@@ -69,10 +69,12 @@ extension RadarGeofenceSwift {
 
     func toNotificationRequest(now: Date = Date()) -> UNNotificationRequest? {
         if !isWithinSchedulingWindow(now: now) {
+            RadarLogger.debug("CSGN skip \(id): outside scheduling window")
             return nil
         }
 
         if !isActiveOnDayOfWeek(now: now) {
+            RadarLogger.debug("CSGN skip \(id): not active on today's day of week")
             return nil
         }
 
@@ -81,6 +83,11 @@ extension RadarGeofenceSwift {
         guard let metadata = metadata,
             let metadataContent = RadarNotificationContent(from: metadata)
         else {
+            // Only surface this for geofences that look like campaigns; ordinary geofences
+            // legitimately carry no notification content and would otherwise spam the log.
+            if metadata?["radar:campaignType"] != nil {
+                RadarLogger.debug("CSGN skip \(id): missing radar:notificationText/radar:campaignId")
+            }
             return nil
         }
 
@@ -96,11 +103,13 @@ extension RadarGeofenceSwift {
                 now: now,
                 closeBufferMinutes: closeBufferMinutes
             ) {
+                RadarLogger.debug("CSGN skip \(id): operating hours closed")
                 return nil
             }
         }
 
         guard let geofenceData = try? JSONEncoder().encode(self) else {
+            RadarLogger.debug("CSGN skip \(id): failed to encode geofence")
             return nil
         }
         var userInfo: [String: Any] = [
@@ -127,6 +136,9 @@ extension RadarGeofenceSwift {
         let repeats = if case let .bool(value)? = metadata["radar:notificationRepeats"] { value } else { false }
         let trigger = UNLocationNotificationTrigger(region: region, repeats: repeats)
 
+        RadarLogger.debug(
+            "CSGN register \(id) campaign=\(metadataContent.campaignId) center=(\(latitude),\(longitude)) r=\(radius) repeats=\(repeats)"
+        )
         return UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
     }
 

--- a/RadarSDK/RadarNotificationHelper.h
+++ b/RadarSDK/RadarNotificationHelper.h
@@ -30,6 +30,12 @@ typedef void (^NotificationPermissionCheckCompletion)(BOOL granted);
 
 + (nullable UNMutableNotificationContent *)extractContentFromMetadata:(nullable NSDictionary *)metadata identifier:(nullable NSString *)identifier;
 
+/// Returns whether a client-side notification carrying `metadata` should be scheduled at `now`:
+/// within the optional `radar:startsAt`/`radar:endsAt` window (inclusive, parsed as wall-clock local
+/// time) and active on the local day in `radar:daysOfWeek`. Absent/empty values mean "no constraint".
+/// Shared by the geofence and beacon notification paths so the evaluation stays in one place.
++ (BOOL)isNotificationActiveForMetadata:(nullable NSDictionary *)metadata now:(NSDate *)now;
+
 + (void)getNotificationDiffWithCompletionHandler:(void (^)(NSArray *notificationsDelivered, NSArray *notificationsRemaining))completionHandler;
 @end
 

--- a/RadarSDK/RadarNotificationHelper.m
+++ b/RadarSDK/RadarNotificationHelper.m
@@ -28,6 +28,64 @@ static dispatch_semaphore_t notificationSemaphore;
     }
 }
 
++ (BOOL)isNotificationActiveForMetadata:(NSDictionary *)metadata now:(NSDate *)now {
+    if (![metadata isKindOfClass:[NSDictionary class]]) {
+        return YES;
+    }
+
+    // "yyyy-MM-dd'T'HH:mm:ss.SSS" is 23 chars; prefix to this length strips any trailing timezone suffix so the string is parsed as wall-clock local time
+    static const NSUInteger kSchedulingWindowDatePrefixLength = 23;
+    static NSDateFormatter *windowFormatter;
+    static dispatch_once_t windowFormatterOnce;
+    dispatch_once(&windowFormatterOnce, ^{
+        windowFormatter = [[NSDateFormatter alloc] init];
+        windowFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        windowFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS";
+    });
+
+    NSString *startsAtString = [metadata objectForKey:@"radar:startsAt"];
+    // Window is [startsAt, endsAt]: skip when now is before the window opens
+    if ([startsAtString isKindOfClass:[NSString class]] && startsAtString.length >= kSchedulingWindowDatePrefixLength) {
+        NSDate *startsAt = [windowFormatter dateFromString:[startsAtString substringToIndex:kSchedulingWindowDatePrefixLength]];
+        if (startsAt && [now compare:startsAt] == NSOrderedAscending) {
+            return NO;
+        }
+    }
+    NSString *endsAtString = [metadata objectForKey:@"radar:endsAt"];
+    // Window is [startsAt, endsAt]: skip when now is strictly past the end (end is inclusive)
+    if ([endsAtString isKindOfClass:[NSString class]] && endsAtString.length >= kSchedulingWindowDatePrefixLength) {
+        NSDate *endsAt = [windowFormatter dateFromString:[endsAtString substringToIndex:kSchedulingWindowDatePrefixLength]];
+        if (endsAt && [now compare:endsAt] == NSOrderedDescending) {
+            return NO;
+        }
+    }
+
+    // `radar:daysOfWeek` is a comma-separated list of day abbreviations ("Sun"…"Sat"); skip when
+    // today (device-local) is not listed. An absent or empty value means every day of the week.
+    NSString *daysOfWeekString = [metadata objectForKey:@"radar:daysOfWeek"];
+    if ([daysOfWeekString isKindOfClass:[NSString class]] && daysOfWeekString.length > 0) {
+        static NSArray<NSString *> *daysOfWeekAbbr;
+        static dispatch_once_t daysOfWeekAbbrOnce;
+        dispatch_once(&daysOfWeekAbbrOnce, ^{
+            daysOfWeekAbbr = @[ @"sun", @"mon", @"tue", @"wed", @"thu", @"fri", @"sat" ];
+        });
+        NSMutableSet<NSString *> *allowedDays = [NSMutableSet set];
+        for (NSString *day in [daysOfWeekString componentsSeparatedByString:@","]) {
+            NSString *trimmed = [[day stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+            if (trimmed.length > 0) {
+                [allowedDays addObject:trimmed];
+            }
+        }
+        NSInteger weekdayIndex = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] component:NSCalendarUnitWeekday fromDate:now] - 1;
+        NSString *today = (weekdayIndex >= 0 && weekdayIndex < (NSInteger)daysOfWeekAbbr.count) ? daysOfWeekAbbr[weekdayIndex] : nil;
+        if (today && allowedDays.count > 0 && ![allowedDays containsObject:today]) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
 + (void)showNotificationsForEvents:(NSArray<RadarEvent *> *)events {
     if (!events || !events.count) {
         return;

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -54,12 +54,15 @@ actor RadarNotificationHelper: NSObject {
         }
 
         let decoded: [RadarGeofenceSwift] = geofences.compactMap { geofenceDict in
-            guard let json = try? JSONSerialization.data(withJSONObject: geofenceDict),
-                let geofence = try? JSONDecoder().decode(RadarGeofenceSwift.self, from: json)
-            else {
+            do {
+                let json = try JSONSerialization.data(withJSONObject: geofenceDict)
+                return try JSONDecoder().decode(RadarGeofenceSwift.self, from: json)
+            } catch {
+                // Surface schema mismatches (e.g. a missing `_id`) that would otherwise drop
+                // the geofence silently and leave no CSGN registered.
+                RadarLogger.debug("NotificationHelper failed to decode geofence: \(error) dict=\(geofenceDict)")
                 return nil
             }
-            return geofence
         }
 
         // Persist the full nearby set (incl. metadata + operatingHours) so a

--- a/RadarSDK/RadarOperatingHoursEvaluator.swift
+++ b/RadarSDK/RadarOperatingHoursEvaluator.swift
@@ -46,6 +46,19 @@ enum RadarOperatingHoursEvaluator {
         }
     }
 
+    /// Returns the day-of-week abbreviation ("Sun"…"Sat") for `date` evaluated in `timeZone`,
+    /// matching the keys used by `isOpen` and the `radar:daysOfWeek` campaign metadata.
+    static func weekdayAbbreviation(for date: Date, timeZone: TimeZone = .current) -> String? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        let weekdayIndex = calendar.component(.weekday, from: date) - 1
+        guard weekdayIndex >= 0, weekdayIndex < daysOfWeekAbbr.count else {
+            return nil
+        }
+        return daysOfWeekAbbr[weekdayIndex]
+    }
+
     private static func minutesSinceMidnight(_ timeString: String) -> Int? {
         if timeString == "24:00" {
             return 24 * 60

--- a/RadarSDK/RadarTrackingOptions.m
+++ b/RadarSDK/RadarTrackingOptions.m
@@ -367,6 +367,8 @@ NSString *const kTypeIsUser = @"is-user";
     return self.desiredStoppedUpdateInterval == options.desiredStoppedUpdateInterval && self.desiredMovingUpdateInterval == options.desiredMovingUpdateInterval &&
            self.desiredSyncInterval == options.desiredSyncInterval && self.desiredAccuracy == options.desiredAccuracy && self.stopDuration == options.stopDuration &&
            self.stopDistance == options.stopDistance &&
+           // Dates serialize to/from the dictionary at millisecond precision (timeIntervalSince1970 * 1000),
+           // so they are only meaningful to the millisecond; compare within 1ms rather than for exact equality.
            (self.startTrackingAfter == nil ? options.startTrackingAfter == nil :
                                              fabs(self.startTrackingAfter.timeIntervalSince1970 - options.startTrackingAfter.timeIntervalSince1970) < 0.001) &&
            (self.stopTrackingAfter == nil ? options.stopTrackingAfter == nil :

--- a/RadarSDK/RadarTrackingOptions.m
+++ b/RadarSDK/RadarTrackingOptions.m
@@ -368,9 +368,9 @@ NSString *const kTypeIsUser = @"is-user";
            self.desiredSyncInterval == options.desiredSyncInterval && self.desiredAccuracy == options.desiredAccuracy && self.stopDuration == options.stopDuration &&
            self.stopDistance == options.stopDistance &&
            (self.startTrackingAfter == nil ? options.startTrackingAfter == nil :
-                                             fabs(self.startTrackingAfter.timeIntervalSince1970 - options.startTrackingAfter.timeIntervalSince1970) < DBL_EPSILON) &&
+                                             fabs(self.startTrackingAfter.timeIntervalSince1970 - options.startTrackingAfter.timeIntervalSince1970) < 0.001) &&
            (self.stopTrackingAfter == nil ? options.stopTrackingAfter == nil :
-                                            fabs(self.stopTrackingAfter.timeIntervalSince1970 - options.stopTrackingAfter.timeIntervalSince1970) < DBL_EPSILON) &&
+                                            fabs(self.stopTrackingAfter.timeIntervalSince1970 - options.stopTrackingAfter.timeIntervalSince1970) < 0.001) &&
            self.syncLocations == options.syncLocations && self.replay == options.replay && self.showBlueBar == options.showBlueBar &&
            self.useStoppedGeofence == options.useStoppedGeofence && self.stoppedGeofenceRadius == options.stoppedGeofenceRadius &&
            self.useMovingGeofence == options.useMovingGeofence && self.movingGeofenceRadius == options.movingGeofenceRadius && self.syncGeofences == options.syncGeofences &&

--- a/RadarSDKTests/RadarNotificationTest.swift
+++ b/RadarSDKTests/RadarNotificationTest.swift
@@ -49,6 +49,14 @@ private func isoString(_ date: Date) -> String {
     formatter.string(from: date)
 }
 
+private let allDaysOfWeek = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+private func weekdayAbbreviation(for date: Date) -> String {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = .current
+    return allDaysOfWeek[cal.component(.weekday, from: date) - 1]
+}
+
 // MARK: - Tests
 
 @Suite()
@@ -149,5 +157,67 @@ struct RadarNotificationTest {
             "radar:startsAt": .string(isoString(now.addingTimeInterval(-1)))
         ])
         #expect(geofence.toNotificationRequest(now: now) == nil)
+    }
+
+    // MARK: - Day of week
+
+    @Test func dayOfWeekIncludesToday_returnsRequest() {
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string(weekdayAbbreviation(for: now))
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) != nil)
+    }
+
+    @Test func dayOfWeekExcludesToday_returnsNil() {
+        let otherDay = allDaysOfWeek.first { $0 != weekdayAbbreviation(for: now) }!
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string(otherDay)
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) == nil)
+    }
+
+    @Test func dayOfWeekListIncludesToday_returnsRequest() {
+        let today = weekdayAbbreviation(for: now)
+        let otherDay = allDaysOfWeek.first { $0 != today }!
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string("\(otherDay),\(today)")
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) != nil)
+    }
+
+    @Test func dayOfWeekListExcludesToday_returnsNil() {
+        let others = allDaysOfWeek.filter { $0 != weekdayAbbreviation(for: now) }
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string("\(others[0]),\(others[1])")
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) == nil)
+    }
+
+    @Test func emptyDaysOfWeek_returnsRequest() {
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string("")
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) != nil)
+    }
+
+    @Test func dayOfWeekCaseInsensitive_returnsRequest() {
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string(weekdayAbbreviation(for: now).lowercased())
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) != nil)
+    }
+
+    @Test func dayOfWeekWhitespaceAndUnknownTokens_returnsRequest() {
+        let geofence = makeGeofence(
+            metadata: baseMetadata(extras: [
+                "radar:daysOfWeek": .string(" \(weekdayAbbreviation(for: now)) , Xyz ")
+            ]))
+        #expect(geofence.toNotificationRequest(now: now) != nil)
     }
 }

--- a/RadarSDKTests/RadarOperatingHoursEvaluatorTest.swift
+++ b/RadarSDKTests/RadarOperatingHoursEvaluatorTest.swift
@@ -87,6 +87,15 @@ struct RadarOperatingHoursEvaluatorTest {
         #expect(RadarOperatingHoursEvaluator.isOpen(operatingHours: hours, now: date(timezone, hour: 14), timeZone: timezone))
     }
 
+    @Test("weekday abbreviation is evaluated in the supplied timezone")
+    func weekdayAbbreviationRespectsTimezone() {
+        // 02:00 UTC on 2026-06-05 is the previous calendar day (and weekday) in Los Angeles (19:00).
+        let instant = date(utc, hour: 2)
+        #expect(RadarOperatingHoursEvaluator.weekdayAbbreviation(for: instant, timeZone: utc) == dayKey(for: instant, timezone: utc))
+        #expect(RadarOperatingHoursEvaluator.weekdayAbbreviation(for: instant, timeZone: losAngeles) == dayKey(for: instant, timezone: losAngeles))
+        #expect(dayKey(for: instant, timezone: utc) != dayKey(for: instant, timezone: losAngeles))
+    }
+
     @Test("the same instant is evaluated in the supplied timezone")
     func respectsTimezone() {
         // 21:00 UTC on 2026-06-05 == 14:00 PDT the same calendar day.

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -11,6 +11,7 @@
 #import "../RadarSDK/RadarAPIClient.h"
 #import "../RadarSDK/RadarAPIHelper.h"
 #import "../RadarSDK/RadarLocationManager.h"
+#import "../RadarSDK/RadarNotificationHelper.h"
 #import "../RadarSDK/RadarSettings.h"
 #import "../RadarSDK/RadarState.h"
 #import "../RadarSDK/RadarLogger.h"
@@ -2303,5 +2304,44 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
         @"skipForegroundCheck": @(YES)
     }];
     XCTAssertTrue(explicitTrue.skipForegroundCheck);
+}
+
+#pragma mark - RadarNotificationHelper isNotificationActiveForMetadata
+
+- (void)testIsNotificationActiveForMetadataDayOfWeek {
+    NSArray<NSString *> *abbr = @[ @"Sun", @"Mon", @"Tue", @"Wed", @"Thu", @"Fri", @"Sat" ];
+    NSDate *now = [NSDate date];
+    NSInteger todayIndex = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] component:NSCalendarUnitWeekday fromDate:now] - 1;
+    NSString *today = abbr[todayIndex];
+    NSString *notToday = abbr[(todayIndex + 3) % 7];
+
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:daysOfWeek": today} now:now],
+                  @"today included should be active");
+    XCTAssertFalse([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:daysOfWeek": notToday} now:now],
+                   @"today excluded should be inactive");
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:daysOfWeek": @""} now:now],
+                  @"empty list means every day");
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:@{} now:now],
+                  @"absent key means every day");
+    NSString *messy = [NSString stringWithFormat:@" %@ , xyz ", [today lowercaseString]];
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:daysOfWeek": messy} now:now],
+                  @"case-insensitive, whitespace-trimmed, unknown tokens ignored");
+}
+
+- (void)testIsNotificationActiveForMetadataSchedulingWindow {
+    NSDate *now = [NSDate date];
+    NSString *past = @"2000-01-01T00:00:00.000";
+    NSString *future = @"2999-01-01T00:00:00.000";
+
+    XCTAssertFalse([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:endsAt": past} now:now],
+                   @"after the window end should be inactive");
+    XCTAssertFalse([RadarNotificationHelper isNotificationActiveForMetadata:@{@"radar:startsAt": future} now:now],
+                   @"before the window start should be inactive");
+    // Hoisted to a local: a multi-entry dictionary literal's comma would otherwise split the XCTAssert macro args.
+    NSDictionary *withinWindow = @{@"radar:startsAt": past, @"radar:endsAt": future};
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:withinWindow now:now],
+                  @"within the window should be active");
+    XCTAssertTrue([RadarNotificationHelper isNotificationActiveForMetadata:@{} now:now],
+                  @"no window means always active");
 }
 @end


### PR DESCRIPTION
## Summary

Adds a day-of-week filter to client-side notifications (CSGN — geofence and beacon), building on the recently added campaign scheduling window (`radar:startsAt`/`radar:endsAt`) and operating-hours work.

A new metadata field **`radar:daysOfWeek`** holds a comma-separated list of day abbreviations (`"Sun"…"Sat"`, e.g. `"Tue,Thu"`). When present, the notification only fires on the listed days, evaluated in **device-local** time. Absent or empty → fires every day, matching the existing window convention.

> Requires the server to forward `radar:daysOfWeek` (and `radar:startsAt`/`radar:endsAt`) in the notification metadata — see [radarlabs/server#7980](https://github.com/radarlabs/server/pull/7980).

## Drive-by fix: flaky `RadarTrackingOptions` date equality

CI intermittently failed on the pre-existing `test_Radar_startTracking_custom`, unrelated to the day-of-week feature. Root cause is in `-[RadarTrackingOptions isEqual:]`:

- `dictionaryValue` serializes `startTrackingAfter`/`stopTrackingAfter` as `timeIntervalSince1970 * 1000`, and `initWithDictionary:` reads them back as `doubleValue / 1000`. `startTrackingWithOptions:` → `getTrackingOptions` round-trips through this.
- `isEqual:` compared the dates with a `< DBL_EPSILON` (~2.2e-16) tolerance. `DBL_EPSILON` is the gap between representable doubles near `1.0`; at timestamp magnitudes (~1.78e9) the real spacing is ~`1.78e9 * DBL_EPSILON` ≈ 4e-7s, so the comparison effectively demanded bit-exact equality.
- The `×1000 ÷1000` round-trip isn't bit-exact for ~1.9% of timestamps, so whether the test passed depended purely on the sub-second value of `[NSDate new]` — hence the flake.

Fix: widen the tolerance to `0.001` (1ms), matching the millisecond precision the dates are actually serialized at.

## Notes

- Metadata values are scalar (`RadarMetadataValue` is string/int/double/bool), so the day list is encoded as a single comma-separated string rather than an array.
- The shared predicate lives on the Objective-C `RadarNotificationHelper` (not the Swift bridge, which is an `actor`) and is tested from `RadarSDKTests.m`; the geofence ObjC block it replaces was previously untested.

## Companion PRs

- Server: [radarlabs/server#7980](https://github.com/radarlabs/server/pull/7980)
- Dashboard: [radarlabs/dashboard#745](https://github.com/radarlabs/dashboard/pull/745)