### PR TITLE
FENCE-2892: Add recursive JSON sanitizer

### DIFF
--- a/RadarSDK/RadarAPIHelper.m
+++ b/RadarSDK/RadarAPIHelper.m
@@ -130,9 +130,9 @@ static NSTimeInterval RadarAPIHelperExtendedNetworkTimeoutInterval(NSTimeInterva
                         requestParams[@"replays"] = updatedReplays;
                     }
 
-                    [req setHTTPBody:[NSJSONSerialization dataWithJSONObject:requestParams options:0 error:NULL]];
+                    [req setHTTPBody:[RadarUtils jsonData:requestParams]];
                 } else {
-                    [req setHTTPBody:[NSJSONSerialization dataWithJSONObject:params options:0 error:NULL]];
+                    [req setHTTPBody:[RadarUtils jsonData:params]];
                 }
             }
 

--- a/RadarSDK/RadarUtils.h
+++ b/RadarSDK/RadarUtils.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSInteger, RadarConnectionType) {
 + (CLLocation *)locationForDictionary:(NSDictionary *_Nonnull)dict;
 + (NSDictionary *)dictionaryForLocation:(CLLocation *)location;
 + (NSString *)dictionaryToJson:(NSDictionary *)dict;
++ (nullable NSData *)jsonData:(nullable NSDictionary *)dict;
 
 + (RadarConnectionType)networkType;
 + (NSString *)networkTypeString;

--- a/RadarSDK/RadarUtils.swift
+++ b/RadarSDK/RadarUtils.swift
@@ -200,7 +200,7 @@ class RadarUtils: NSObject {
             RadarLogger.shared.warning("RadarUtils.dictionaryToJson: input contained non-JSON values; sanitizing")
             jsonObject = jsonSanitized(dict) ?? [:]
         }
-        
+
         do {
             let data = try JSONSerialization.data(withJSONObject: jsonObject)
             return String(data: data, encoding: .utf8) ?? "{}"
@@ -242,12 +242,12 @@ class RadarUtils: NSObject {
         }
         return escaped
     }
-    
+
     static func jsonSanitized(_ value: Any) -> Any? {
         switch value {
         case let dict as [AnyHashable: Any]:
             return dict.reduce(into: [String: Any]()) { result, pair in
-                guard let key = pair.key as? String else { return } // drop non-string keys
+                guard let key = pair.key as? String else { return }  // drop non-string keys
                 if let sanitized = jsonSanitized(pair.value) {
                     result[key] = sanitized
                 }
@@ -257,13 +257,13 @@ class RadarUtils: NSObject {
         case is String, is NSNull:
             return value
         case let number as NSNumber:
-            return number.doubleValue.isFinite ? number : nil // reject NaN/±Inf
+            return number.doubleValue.isFinite ? number : nil  // reject NaN/±Inf
         default:
-            return nil // Data, Date, URL, custom objects
+            return nil  // Data, Date, URL, custom objects
         }
     }
-    
-    @objc static func jsonData(_ dict: [String: Any]?) -> Data? {
+
+    static func jsonData(_ dict: [String: Any]?) -> Data? {
         guard let dict = dict else { return nil }
         let jsonObject = JSONSerialization.isValidJSONObject(dict) ? dict : (jsonSanitized(dict) ?? [:])
         return try? JSONSerialization.data(withJSONObject: jsonObject)

--- a/RadarSDK/RadarUtils.swift
+++ b/RadarSDK/RadarUtils.swift
@@ -190,22 +190,21 @@ class RadarUtils: NSObject {
     static func dictionaryToJson(_ dict: [String: Any]?) -> String {
         guard let dict = dict else { return "{}" }
 
-        // Defends against NSJSONSerialization's NSException path (NaN, non-string keys,
-        // unsupported types), which Swift's do/catch below doesn't catch.
-        guard JSONSerialization.isValidJSONObject(dict) else {
-            RadarLogger.shared.warning("RadarUtils.dictionaryToJson: input is not a valid JSON object, returning empty")
-            return "{}"
+        let jsonObject: Any
+        if JSONSerialization.isValidJSONObject(dict) {
+            jsonObject = dict
+        } else {
+            // Drop only the offending values rather than discarding the whole payload.
+            // JSONSerialization throws an NSException (not a Swift error) for these, which
+            // Swift do/catch can't catch — so we must sanitize *before* serializing.
+            RadarLogger.shared.warning("RadarUtils.dictionaryToJson: input contained non-JSON values; sanitizing")
+            jsonObject = jsonSanitized(dict) ?? [:]
         }
-
+        
         do {
-            let data = try JSONSerialization.data(withJSONObject: dict)
-            guard let string = String(data: data, encoding: .utf8) else {
-                // data could not be converted to string
-                return "{}"
-            }
-            return string
+            let data = try JSONSerialization.data(withJSONObject: jsonObject)
+            return String(data: data, encoding: .utf8) ?? "{}"
         } catch {
-            // failed to json serialize
             RadarLogger.shared.warning("RadarUtils.dictionaryToJson failed: \(error.localizedDescription)")
             return "{}"
         }
@@ -242,6 +241,32 @@ class RadarUtils: NSObject {
             }
         }
         return escaped
+    }
+    
+    static func jsonSanitized(_ value: Any) -> Any? {
+        switch value {
+        case let dict as [AnyHashable: Any]:
+            return dict.reduce(into: [String: Any]()) { result, pair in
+                guard let key = pair.key as? String else { return } // drop non-string keys
+                if let sanitized = jsonSanitized(pair.value) {
+                    result[key] = sanitized
+                }
+            }
+        case let array as [Any]:
+            return array.compactMap { jsonSanitized($0) }
+        case is String, is NSNull:
+            return value
+        case let number as NSNumber:
+            return number.doubleValue.isFinite ? number : nil // reject NaN/±Inf
+        default:
+            return nil // Data, Date, URL, custom objects
+        }
+    }
+    
+    @objc static func jsonData(_ dict: [String: Any]?) -> Data? {
+        guard let dict = dict else { return nil }
+        let jsonObject = JSONSerialization.isValidJSONObject(dict) ? dict : (jsonSanitized(dict) ?? [:])
+        return try? JSONSerialization.data(withJSONObject: jsonObject)
     }
 }
 

--- a/RadarSDK/RadarUtils.swift
+++ b/RadarSDK/RadarUtils.swift
@@ -263,9 +263,9 @@ class RadarUtils: NSObject {
         }
     }
 
-    static func jsonData(_ dict: [String: Any]?) -> Data? {
+    static func jsonData(_ dict: NSDictionary?) -> Data? {
         guard let dict = dict else { return nil }
-        let jsonObject = JSONSerialization.isValidJSONObject(dict) ? dict : (jsonSanitized(dict) ?? [:])
+        let jsonObject: Any = JSONSerialization.isValidJSONObject(dict) ? dict : (jsonSanitized(dict) ?? [:])
         return try? JSONSerialization.data(withJSONObject: jsonObject)
     }
 }

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -54,22 +54,27 @@ struct RadarUtilsTests {
         #expect((decoded?["nested"] as? [String: Any])?.isEmpty == true)
     }
 
-    @Test func dictionaryToJsonDropsDataButKeepsSiblings() {
+    @Test func dictionaryToJsonDropsDataButKeepsSiblings() throws {
         let dict: [String: Any] = ["foo": "bar", "blob": Data("x".utf8)]
-        let json = RadarUtils.dictionaryToJson(dict)
-        #expect(json.contains("\"foo\":\"bar\""))
-        #expect(!json.contains("blob"))
+        let decoded =
+            try JSONSerialization.jsonObject(
+                with: Data(RadarUtils.dictionaryToJson(dict).utf8)) as? [String: Any]
+        #expect(decoded?["foo"] as? String == "bar")
+        #expect(decoded?.keys.contains("blob") == false)
     }
-
-    @Test func dictionarytoJsonSanitizedNotificationDiffWithData() {
+    @Test func dictionaryToJsonSanitizesNotificationDiffWithData() throws {
         let params: [String: Any] = [
             "latitude": 1.0,
             "notificationDiff": [["identifier": "radar_x", "registeredAt": 123, "info": Data("y".utf8)]],
         ]
-        let json = RadarUtils.dictionaryToJson(params)
-        #expect(json.contains("\"identifier\":\"radar_x\""))
-        #expect(json.contains("\"latitude\":1"))
-        #expect(!json.contains("info"))  // the only thing dropped
+        let decoded =
+            try JSONSerialization.jsonObject(
+                with: Data(RadarUtils.dictionaryToJson(params).utf8)) as? [String: Any]
+        #expect(decoded?["latitude"] as? Double == 1.0)
+        let entry = (decoded?["notificationDiff"] as? [[String: Any]])?.first
+        #expect(entry?["identifier"] as? String == "radar_x")
+        #expect(entry?["registeredAt"] as? Int == 123)
+        #expect(entry?.keys.contains("info") == false)
     }
 
     @Test func escapeNonAsciiLeavesAsciiUntouched() {

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -60,7 +60,7 @@ struct RadarUtilsTests {
         #expect(json.contains("\"foo\":\"bar\""))
         #expect(!json.contains("blob"))
     }
-    
+
     @Test func dictionarytoJsonSanitizedNotificationDiffWithData() {
         let params: [String: Any] = [
             "latitude": 1.0,
@@ -69,7 +69,7 @@ struct RadarUtilsTests {
         let json = RadarUtils.dictionaryToJson(params)
         #expect(json.contains("\"identifier\":\"radar_x\""))
         #expect(json.contains("\"latitude\":1"))
-        #expect(!json.contains("info"))   // the only thing dropped
+        #expect(!json.contains("info"))  // the only thing dropped
     }
 
     @Test func escapeNonAsciiLeavesAsciiUntouched() {

--- a/RadarSDKTests/RadarUtilsTests.swift
+++ b/RadarSDKTests/RadarUtilsTests.swift
@@ -45,10 +45,31 @@ struct RadarUtilsTests {
         #expect(RadarUtils.dictionaryToJson(dict) == "{}")
     }
 
-    @Test func dictionaryToJsonReturnsEmptyForNestedNonStringKey() {
+    @Test func dictionaryToJsonDropsNestedNonStringKeysKeepingContainer() throws {
         let inner: NSDictionary = [1: "value"]
         let dict: [String: Any] = ["nested": inner]
-        #expect(RadarUtils.dictionaryToJson(dict) == "{}")
+        let json = RadarUtils.dictionaryToJson(dict)
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        #expect(decoded?.keys.contains("nested") == true)
+        #expect((decoded?["nested"] as? [String: Any])?.isEmpty == true)
+    }
+
+    @Test func dictionaryToJsonDropsDataButKeepsSiblings() {
+        let dict: [String: Any] = ["foo": "bar", "blob": Data("x".utf8)]
+        let json = RadarUtils.dictionaryToJson(dict)
+        #expect(json.contains("\"foo\":\"bar\""))
+        #expect(!json.contains("blob"))
+    }
+    
+    @Test func dictionarytoJsonSanitizedNotificationDiffWithData() {
+        let params: [String: Any] = [
+            "latitude": 1.0,
+            "notificationDiff": [["identifier": "radar_x", "registeredAt": 123, "info": Data("y".utf8)]],
+        ]
+        let json = RadarUtils.dictionaryToJson(params)
+        #expect(json.contains("\"identifier\":\"radar_x\""))
+        #expect(json.contains("\"latitude\":1"))
+        #expect(!json.contains("info"))   // the only thing dropped
     }
 
     @Test func escapeNonAsciiLeavesAsciiUntouched() {


### PR DESCRIPTION
## Summary
Hardens JSON serialization in `RadarUtils` so a non-JSON value (e.g. `NSData`, `NSDate`, `NaN/Inf`) anywhere in a request payload can never crash the host app or silently drop the entire payload.

## Manual test steps
just a json serializer covered by the unit tests. 

## Checklist

- [x] New code is written in Swift (the SDK is migrating off Objective-C)
- [x] Added or updated unit tests (`make test`)
- [x] `make lint-swift` and `make format-check` pass locally
- [x] For breaking changes: added a `MIGRATION.md` entry and bumped the version with `./set-version.sh`
- [x] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/format violations on lines I changed; removed any now-stale `.swiftlint-baseline.json` entries

