### PR TITLE
FENCE-2887: Test CSGN scheduling-window deregistration on refresh

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		F64C80D72F64876500943B7A /* RadarSDKFraud.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F64C7FB52F645ABD00943B7A /* RadarSDKFraud.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F6513E792E60A5F600523472 /* LocationPushExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F6513E722E60A5F600523472 /* LocationPushExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F6513F602E6B736200523472 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6513F5F2E6B736200523472 /* MainView.swift */; };
+		F6513F702E6B736200523472 /* CSGNInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6513F712E6B736200523472 /* CSGNInspectorView.swift */; };
 		F65F793E2EF458E600399E84 /* MyIAMDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65F79382EF458E000399E84 /* MyIAMDelegate.swift */; };
 		F66DAD6A2E707F0700896773 /* waypoints.gpx in Sources */ = {isa = PBXBuildFile; fileRef = F66DAD642E707F0300896773 /* waypoints.gpx */; };
 /* End PBXBuildFile section */
@@ -250,6 +251,7 @@
 		F64C7FB52F645ABD00943B7A /* RadarSDKFraud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RadarSDKFraud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6513E722E60A5F600523472 /* LocationPushExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LocationPushExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6513F5F2E6B736200523472 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		F6513F712E6B736200523472 /* CSGNInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSGNInspectorView.swift; sourceTree = "<group>"; };
 		F65F79382EF458E000399E84 /* MyIAMDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyIAMDelegate.swift; sourceTree = "<group>"; };
 		F66DAD642E707F0300896773 /* waypoints.gpx */ = {isa = PBXFileReference; lastKnownFileType = text; path = waypoints.gpx; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -467,6 +469,7 @@
 				DDB861D22385FC3E00770661 /* Default-568h@2x.png */,
 				DD236D26230A006700EB88F9 /* AppDelegate.swift */,
 				F6513F5F2E6B736200523472 /* MainView.swift */,
+				F6513F712E6B736200523472 /* CSGNInspectorView.swift */,
 				F65F79382EF458E000399E84 /* MyIAMDelegate.swift */,
 				BA5198922EDE0F06004A3B35 /* TripLiveActivityManager.swift */,
 				F66DAD642E707F0300896773 /* waypoints.gpx */,
@@ -751,6 +754,7 @@
 				DD236D27230A006700EB88F9 /* AppDelegate.swift in Sources */,
 				BA77932C2FAA663C00E197CA /* TripsPanel.swift in Sources */,
 				F6513F602E6B736200523472 /* MainView.swift in Sources */,
+				F6513F702E6B736200523472 /* CSGNInspectorView.swift in Sources */,
 				BAB2ACB32FB53C0600560332 /* TripGeofenceSource.swift in Sources */,
 				F61886C32EA7DB5F0072E87C /* LogsView.swift in Sources */,
 				F65F793E2EF458E600399E84 /* MyIAMDelegate.swift in Sources */,

--- a/Example/Example/CSGNInspectorView.swift
+++ b/Example/Example/CSGNInspectorView.swift
@@ -1,0 +1,319 @@
+//
+//  CSGNInspectorView.swift
+//  Example
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import RadarSDK
+import SwiftUI
+import UserNotifications
+
+/// General-purpose inspector for client-side geofence notifications (CSGNs).
+///
+/// Snapshots the live registered state using public APIs only — no campaign-specific
+/// hardcoding — so it works for any CSGN. It surfaces what the pending-notification list
+/// alone can't: each region's geometry, whether the device is currently inside a region
+/// (iOS won't fire an entry trigger until you leave and re-enter), and the location /
+/// notification authorization that gate background delivery.
+///
+/// Pair this with `Radar.setLogLevel(.debug)` + the Debug tab: this view shows what *is*
+/// registered and whether it can fire; the SDK's `CSGN skip <id>: ...` logs explain why a
+/// geofence was *not* registered.
+struct CSGNInspectorView: View {
+
+    /// `radar_geofence_` notifications are the client-side geofence triggers registered by
+    /// the SDK. The prefix is internal to RadarSDK, so it is duplicated here intentionally.
+    private static let radarGeofencePrefix = "radar_geofence_"
+
+    /// One registered CSGN, flattened from its pending `UNNotificationRequest`. Optional
+    /// fields are left empty (`—`) when the campaign didn't set them.
+    private struct CSGNRow: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String
+        let body: String
+        let url: String
+        let campaignId: String
+        let campaignType: String
+        let daysOfWeek: String
+        let startsAt: String
+        let endsAt: String
+        let restrictToOperatingHours: String
+        let operatingHoursCloseBuffer: String
+        let repeats: String
+        let registeredAt: String
+        let tag: String          // decoded from the embedded geofence payload
+        let externalId: String   // decoded from the embedded geofence payload
+        let center: CLLocationCoordinate2D?
+        let radius: Double?
+        let isInside: Bool?          // nil = no current location to compare against
+        let distanceToCenter: Double?
+    }
+
+    @State private var locationAuth = "—"
+    @State private var notificationAuth = "—"
+    @State private var currentLocationText = "—"
+    @State private var rows: [CSGNRow] = []
+    @State private var lastRefreshed = "never"
+    @State private var isRefreshing = false
+    @State private var showFiringSteps = false
+
+    /// Recommended distance to walk past the edge before re-entering, derived from the
+    /// largest registered region. GPS error is added to the radius, so we suggest the
+    /// greater of 2× the radius or radius + 150 m (≥200 m when nothing is registered yet).
+    private var recommendedOutMeters: Int {
+        guard let maxRadius = rows.compactMap(\.radius).max() else { return 200 }
+        return Int(max(maxRadius * 2, maxRadius + 150).rounded())
+    }
+
+    private var firingSteps: [String] {
+        [
+            "1. Use a large, isolated geofence (≥150–200 m radius). Make it big enough to walk through the center, not just clip the edge — small (<100 m) or overlapping geofences fire inconsistently.",
+            "2. Pick a spot you can reach from well outside, and don't place it where you're already standing (a region you start INSIDE won't fire).",
+            "3. Set Location permission to Always (Settings → this app → Location). Background entries aren't delivered with \"While Using\".",
+            "4. Start OUTSIDE the geofence. Any region marked INSIDE below won't fire until you leave first.",
+            "5. Walk/drive at least ~\(recommendedOutMeters) m past the edge, then stay out ~1–2 min so iOS registers the exit and the SDK re-registers the region while you're outside.",
+            "6. Head back in through the center, and keep moving — iOS detects crossings from motion + cell/Wi-Fi, not constant GPS.",
+            "7. Delivery takes ~20 s to a few minutes. In the foreground, watch for the banner / the \"will present notification!\" console log.",
+        ]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                header
+
+                DisclosureGroup(isExpanded: $showFiringSteps) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(firingSteps.enumerated()), id: \.offset) { _, step in
+                            Text(step)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+                } label: {
+                    Text("How to make a CSGN fire").bold()
+                }
+                .font(.system(.footnote, design: .monospaced))
+                .padding(8)
+                .background(Color(.systemGray5))
+                .cornerRadius(8)
+
+                Group {
+                    Text("Location auth: \(locationAuth)")
+                    Text("Notification auth: \(notificationAuth)")
+                    Text("Current location: \(currentLocationText)")
+                    Text("Registered CSGNs: \(rows.count)  (~20 region/app budget, shared with tracking)")
+                    Text("Refreshed: \(lastRefreshed)")
+                }
+                .font(.system(.footnote, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+
+                if rows.isEmpty {
+                    Text("No radar_geofence_* notifications pending. If a campaign should be here, check the Debug tab for `CSGN skip` logs.")
+                        .font(.system(.footnote, design: .monospaced))
+                }
+
+                ForEach(rows) { row in
+                    rowView(row)
+                }
+            }
+            .padding()
+        }
+        .onAppear { refresh() }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Registered CSGNs").font(.title2).bold()
+            Spacer()
+            Button(action: refresh) {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .disabled(isRefreshing)
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: CSGNRow) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(row.title.isEmpty ? row.id : row.title).bold()
+            if !row.subtitle.isEmpty {
+                Text("subtitle: \(row.subtitle)")
+            }
+            Text("body: \(row.body)")
+            Text("geofenceId: \(row.id)")
+            if !row.tag.isEmpty {
+                Text("tag: \(row.tag)")
+            }
+            if !row.externalId.isEmpty {
+                Text("externalId: \(row.externalId)")
+            }
+            Text("campaignId: \(row.campaignId)  type: \(row.campaignType)")
+            Text("daysOfWeek: \(row.daysOfWeek)")
+            Text("startsAt: \(row.startsAt)")
+            Text("endsAt: \(row.endsAt)")
+            Text("restrictToOperatingHours: \(row.restrictToOperatingHours)  closeBuffer: \(row.operatingHoursCloseBuffer)")
+            Text("repeats: \(row.repeats)  registeredAt: \(row.registeredAt)")
+            if !row.url.isEmpty {
+                Text("url: \(row.url)")
+            }
+
+            if let center = row.center, let radius = row.radius {
+                Text(String(format: "region: (%.6f, %.6f) r=%.0fm", center.latitude, center.longitude, radius))
+                switch row.isInside {
+                case .some(true):
+                    Text("⚠️ INSIDE this region — iOS won't fire entry until you exit & re-enter")
+                        .foregroundColor(.red)
+                case .some(false):
+                    if let d = row.distanceToCenter {
+                        Text(String(format: "OUTSIDE — %.0fm to center, %.0fm to edge", d, d - radius))
+                            .foregroundColor(.green)
+                    }
+                case .none:
+                    Text("location unknown — can't determine inside/outside")
+                }
+            } else {
+                Text("no location trigger / region")
+            }
+        }
+        .font(.system(.caption, design: .monospaced))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+    }
+
+    private func refresh() {
+        isRefreshing = true
+        locationAuth = Self.describe(CLLocationManager().authorizationStatus)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let auth = Self.describe(settings.authorizationStatus)
+            DispatchQueue.main.async { notificationAuth = auth }
+        }
+
+        // Fetch a fresh location first, then build the rows relative to it so each region's
+        // inside/outside + distance is accurate.
+        Radar.getLocation { _, location, _ in
+            DispatchQueue.main.async {
+                if let location = location {
+                    currentLocationText = String(
+                        format: "(%.6f, %.6f) ±%.0fm",
+                        location.coordinate.latitude, location.coordinate.longitude, location.horizontalAccuracy
+                    )
+                } else {
+                    currentLocationText = "unavailable"
+                }
+                buildRows(current: location)
+            }
+        }
+    }
+
+    private func buildRows(current: CLLocation?) {
+        UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+            let built: [CSGNRow] = requests
+                .filter { $0.identifier.hasPrefix(Self.radarGeofencePrefix) }
+                .map { request in
+                    let userInfo = request.content.userInfo
+                    let region = (request.trigger as? UNLocationNotificationTrigger)?.region as? CLCircularRegion
+                    let geofence = Self.decodeGeofence(userInfo["geofenceData"])
+
+                    var isInside: Bool?
+                    var distance: Double?
+                    if let region = region, let current = current {
+                        isInside = region.contains(current.coordinate)
+                        distance = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                            .distance(from: current)
+                    }
+
+                    return CSGNRow(
+                        id: (userInfo["geofenceId"] as? String) ?? request.identifier,
+                        title: request.content.title,
+                        subtitle: request.content.subtitle,
+                        body: request.content.body,
+                        url: Self.str(userInfo["radar:notificationURL"] ?? userInfo["url"]),
+                        campaignId: Self.str(userInfo["radar:campaignId"]),
+                        campaignType: Self.str(userInfo["radar:campaignType"]),
+                        daysOfWeek: Self.str(userInfo["radar:daysOfWeek"]),
+                        startsAt: Self.str(userInfo["radar:startsAt"]),
+                        endsAt: Self.str(userInfo["radar:endsAt"]),
+                        restrictToOperatingHours: Self.str(userInfo["radar:restrictToOperatingHours"]),
+                        operatingHoursCloseBuffer: Self.str(userInfo["radar:operatingHoursCloseBufferMinutes"]),
+                        repeats: Self.str(userInfo["radar:notificationRepeats"]),
+                        registeredAt: Self.dateString(userInfo["registeredAt"]),
+                        tag: Self.str(geofence?["tag"]),
+                        externalId: Self.str(geofence?["externalId"]),
+                        center: region?.center,
+                        radius: region?.radius,
+                        isInside: isInside,
+                        distanceToCenter: distance
+                    )
+                }
+            DispatchQueue.main.async {
+                rows = built
+                lastRefreshed = Self.timeString()
+                isRefreshing = false
+            }
+        }
+    }
+
+    /// The SDK stores the full geofence as JSON-encoded `Data` under `geofenceData` so a
+    /// refresh can re-evaluate it. Decode it back to a dictionary to surface tag/externalId.
+    private static func decodeGeofence(_ value: Any?) -> [String: Any]? {
+        guard let data = value as? Data,
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return json
+    }
+
+    private static func str(_ value: Any?) -> String {
+        guard let value = value else { return "—" }
+        return "\(value)"
+    }
+
+    private static func dateString(_ value: Any?) -> String {
+        guard let interval = value as? Double else { return "—" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: Date(timeIntervalSince1970: interval))
+    }
+
+    private static func describe(_ status: CLAuthorizationStatus) -> String {
+        switch status {
+        case .authorizedAlways: return "Always"
+        case .authorizedWhenInUse: return "WhenInUse ⚠️ (background CSGNs need Always)"
+        case .denied: return "Denied"
+        case .restricted: return "Restricted"
+        case .notDetermined: return "NotDetermined"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private static func describe(_ status: UNAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "Authorized"
+        case .provisional: return "Provisional"
+        case .ephemeral: return "Ephemeral"
+        case .denied: return "Denied"
+        case .notDetermined: return "NotDetermined"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private static func timeString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: Date())
+    }
+}
+
+#Preview {
+    CSGNInspectorView()
+}

