### PR TITLE
FENCE-2913: Fix "Ambiguous use of ipGeocode()" for Swift async callers

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */; };
 		BA8647BB2F6C8F0E00F1A199 /* SyncRegionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8647BA2F6C8F0600F1A199 /* SyncRegionResponse.swift */; };
 		BAC932F02FF43E8100503C2C /* RadarStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC932EF2FF43E7400503C2C /* RadarStateTests.swift */; };
+		BAC932F42FF578EB00503C2C /* RadarIPGeocodeAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC932F32FF578D700503C2C /* RadarIPGeocodeAsyncTests.swift */; };
 		DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD103210237E0C47003DD408 /* RadarSDKTests.m */; };
 		DD103215237F1795003DD408 /* track.json in Resources */ = {isa = PBXBuildFile; fileRef = DD103214237F1795003DD408 /* track.json */; };
 		DD4D4D2523E648D000D36C1D /* search_autocomplete.json in Resources */ = {isa = PBXBuildFile; fileRef = DD4D4D2423E648D000D36C1D /* search_autocomplete.json */; };
@@ -375,6 +376,7 @@
 		BA8647B82F6C7DAD00F1A199 /* RadarSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSyncManagerTests.swift; sourceTree = "<group>"; };
 		BA8647BA2F6C8F0600F1A199 /* SyncRegionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRegionResponse.swift; sourceTree = "<group>"; };
 		BAC932EF2FF43E7400503C2C /* RadarStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarStateTests.swift; sourceTree = "<group>"; };
+		BAC932F32FF578D700503C2C /* RadarIPGeocodeAsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarIPGeocodeAsyncTests.swift; sourceTree = "<group>"; };
 		D1FACB1BB65B49969B63CEA7 /* RadarAPIHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelperTests.swift; sourceTree = "<group>"; };
 		DD103210237E0C47003DD408 /* RadarSDKTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadarSDKTests.m; sourceTree = "<group>"; };
 		DD103214237F1795003DD408 /* track.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = track.json; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 		DD236C822308797B00EB88F9 /* RadarSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				BAC932F32FF578D700503C2C /* RadarIPGeocodeAsyncTests.swift */,
 				BAC932EF2FF43E7400503C2C /* RadarStateTests.swift */,
 				BA561CD92FD3868600D7A3E3 /* RadarOperatingHoursEvaluatorTest.swift */,
 				BA7180542FB3D32900A28DD4 /* RadarUtilsTests.swift */,
@@ -1142,6 +1145,7 @@
 				BA46C16C2F4E0CFA00031891 /* RadarTripLegTest.m in Sources */,
 				F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */,
 				F6B7E3C02F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift in Sources */,
+				BAC932F42FF578EB00503C2C /* RadarIPGeocodeAsyncTests.swift in Sources */,
 				BAC932F02FF43E8100503C2C /* RadarStateTests.swift in Sources */,
 				F6B7E3BF2F760001006A5A24 /* RadarNotificationTest.swift in Sources */,
 				DD8E2F7724018C25002D51AB /* RadarAPIHelperMock.m in Sources */,

