### PR TITLE
FENCE-2904: Add RadarIndoors protocol surface and bump RadarSDKIndoors submodule

### DIFF
--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -98,6 +98,8 @@ typedef NS_ENUM(NSInteger, RadarLocationSource) {
     RadarLocationSourceBeaconEnter,
     /// Beacon exit
     RadarLocationSourceBeaconExit,
+    /// Location from RadarSDKIndoors
+    RadarLocationSourceIndoors,
     /// Unknown
     RadarLocationSourceUnknown
 };

--- a/RadarSDK/Include/RadarGeofence.h
+++ b/RadarSDK/Include/RadarGeofence.h
@@ -61,6 +61,11 @@
  */
 @property (nullable, strong, nonatomic, readonly) NSNumber *geofenceStopDetection;
 
+/**
+ The active indoor model ID if a model exists.
+ */
+@property (nullable, copy, nonatomic, readonly) NSString *activeIndoorModelId;
+
 + (NSArray<NSDictionary *> *_Nullable)arrayForGeofences:(NSArray<RadarGeofence *> *_Nullable)geofences;
 - (NSDictionary *_Nonnull)dictionaryValue;
 

--- a/RadarSDK/Include/RadarIndoorsProtocol.h
+++ b/RadarSDK/Include/RadarIndoorsProtocol.h
@@ -18,6 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
         withKnownLocation:(CLLocation *_Nullable)knownLocation
         completionHandler:(RadarIndoorsScanCompletionHandler)completionHandler;
 
++ (void)start;
+
++ (void)stop;
+
++ (void)setLocation:(CLLocation *_Nullable)location;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -1615,6 +1615,9 @@ BOOL _initialized = NO;
     case RadarLocationSourceBeaconExit:
         str = @"BEACON_EXIT";
         break;
+    case RadarLocationSourceIndoors:
+        str = @"INDOORS";
+        break;
     case RadarLocationSourceUnknown:
         str = @"UNKNOWN";
     }

--- a/RadarSDK/RadarGeofence+Internal.h
+++ b/RadarSDK/RadarGeofence+Internal.h
@@ -19,7 +19,8 @@
                       operatingHours:(RadarOperatingHours *_Nullable)operatingHours
                             geometry:(RadarGeofenceGeometry *_Nonnull)geometry
                       dwellThreshold:(NSNumber *_Nullable)dwellThreshold
-               geofenceStopDetection:(NSNumber *_Nullable)geofenceStopDetection;
+               geofenceStopDetection:(NSNumber *_Nullable)geofenceStopDetection
+                 activeIndoorModelId:(NSString *_Nullable)activeIndoorModelId;
 - (instancetype _Nullable)initWithObject:(id _Nonnull)object;
 
 @end

--- a/RadarSDK/RadarGeofence.m
+++ b/RadarSDK/RadarGeofence.m
@@ -40,7 +40,8 @@
                       operatingHours:(RadarOperatingHours *_Nullable)operatingHours
                             geometry:(RadarGeofenceGeometry *_Nonnull)geometry
                       dwellThreshold:(NSNumber *_Nullable)dwellThreshold
-                  geofenceStopDetection:(NSNumber *_Nullable)geofenceStopDetection {
+                  geofenceStopDetection:(NSNumber *_Nullable)geofenceStopDetection
+                 activeIndoorModelId:(NSString *_Nullable)activeIndoorModelId {
     self = [super init];
     if (self) {
         __id = _id;
@@ -52,6 +53,7 @@
         _geometry = geometry;
         _dwellThreshold = dwellThreshold;
         _geofenceStopDetection = geofenceStopDetection;
+        _activeIndoorModelId = activeIndoorModelId;
     }
     return self;
 }
@@ -112,7 +114,13 @@
     if (stopDetectionObj && [stopDetectionObj isKindOfClass:[NSNumber class]]) {
         geofenceStopDetection = (NSNumber *)stopDetectionObj;
     }
-    
+
+    NSString *activeIndoorModelId;
+    id activeIndoorModelIdObj = dict[@"activeIndoorModelId"];
+    if (activeIndoorModelIdObj && [activeIndoorModelIdObj isKindOfClass:[NSString class]]) {
+        activeIndoorModelId = (NSString *)activeIndoorModelIdObj;
+    }
+
     id typeObj = dict[@"type"];
     if ([typeObj isKindOfClass:[NSString class]]) {
         NSString *type = (NSString *)typeObj;
@@ -155,7 +163,7 @@
         }
     }
     
-    return [[RadarGeofence alloc] initWithId:_id description:description tag:tag externalId:externalId metadata:metadata operatingHours:operatingHours geometry:geometry dwellThreshold:dwellThreshold geofenceStopDetection:geofenceStopDetection];
+    return [[RadarGeofence alloc] initWithId:_id description:description tag:tag externalId:externalId metadata:metadata operatingHours:operatingHours geometry:geometry dwellThreshold:dwellThreshold geofenceStopDetection:geofenceStopDetection activeIndoorModelId:activeIndoorModelId];
 }
 
 - (NSMutableArray<RadarCoordinate *> *)getPolygonCoordinates:(NSDictionary *)dict {


### PR DESCRIPTION
## What this is

The first of several smaller PRs carved out of the long-lived `shicheng/ml-beacons` branch (existing PR #515), which adds ML-based indoor positioning. That branch is too large and stale to review as one unit, so it's being split into logically-coherent pieces branched fresh off current `master`.

**This PR is the foundational layer only** — the additive API/protocol surface that the later PRs build on. It contains no engine logic and is a runtime no-op on its own: nothing in the SDK calls any of this yet.

## Note on how this was extracted

`master` has drifted since `shicheng/ml-beacons` last synced (2026-03-05) — it independently added `dwellThreshold`/`geofenceStopDetection`, and removed some geocode/sharing APIs. So rather than copy files verbatim from the branch (which would have clobbered that work), the indoor-specific hunks in `RadarGeofence.*` and `Radar.m` were **hand-applied on top of current master**. `RadarIndoorsProtocol.h` and the submodule bump had no drift and were taken directly.

## Follow-up PRs (not in this one)

1. **`RadarIndoors` ML engine** — the actor wrapper + Swift bridge (depends on this PR's `activeIndoorModelId`).
2. **Wire `RadarIndoors` into the tracking pipeline** — the hot-path changes in `RadarLocationManager`/`Radar`/`RadarAPIClient`.
3. **Example app** — the indoor survey/calibration tooling (MapLibre, AR, survey upload).