--- a/Example/Example/MainView.swift
+++ b/Example/Example/MainView.swift
@@ -15,6 +15,7 @@ struct MainView: View {
         case Map
         case Logs
         case Tests
+        case CSGN
     }
 
     @State private var selectedTab: TabIdentifier = .Tests
@@ -32,6 +33,10 @@ struct MainView: View {
             TestsView(selectedTab: $selectedTab).tabItem {
                 Text("Tests")
             }.tag(TabIdentifier.Tests)
+
+            CSGNInspectorView().tabItem {
+                Text("CSGN")
+            }.tag(TabIdentifier.CSGN)
         }
     }
 }

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
 		F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */; };
 		F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */; };
+		F6B7E3C02F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */; };
 		F6B7E3BF2F760001006A5A24 /* RadarNotificationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */; };
 		F6B7E3492F745E49006A5A24 /* RadarNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3482F745E44006A5A24 /* RadarNotification.swift */; };
 		F6B7E3BD2F758A13006A5A24 /* MockRadarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */; };
@@ -472,6 +473,7 @@
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
 		F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSettingsTest.swift; sourceTree = "<group>"; };
 		F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationHelperTest.swift; sourceTree = "<group>"; };
+		F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationHelperRefreshTest.swift; sourceTree = "<group>"; };
 		F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationTest.swift; sourceTree = "<group>"; };
 		F6B7E3482F745E44006A5A24 /* RadarNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotification.swift; sourceTree = "<group>"; };
 		F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRadarState.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
 				F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */,