--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -1323,8 +1323,7 @@ typedef void (^_Nonnull RadarIndoorsScanCompletionHandler)(NSString *_Nullable r
 
  @see https://radar.com/documentation/api#ip-geocode
  */
-+ (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeCompletionHandler)completionHandler
-    __attribute__((deprecated("Use ipGeocodeWithErrorCompletionHandler: to also receive the underlying NSError on network/parse errors.")));
++ (void)ipGeocodeWithCompletionHandler:(RadarIPGeocodeCompletionHandler)completionHandler NS_SWIFT_NAME(ipGeocode(completionHandler:));
 
 /**
  Geocodes the device's current IP address, converting IP address to partial address. The completion handler also receives the underlying NSError when the failure originated from a caught network, parse, or exception error — forward it to an error collector (Sentry, Crashlytics, etc.) to capture diagnostics.
@@ -1333,8 +1332,8 @@ typedef void (^_Nonnull RadarIndoorsScanCompletionHandler)(NSString *_Nullable r
 
  @see https://radar.com/documentation/api#ip-geocode
  */
-+ (void)ipGeocodeWithErrorCompletionHandler:(RadarIPGeocodeWithErrorCompletionHandler)completionHandler NS_SWIFT_NAME(ipGeocode(completionHandler:));
-
++ (void)ipGeocodeWithErrorCompletionHandler:(RadarIPGeocodeWithErrorCompletionHandler)completionHandler
+    NS_SWIFT_NAME(ipGeocode(completionHandler:)) NS_SWIFT_DISABLE_ASYNC;
 
 /**
  Validates an address, attaching a verification status, property type, and ZIP+4.

--- a/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
+++ b/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
@@ -21,11 +21,18 @@ final class RadarIPGeocodeAsyncTests: XCTestCase {
         apiHelperMock = RadarAPIHelperMock()
         RadarAPIClient.sharedInstance().apiHelper = apiHelperMock
     }
+    
+    private func jsonDictionary(fromResource resource: String) throws -> [AnyHashable: Any] {
+        let bundle = Bundle(for: Self.self)
+        let url = try XCTUnwrap(bundle.url(forResource: resource, withExtension: "json"))
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [AnyHashable: Any])
+    }
 
     // Regression guard for the `3.34.1` "Ambiguous use of ipGeocode()" break
-    func test_ipGeocode_async_isUnambiguous_andReturnsThreeTuple() async {
+    func test_ipGeocode_async_isUnambiguous_andReturnsThreeTuple() async throws {
         apiHelperMock.mockStatus = .success
-        apiHelperMock.mockResponse = RadarTestUtils.jsonDictionary(fromResource: "geocode_ip")
+        apiHelperMock.mockResponse = try jsonDictionary(fromResource: "geocode_ip")
 
         let (status, address, proxy) = await Radar.ipGeocode()
 

--- a/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
+++ b/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
@@ -11,24 +11,24 @@ import XCTest
 @testable import RadarSDK
 
 final class RadarIPGeocodeAsyncTests: XCTestCase {
-    
+
     private var apiHelperMock: RadarAPIHelperMock!
-    
+
     override func setUp() {
         super.setUp()
         Radar.initialize(publishableKey: "prj_test_pk_radar_sdk_ios")
-        
+
         apiHelperMock = RadarAPIHelperMock()
         RadarAPIClient.sharedInstance().apiHelper = apiHelperMock
     }
-    
+
     // Regression guard for the `3.34.1` "Ambiguous use of ipGeocode()" break
     func test_ipGeocode_async_isUnambiguous_andReturnsThreeTuple() async {
         apiHelperMock.mockStatus = .success
         apiHelperMock.mockResponse = RadarTestUtils.jsonDictionary(fromResource: "geocode_ip")
-        
+
         let (status, address, proxy) = await Radar.ipGeocode()
-        
+
         XCTAssertEqual(status, .success)
         XCTAssertNotNil(address)
         XCTAssertTrue(proxy)

--- a/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
+++ b/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
@@ -21,7 +21,7 @@ final class RadarIPGeocodeAsyncTests: XCTestCase {
         apiHelperMock = RadarAPIHelperMock()
         RadarAPIClient.sharedInstance().apiHelper = apiHelperMock
     }
-    
+
     private func jsonDictionary(fromResource resource: String) throws -> [AnyHashable: Any] {
         let bundle = Bundle(for: Self.self)
         let url = try XCTUnwrap(bundle.url(forResource: resource, withExtension: "json"))

--- a/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
+++ b/RadarSDKTests/RadarIPGeocodeAsyncTests.swift
@@ -1,0 +1,36 @@
+//
+//  RadarIPGeocodeAsyncTests.swift
+//  RadarSDK
+//
+//  Created by Alan Charles on 7/1/26.
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import RadarSDK
+
+final class RadarIPGeocodeAsyncTests: XCTestCase {
+    
+    private var apiHelperMock: RadarAPIHelperMock!
+    
+    override func setUp() {
+        super.setUp()
+        Radar.initialize(publishableKey: "prj_test_pk_radar_sdk_ios")
+        
+        apiHelperMock = RadarAPIHelperMock()
+        RadarAPIClient.sharedInstance().apiHelper = apiHelperMock
+    }
+    
+    // Regression guard for the `3.34.1` "Ambiguous use of ipGeocode()" break
+    func test_ipGeocode_async_isUnambiguous_andReturnsThreeTuple() async {
+        apiHelperMock.mockStatus = .success
+        apiHelperMock.mockResponse = RadarTestUtils.jsonDictionary(fromResource: "geocode_ip")
+        
+        let (status, address, proxy) = await Radar.ipGeocode()
+        
+        XCTAssertEqual(status, .success)
+        XCTAssertNotNil(address)
+        XCTAssertTrue(proxy)
+    }
+}

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -7,3 +7,4 @@
 #import "../RadarSDK/RadarLocationManager.h"
 #import "RadarAPIHelperMock.h"
 #import "RadarPermissionsHelperMock.h"
+#import "RadarTestUtils.h"

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -7,4 +7,3 @@
 #import "../RadarSDK/RadarLocationManager.h"
 #import "RadarAPIHelperMock.h"
 #import "RadarPermissionsHelperMock.h"
-#import "RadarTestUtils.h"

--- a/RadarSDKTests/RadarSDKTests.m
+++ b/RadarSDKTests/RadarSDKTests.m
@@ -2058,7 +2058,7 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 }
 
 - (void)test_Radar_ipGeocode_legacy_three_arg_callback_still_called {
-    // Backward-compat: integrators using the deprecated 3-arg
+    // Backward-compat: integrators using the legacy 3-arg
     // +ipGeocodeWithCompletionHandler: must still receive callbacks.
     self.permissionsHelperMock.mockLocationAuthorizationStatus = kCLAuthorizationStatusAuthorizedWhenInUse;
     self.apiHelperMock.mockStatus = RadarStatusErrorNetwork;
@@ -2068,14 +2068,11 @@ static NSString *const kPublishableKey = @"prj_test_pk_0000000000000000000000000
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *_Nullable address, BOOL proxy) {
         XCTAssertEqual(status, RadarStatusErrorNetwork);
 
         [expectation fulfill];
     }];
-#pragma clang diagnostic pop
 
     [self waitForExpectationsWithTimeout:30
                                  handler:^(NSError *_Nullable error) {


### PR DESCRIPTION
## Summary
Restores the Swift `async` form of `Radar.ipGeocode()`, which broke in **3.34.1**. Callers of `await Radar.ipGeocode()` were hitting a compile error: *"Ambiguous use of `ipGeocode()`"*.

## Root cause
#611 (FENCE-2857, shipped in 3.34.1) added `+ipGeocodeWithErrorCompletionHandler:` alongside the existing `+ipGeocodeWithCompletionHandler:`. Both map to the same Swift name, so Swift synthesized two `ipGeocode() async` overloads that differ only by `throws`, making every async call site ambiguous and uncompilable.

## Fix
- Add `NS_SWIFT_DISABLE_ASYNC` to `+ipGeocodeWithErrorCompletionHandler:` so only the original non-throwing `ipGeocode() async` is synthesized (restores the pre-3.34.1 signature, no `try` needed).
- Remove the `deprecated` attribute from `+ipGeocodeWithCompletionHandler:` so async callers don't get a deprecation warning (async now resolves to this method).

Both closure APIs are unchanged; the 4-arg error variant remains usable as a closure. No compiling code relied on the async form, since it hasn't compiled since 3.34.1.

## Testing
- New `RadarIPGeocodeAsyncTests.swift` regression guard calls `await Radar.ipGeocode()` (ambiguity = build failure).
- Existing ObjC closure/error/legacy tests still pass.
- `make test-pretty`

## Checklist

- [x] New code is written in Swift (the SDK is migrating off Objective-C)
- [x] Added or updated unit tests (`make test`)
- [x] `make lint-swift` and `make format-check` pass locally
- [x] For breaking changes: added a `MIGRATION.md` entry and bumped the version with `./set-version.sh`
- [x] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/format violations on lines I changed; removed any now-stale `.swiftlint-baseline.json` entries