+				F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */,
 				F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */,
 				96B465BB27D6732500D7119B /* CLLocation+RadarTests.m */,
 				DD8E2F7824018C37002D51AB /* CLLocationManagerMock.h */,
@@ -1145,6 +1148,7 @@
 				DD8E2F7424018C17002D51AB /* RadarPermissionsHelperMock.m in Sources */,
 				BA46C16C2F4E0CFA00031891 /* RadarTripLegTest.m in Sources */,
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,
+				F6B7E3C02F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift in Sources */,
 				F6B7E3BF2F760001006A5A24 /* RadarNotificationTest.swift in Sources */,
 				DD8E2F7724018C25002D51AB /* RadarAPIHelperMock.m in Sources */,
 				B0A0F0032FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift in Sources */,

--- a/RadarSDK/RadarNotificationHelper.swift
+++ b/RadarSDK/RadarNotificationHelper.swift
@@ -62,8 +62,9 @@ actor RadarNotificationHelper: NSObject {
             return geofence
         }
 
-        // Persist the full nearby set (incl. metadata + operatingHours) so a
-        // refresh can re-evaluate operating hours later without a track
+        // Persist the full nearby set (incl. metadata + operatingHours) so a refresh can
+        // re-evaluate operating hours and the campaign scheduling window (radar:startsAt/endsAt)
+        // later without a track
         geofenceStore.write(decoded)
 
         await registerGeofences(decoded)

--- a/RadarSDKTests/RadarNotificationHelperRefreshTest.swift
+++ b/RadarSDKTests/RadarNotificationHelperRefreshTest.swift
@@ -1,0 +1,122 @@
+//
+//  RadarNotificationHelperRefreshTest.swift
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+private let schedulingWindowFormatter: DateFormatter = {
+    let fmt = DateFormatter()
+    fmt.locale = Locale(identifier: "en_US_POSIX")
+    fmt.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    return fmt
+}()
+
+private func isoString(_ date: Date) -> String {
+    schedulingWindowFormatter.string(from: date)
+}
+
+extension RadarNotificationHelperTest {
+
+    @Test("refresh re-registers from the persisted store")
+    func refreshReRegistersFromStore() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let fileName = "refresh_\(UUID().uuidString).json"
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        await helper.registerGeofenceNotifications(geofences: [
+            makeGeofenceDict(id: "1"),
+            makeGeofenceDict(id: "2"),
+        ])
+
+        // Simulate the pending list being lost (e.g. relaunch) so we can prove refresh rebuilds it.
+        mockCenter.pendingRequests.removeAll()
+
+        let helperAfterRelaunch = RadarNotificationHelper(
+            notificationCenter: mockCenter,
+            radarState: mockState,
+            geofenceStore: RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
+        )
+        await helperAfterRelaunch.refreshGeofenceNotifications()
+
+        let pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1", "radar_geofence_2"]))
+
+        store.clear()
+    }
+
+    @Test("refresh with an empty store is a no-op")
+    func refreshEmptyStoreNoOp() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: "refresh_empty_\(UUID().uuidString).json")
+        store.clear()
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        await helper.refreshGeofenceNotifications()
+
+        let pending = await mockCenter.pendingNotificationRequests()
+        #expect(pending.isEmpty)
+    }
+
+    @Test("refresh deregisters a campaign whose scheduling window has ended")
+    func refreshDeregistersEndedWindow() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let fileName = "refresh_window_\(UUID().uuidString).json"
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        // Registered while within the window (endsAt in the future): both are pending.
+        await helper.registerGeofenceNotifications(geofences: [
+            makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(3600))),
+            makeGeofenceDict(id: "2"),
+        ])
+        var pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1", "radar_geofence_2"]))
+
+        // The window for geofence "1" has since ended (endsAt now in the past). A refresh push
+        // re-evaluates the cache and must prune it, leaving the windowless geofence registered.
+        store.write([
+            decodeGeofence(makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(-3600))))!,
+            decodeGeofence(makeGeofenceDict(id: "2"))!,
+        ])
+        await helper.refreshGeofenceNotifications()
+
+        pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_2"]))
+
+        store.clear()
+    }
+
+    @Test("refresh keeps a campaign still within its scheduling window")
+    func refreshKeepsActiveWindow() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: "refresh_active_\(UUID().uuidString).json")
+        store.write([
+            decodeGeofence(
+                makeGeofenceDict(
+                    id: "1",
+                    startsAt: isoString(Date().addingTimeInterval(-3600)),
+                    endsAt: isoString(Date().addingTimeInterval(3600))
+                )
+            )!
+        ])
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        await helper.refreshGeofenceNotifications()
+
+        let pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1"]))
+
+        store.clear()
+    }
+}

--- a/RadarSDKTests/RadarNotificationHelperTest.swift
+++ b/RadarSDKTests/RadarNotificationHelperTest.swift
@@ -63,7 +63,9 @@ private func makeGeofenceDict(
     campaignId: String = "campaign_1",
     operatingHours: [String: [[String]]]? = nil,
     restrictToOperatingHours: Bool = false,
-    closeBufferMinutes: Int? = nil
+    closeBufferMinutes: Int? = nil,
+    startsAt: String? = nil,
+    endsAt: String? = nil
 ) -> [String: Sendable] {
     var metadata: [String: Sendable] = [
         "radar:notificationText": "Hello from \(id)",
@@ -74,6 +76,12 @@ private func makeGeofenceDict(
     }
     if let closeBufferMinutes {
         metadata["radar:operatingHoursCloseBufferMinutes"] = closeBufferMinutes
+    }
+    if let startsAt {
+        metadata["radar:startsAt"] = startsAt
+    }
+    if let endsAt {
+        metadata["radar:endsAt"] = endsAt
     }
 
     var dict: [String: Sendable] = [
@@ -109,6 +117,19 @@ private func localDayKey(for date: Date) -> String {
     cal.timeZone = .current
     let idx = cal.component(.weekday, from: date) - 1
     return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][idx]
+}
+
+// Formats a wall-clock scheduling-window timestamp the way the server sends radar:startsAt/endsAt
+// (the SDK parses the leading 23 chars; the trailing timezone is ignored).
+private let schedulingWindowFormatter: DateFormatter = {
+    let fmt = DateFormatter()
+    fmt.locale = Locale(identifier: "en_US_POSIX")
+    fmt.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    return fmt
+}()
+
+private func isoString(_ date: Date) -> String {
+    schedulingWindowFormatter.string(from: date)
 }
 
 // MARK: - Tests
@@ -385,5 +406,59 @@ struct RadarNotificationHelperTest {
 
         let pending = await mockCenter.pendingNotificationRequests()
         #expect(pending.isEmpty)
+    }
+
+    @Test("refresh deregisters a campaign whose scheduling window has ended")
+    func refreshDeregistersEndedWindow() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let fileName = "refresh_window_\(UUID().uuidString).json"
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        // Registered while within the window (endsAt in the future): both are pending.
+        await helper.registerGeofenceNotifications(geofences: [
+            makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(3600))),
+            makeGeofenceDict(id: "2"),
+        ])
+        var pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1", "radar_geofence_2"]))
+
+        // The window for geofence "1" has since ended (endsAt now in the past). A refresh push
+        // re-evaluates the cache and must prune it, leaving the windowless geofence registered.
+        store.write([
+            decodeGeofence(makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(-3600))))!,
+            decodeGeofence(makeGeofenceDict(id: "2"))!,
+        ])
+        await helper.refreshGeofenceNotifications()
+
+        pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_2"]))
+
+        store.clear()
+    }
+
+    @Test("refresh keeps a campaign still within its scheduling window")
+    func refreshKeepsActiveWindow() async {
+        let mockCenter = MockNotificationCenter()
+        let mockState = MockRadarState()
+        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: "refresh_active_\(UUID().uuidString).json")
+        store.write([
+            decodeGeofence(
+                makeGeofenceDict(
+                    id: "1",
+                    startsAt: isoString(Date().addingTimeInterval(-3600)),
+                    endsAt: isoString(Date().addingTimeInterval(3600))
+                )
+            )!
+        ])
+        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
+
+        await helper.refreshGeofenceNotifications()
+
+        let pending = await mockCenter.pendingNotificationRequests()
+        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1"]))
+
+        store.clear()
     }
 }

--- a/RadarSDKTests/RadarNotificationHelperTest.swift
+++ b/RadarSDKTests/RadarNotificationHelperTest.swift
@@ -58,7 +58,7 @@ final class MockNotificationCenter: NotificationCenterProtocol, @unchecked Senda
 
 // MARK: - Test Helpers
 
-private func makeGeofenceDict(
+func makeGeofenceDict(
     id: String,
     campaignId: String = "campaign_1",
     operatingHours: [String: [[String]]]? = nil,
@@ -101,7 +101,7 @@ private func makeGeofenceDict(
     return dict
 }
 
-private func decodeGeofence(_ dict: [String: Sendable]) -> RadarGeofenceSwift? {
+func decodeGeofence(_ dict: [String: Sendable]) -> RadarGeofenceSwift? {
     guard let json = try? JSONSerialization.data(withJSONObject: dict) else { return nil }
     return try? JSONDecoder().decode(RadarGeofenceSwift.self, from: json)
 }
@@ -117,19 +117,6 @@ private func localDayKey(for date: Date) -> String {
     cal.timeZone = .current
     let idx = cal.component(.weekday, from: date) - 1
     return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][idx]
-}
-
-// Formats a wall-clock scheduling-window timestamp the way the server sends radar:startsAt/endsAt
-// (the SDK parses the leading 23 chars; the trailing timezone is ignored).
-private let schedulingWindowFormatter: DateFormatter = {
-    let fmt = DateFormatter()
-    fmt.locale = Locale(identifier: "en_US_POSIX")
-    fmt.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-    return fmt
-}()
-
-private func isoString(_ date: Date) -> String {
-    schedulingWindowFormatter.string(from: date)
 }
 
 // MARK: - Tests
@@ -365,100 +352,4 @@ struct RadarNotificationHelperTest {
         #expect(geofence?.toNotificationRequest(now: now) == nil)
     }
 
-    @Test("refresh re-registers from the persisted store")
-    func refreshReRegistersFromStore() async {
-        let mockCenter = MockNotificationCenter()
-        let mockState = MockRadarState()
-        let fileName = "refresh_\(UUID().uuidString).json"
-        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
-        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
-
-        await helper.registerGeofenceNotifications(geofences: [
-            makeGeofenceDict(id: "1"),
-            makeGeofenceDict(id: "2"),
-        ])
-
-        // Simulate the pending list being lost (e.g. relaunch) so we can prove refresh rebuilds it.
-        mockCenter.pendingRequests.removeAll()
-
-        let helperAfterRelaunch = RadarNotificationHelper(
-            notificationCenter: mockCenter,
-            radarState: mockState,
-            geofenceStore: RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
-        )
-        await helperAfterRelaunch.refreshGeofenceNotifications()
-
-        let pending = await mockCenter.pendingNotificationRequests()
-        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1", "radar_geofence_2"]))
-
-        store.clear()
-    }
-
-    @Test("refresh with an empty store is a no-op")
-    func refreshEmptyStoreNoOp() async {
-        let mockCenter = MockNotificationCenter()
-        let mockState = MockRadarState()
-        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: "refresh_empty_\(UUID().uuidString).json")
-        store.clear()
-        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
-
-        await helper.refreshGeofenceNotifications()
-
-        let pending = await mockCenter.pendingNotificationRequests()
-        #expect(pending.isEmpty)
-    }
-
-    @Test("refresh deregisters a campaign whose scheduling window has ended")
-    func refreshDeregistersEndedWindow() async {
-        let mockCenter = MockNotificationCenter()
-        let mockState = MockRadarState()
-        let fileName = "refresh_window_\(UUID().uuidString).json"
-        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: fileName)
-        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
-
-        // Registered while within the window (endsAt in the future): both are pending.
-        await helper.registerGeofenceNotifications(geofences: [
-            makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(3600))),
-            makeGeofenceDict(id: "2"),
-        ])
-        var pending = await mockCenter.pendingNotificationRequests()
-        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1", "radar_geofence_2"]))
-
-        // The window for geofence "1" has since ended (endsAt now in the past). A refresh push
-        // re-evaluates the cache and must prune it, leaving the windowless geofence registered.
-        store.write([
-            decodeGeofence(makeGeofenceDict(id: "1", endsAt: isoString(Date().addingTimeInterval(-3600))))!,
-            decodeGeofence(makeGeofenceDict(id: "2"))!,
-        ])
-        await helper.refreshGeofenceNotifications()
-
-        pending = await mockCenter.pendingNotificationRequests()
-        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_2"]))
-
-        store.clear()
-    }
-
-    @Test("refresh keeps a campaign still within its scheduling window")
-    func refreshKeepsActiveWindow() async {
-        let mockCenter = MockNotificationCenter()
-        let mockState = MockRadarState()
-        let store = RadarFileStorageObject<[RadarGeofenceSwift]>(fileName: "refresh_active_\(UUID().uuidString).json")
-        store.write([
-            decodeGeofence(
-                makeGeofenceDict(
-                    id: "1",
-                    startsAt: isoString(Date().addingTimeInterval(-3600)),
-                    endsAt: isoString(Date().addingTimeInterval(3600))
-                )
-            )!
-        ])
-        let helper = RadarNotificationHelper(notificationCenter: mockCenter, radarState: mockState, geofenceStore: store)
-
-        await helper.refreshGeofenceNotifications()
-
-        let pending = await mockCenter.pendingNotificationRequests()
-        #expect(Set(pending.map(\.identifier)) == Set(["radar_geofence_1"]))
-
-        store.clear()
-    }
 }


### PR DESCRIPTION
## Summary
Adds test coverage locking in **scheduling-window deregistration** for client-side geofence notifications (CSGNs). The behavior already exists end-to-end across two merged PRs:
- `RadarGeofenceSwift.toNotificationRequest(now:)` gates registration on `isWithinSchedulingWindow`, which reads `radar:startsAt`/`radar:endsAt` from campaign metadata (#618).
- `RadarNotificationHelper.refreshGeofenceNotifications()` re-runs that over the durable cache on a `radar:refreshNotifications` push (#617), and `RadarGeofenceSwift` persists `metadata`, so the window survives in the cache.

The only gap was a test proving a refresh actually **prunes** a window-expired campaign (previously only operating-hours refresh was covered).

Pairs with the server change that emits `radar:startsAt`/`radar:endsAt` and sends the `radar:refreshNotifications` nudge when a campaign's window ends — companion server PR: https://github.com/radarlabs/server/pull/8016

Also adds a new tab for inspecting CSGNs!

## Changes
- `RadarNotificationHelperTest.swift`: extend `makeGeofenceDict` with `startsAt`/`endsAt`; add tests that a refresh prunes a campaign whose `radar:endsAt` has passed and keeps one still within its window.
- `RadarNotificationHelper.swift`: clarify the cache-persist comment (refresh re-evaluates the scheduling window alongside operating hours). No behavior change.

<details><summary>CSGN Inspector</summary>
<p>

| | |
|--------|--------|
| <img width="585" height="1266" alt="Screenshot 2026-06-26 at 1 52 30 PM" src="https://github.com/user-attachments/assets/cbf54743-4875-4d10-8b02-5bf2ca8fb753" /> | <img width="585" height="1266" alt="Screenshot 2026-06-26 at 1 53 08 PM" src="https://github.com/user-attachments/assets/2e442236-50db-4eb8-b56b-1b67b155ce95" /> | 

</p>
</details> 