### PR TITLE
FENCE-2804: Port `locationManager:didUpdateHeading`: to Swift

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		B0A0F0022FBC000100111111 /* RadarLocationManager+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0062FBC000100111111 /* RadarLocationManager+Swift.swift */; };
 		B0A0F0032FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0072FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift */; };
 		B0A0F0082FBC000100111111 /* RadarLocationManagerSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = B0A0F0092FBC000100111111 /* RadarLocationManagerSwift.h */; };
+		B0A0F0262FBC000100111111 /* RadarUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = B0A0F0272FBC000100111111 /* RadarUserDefaults.h */; };
 		B0A0F0142FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0152FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift */; };
 		B0A0F0162FBC000100111111 /* TrackingCLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */; };
 		B0A0F0182FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */; };
@@ -345,6 +346,7 @@
 		B0A0F0062FBC000100111111 /* RadarLocationManager+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RadarLocationManager+Swift.swift"; sourceTree = "<group>"; };
 		B0A0F0072FBC000100111111 /* RadarLocationManagerSwiftSeamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftSeamTests.swift; sourceTree = "<group>"; };
 		B0A0F0092FBC000100111111 /* RadarLocationManagerSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarLocationManagerSwift.h; sourceTree = "<group>"; };
+		B0A0F0272FBC000100111111 /* RadarUserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarUserDefaults.h; sourceTree = "<group>"; };
 		B0A0F0152FBC000100111111 /* RadarLocationManagerSwiftTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftTestHelpers.swift; sourceTree = "<group>"; };
 		B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingCLLocationManager.swift; sourceTree = "<group>"; };
 		B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftBeaconSyncTests.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 				DD236CF723088F8400EB88F9 /* RadarLocationManager.h */,
 				DD236CF823088F8400EB88F9 /* RadarLocationManager.m */,
 				B0A0F0092FBC000100111111 /* RadarLocationManagerSwift.h */,
+				B0A0F0272FBC000100111111 /* RadarUserDefaults.h */,
 				B0A0F0062FBC000100111111 /* RadarLocationManager+Swift.swift */,
 				DD236D66230A0D6700EB88F9 /* RadarLogger.h */,
 				F64FF0DC2E4D2BEA00DF3926 /* RadarLogger.swift */,
@@ -917,6 +920,7 @@
 				96A5A10A27AD9F7F007B960B /* RadarAddress.h in Headers */,
 				0107AA1926220052008AB52F /* RadarLocationManager.h in Headers */,
 				B0A0F0082FBC000100111111 /* RadarLocationManagerSwift.h in Headers */,
+				B0A0F0262FBC000100111111 /* RadarUserDefaults.h in Headers */,
 				96A5A10127AD9F7F007B960B /* RadarRoute.h in Headers */,
 				BA264CFD2FF31BD9000EDFE6 /* RadarReplay.h in Headers */,
 				96A5A0FE27AD9F7F007B960B /* RadarTrip.h in Headers */,

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		B0A0F0162FBC000100111111 /* TrackingCLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */; };
 		B0A0F0182FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */; };
 		B0A0F0202FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0212FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */; };
+		B0A0F0222FBC000100111111 /* StubCLHeading.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0232FBC000100111111 /* StubCLHeading.swift */; };
+		B0A0F0242FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0252FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift */; };
 		BA264CFB2FF3158B000EDFE6 /* RadarReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA264CFA2FF31582000EDFE6 /* RadarReplay.swift */; };
 		BA264CFD2FF31BD9000EDFE6 /* RadarReplay.h in Headers */ = {isa = PBXBuildFile; fileRef = BA264CFC2FF31BD5000EDFE6 /* RadarReplay.h */; };
 		BA264CFF2FF31FB6000EDFE6 /* RadarReplayBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA264CFE2FF31FAF000EDFE6 /* RadarReplayBuffer.swift */; };
@@ -347,6 +349,8 @@
 		B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingCLLocationManager.swift; sourceTree = "<group>"; };
 		B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftBeaconSyncTests.swift; sourceTree = "<group>"; };
 		B0A0F0212FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftRegionTests.swift; sourceTree = "<group>"; };
+		B0A0F0232FBC000100111111 /* StubCLHeading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubCLHeading.swift; sourceTree = "<group>"; };
+		B0A0F0252FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftHeadingTests.swift; sourceTree = "<group>"; };
 		BA264CFA2FF31582000EDFE6 /* RadarReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarReplay.swift; sourceTree = "<group>"; };
 		BA264CFC2FF31BD5000EDFE6 /* RadarReplay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarReplay.h; sourceTree = "<group>"; };
 		BA264CFE2FF31FAF000EDFE6 /* RadarReplayBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarReplayBuffer.swift; sourceTree = "<group>"; };
@@ -728,6 +732,8 @@
 				B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */,
 				B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */,
 				B0A0F0212FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */,
+				B0A0F0232FBC000100111111 /* StubCLHeading.swift */,
+				B0A0F0252FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
@@ -1172,6 +1178,8 @@
 				B0A0F0162FBC000100111111 /* TrackingCLLocationManager.swift in Sources */,
 				B0A0F0182FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */,
 				B0A0F0202FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift in Sources */,
+				B0A0F0222FBC000100111111 /* StubCLHeading.swift in Sources */,
+				B0A0F0242FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift in Sources */,
 				BA8647B92F6C7DB700F1A199 /* RadarSyncManagerTests.swift in Sources */,
 				96B465BC27D6732500D7119B /* CLLocation+RadarTests.m in Sources */,
 				DD103211237E0C47003DD408 /* RadarSDKTests.m in Sources */,

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -261,4 +261,20 @@ final class RadarLocationManagerSwift: NSObject {
             locationManager.stopMonitoring(for: region)
         }
     }
+
+    // Takes the heading rather than the location manager, so it uses a plain selector
+    // instead of the `...OnLocationManager:` convention. `RadarState` is a non-@objc Swift
+    // class and can't appear in an @objc signature, so it's constructed inside the method.
+    @objc(didUpdateHeading:)
+    static func didUpdateHeading(_ heading: CLHeading) {
+        RadarState().lastHeadingData = [
+            "magneticHeading": heading.magneticHeading,
+            "trueHeading": heading.trueHeading,
+            "headingAccuracy": heading.headingAccuracy,
+            "x": heading.x,
+            "y": heading.y,
+            "z": heading.z,
+            "timestamp": heading.timestamp.timeIntervalSince1970,
+        ]
+    }
 }

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1505,6 +1505,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didUpdateHeading:newHeading];
+        return;
+    }
+
     [RadarState setLastHeadingData:@{
         @"magneticHeading" : @(newHeading.magneticHeading),
         @"trueHeading" : @(newHeading.trueHeading),

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -39,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)removeSyncedGeofencesOnLocationManager:(CLLocationManager *)locationManager;
 + (void)removeAllRegionsOnLocationManager:(CLLocationManager *)locationManager;
 
++ (void)didUpdateHeading:(CLHeading *)newHeading;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarState.m
+++ b/RadarSDK/RadarState.m
@@ -12,6 +12,7 @@
 #import "CLLocation+Radar.h"
 #import "RadarUtils.h"
 #import "RadarLogger.h"
+#import "RadarUserDefaults.h"
 
 @implementation RadarState
 
@@ -179,11 +180,13 @@ static NSTimeInterval const kBackupInterval = 2.0; // 2 seconds
 }
 
 + (NSDictionary *)lastHeadingData {
-    return [[NSUserDefaults standardUserDefaults] dictionaryForKey:kLastHeadingData];
+    // Reads through the app-group-aware store so it stays consistent with the Swift
+    // RadarLocationManager twin, which writes heading via RadarUserDefaults.
+    return [[RadarUserDefaults sharedUserDefaults] dictionaryForKey:kLastHeadingData];
 }
 
 + (void)setLastHeadingData:(NSDictionary *_Nullable)lastHeadingData {
-    [[NSUserDefaults standardUserDefaults] setObject:lastHeadingData forKey:kLastHeadingData];
+    [[RadarUserDefaults sharedUserDefaults] setObject:lastHeadingData forKey:kLastHeadingData];
 }
 
 + (NSDictionary *)lastMotionActivityData {

--- a/RadarSDK/RadarState.swift
+++ b/RadarSDK/RadarState.swift
@@ -25,4 +25,16 @@ class RadarState {
             }
         }
     }
+
+    public var lastHeadingData: [String: Double]? {
+        get {
+            guard let dict = RadarUserDefaults.dictionary(forKey: .LastHeadingData) else {
+                return nil
+            }
+            return dict.compactMapValues { ($0 as? NSNumber)?.doubleValue }
+        }
+        set {
+            RadarUserDefaults.set(newValue, forKey: .LastHeadingData)
+        }
+    }
 }

--- a/RadarSDK/RadarState.swift
+++ b/RadarSDK/RadarState.swift
@@ -31,7 +31,7 @@ class RadarState {
             guard let dict = RadarUserDefaults.dictionary(forKey: .LastHeadingData) else {
                 return nil
             }
-            return dict.compactMapValues { ($0 as? NSNumber)?.doubleValue }
+            return dict.compactMapValues { heading in (heading as? NSNumber)?.doubleValue }
         }
         set {
             RadarUserDefaults.set(newValue, forKey: .LastHeadingData)

--- a/RadarSDK/RadarUserDefaults.h
+++ b/RadarSDK/RadarUserDefaults.h
@@ -1,0 +1,24 @@
+//
+//  RadarUserDefaults.h
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+//  ObjC-visible interface for the Swift RadarUserDefaults storage funnel. The
+//  implementation lives in RadarUserDefaults.swift, which is internal to the module and
+//  therefore absent from the public RadarSDK-Swift.h. ObjC accessors that have not yet
+//  migrated to the Swift `Key`-typed API import this header to reach the same
+//  app-group-aware backing store the Swift funnel uses.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RadarUserDefaults : NSObject
+
++ (NSUserDefaults *)sharedUserDefaults;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/RadarSDK/RadarUserDefaults.swift
+++ b/RadarSDK/RadarUserDefaults.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class RadarUserDefaults: NSObject {
+@objc(RadarUserDefaults) class RadarUserDefaults: NSObject {
 
     public enum Key: String, CaseIterable {
         // RadarSettings
@@ -76,6 +76,12 @@ class RadarUserDefaults: NSObject {
                 return UserDefaults.standard
             }
         }()
+
+    /// The backing store the SDK persists to — the app-group suite when one is configured
+    /// via `Radar.initializeWithAppGroup:`, otherwise `UserDefaults.standard`. Exposed to
+    /// ObjC so accessors not yet migrated to the `Key`-typed API (e.g. `RadarState`'s
+    /// heading data) read and write the same store this funnel uses.
+    @objc static var sharedUserDefaults: UserDefaults { userDefaults }
 
     private static let flushQueue = DispatchQueue(
         label: "io.radar.userdefaults.flush",

--- a/RadarSDKTests/RadarLocationManagerSwiftHeadingTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftHeadingTests.swift
@@ -1,0 +1,88 @@
+//
+//  RadarLocationManagerSwiftHeadingTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    actor RadarLocationManagerSwiftHeadingTests {
+
+        // MARK: - didUpdateHeading
+
+        @Test("didUpdateHeading stores every CLHeading field under the heading key")
+        func didUpdateHeadingStoresAllFields() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer {
+                RadarLocationManagerSwiftTestHelpers.clearState()
+                RadarUserDefaults.set(nil, forKey: .LastHeadingData)
+            }
+
+            let stub = StubCLHeading(
+                magneticHeading: 12.5,
+                trueHeading: 34.5,
+                headingAccuracy: 5,
+                x: 0.1,
+                y: 0.2,
+                z: 0.3,
+                timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+
+            RadarLocationManagerSwift.didUpdateHeading(stub)
+
+            let stored = RadarState().lastHeadingData
+            #expect(stored?["magneticHeading"] == 12.5)
+            #expect(stored?["trueHeading"] == 34.5)
+            #expect(stored?["headingAccuracy"] == 5)
+            #expect(stored?["x"] == 0.1)
+            #expect(stored?["y"] == 0.2)
+            #expect(stored?["z"] == 0.3)
+            #expect(stored?["timestamp"] == 1_700_000_000)
+        }
+
+        @Test("didUpdateHeading overwrites previously stored heading data")
+        func didUpdateHeadingOverwritesPrevious() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer {
+                RadarLocationManagerSwiftTestHelpers.clearState()
+                RadarUserDefaults.set(nil, forKey: .LastHeadingData)
+            }
+
+            RadarLocationManagerSwift.didUpdateHeading(
+                StubCLHeading(
+                    magneticHeading: 1,
+                    trueHeading: 1,
+                    headingAccuracy: 1,
+                    x: 1,
+                    y: 1,
+                    z: 1,
+                    timestamp: Date(timeIntervalSince1970: 1)
+                )
+            )
+            RadarLocationManagerSwift.didUpdateHeading(
+                StubCLHeading(
+                    magneticHeading: 99,
+                    trueHeading: 88,
+                    headingAccuracy: 7,
+                    x: 0.5,
+                    y: 0.6,
+                    z: 0.7,
+                    timestamp: Date(timeIntervalSince1970: 2)
+                )
+            )
+
+            let stored = RadarState().lastHeadingData
+            #expect(stored?["magneticHeading"] == 99)
+            #expect(stored?["trueHeading"] == 88)
+            #expect(stored?["headingAccuracy"] == 7)
+            #expect(stored?["timestamp"] == 2)
+        }
+    }
+}

--- a/RadarSDKTests/StubCLHeading.swift
+++ b/RadarSDKTests/StubCLHeading.swift
@@ -1,0 +1,54 @@
+//
+//  StubCLHeading.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Foundation
+
+/// Test-only `CLHeading` subclass that overrides the read-only heading fields so the
+/// Swift twin can be exercised without real Core Location. Subclassing CLHeading is
+/// officially unsupported by Apple, but this is the same technique
+/// `TrackingCLLocationManager` uses for `CLLocationManager`.
+final class StubCLHeading: CLHeading, @unchecked Sendable {
+    private let _magneticHeading: CLLocationDirection
+    private let _trueHeading: CLLocationDirection
+    private let _headingAccuracy: CLLocationDirection
+    private let _x: CLHeadingComponentValue
+    private let _y: CLHeadingComponentValue
+    private let _z: CLHeadingComponentValue
+    private let _timestamp: Date
+
+    init(
+        magneticHeading: CLLocationDirection,
+        trueHeading: CLLocationDirection,
+        headingAccuracy: CLLocationDirection,
+        x: CLHeadingComponentValue,
+        y: CLHeadingComponentValue,
+        z: CLHeadingComponentValue,
+        timestamp: Date
+    ) {
+        _magneticHeading = magneticHeading
+        _trueHeading = trueHeading
+        _headingAccuracy = headingAccuracy
+        _x = x
+        _y = y
+        _z = z
+        _timestamp = timestamp
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not used by tests")
+    }
+
+    override var magneticHeading: CLLocationDirection { _magneticHeading }
+    override var trueHeading: CLLocationDirection { _trueHeading }
+    override var headingAccuracy: CLLocationDirection { _headingAccuracy }
+    override var x: CLHeadingComponentValue { _x }
+    override var y: CLHeadingComponentValue { _y }
+    override var z: CLHeadingComponentValue { _z }
+    override var timestamp: Date { _timestamp }
+}

--- a/RadarSDKTests/StubCLHeading.swift
+++ b/RadarSDKTests/StubCLHeading.swift
@@ -13,13 +13,13 @@ import Foundation
 /// officially unsupported by Apple, but this is the same technique
 /// `TrackingCLLocationManager` uses for `CLLocationManager`.
 final class StubCLHeading: CLHeading, @unchecked Sendable {
-    private let _magneticHeading: CLLocationDirection
-    private let _trueHeading: CLLocationDirection
-    private let _headingAccuracy: CLLocationDirection
-    private let _x: CLHeadingComponentValue
-    private let _y: CLHeadingComponentValue
-    private let _z: CLHeadingComponentValue
-    private let _timestamp: Date
+    private let storedMagneticHeading: CLLocationDirection
+    private let storedTrueHeading: CLLocationDirection
+    private let storedHeadingAccuracy: CLLocationDirection
+    private let storedX: CLHeadingComponentValue
+    private let storedY: CLHeadingComponentValue
+    private let storedZ: CLHeadingComponentValue
+    private let storedTimestamp: Date
 
     init(
         magneticHeading: CLLocationDirection,
@@ -30,13 +30,13 @@ final class StubCLHeading: CLHeading, @unchecked Sendable {
         z: CLHeadingComponentValue,
         timestamp: Date
     ) {
-        _magneticHeading = magneticHeading
-        _trueHeading = trueHeading
-        _headingAccuracy = headingAccuracy
-        _x = x
-        _y = y
-        _z = z
-        _timestamp = timestamp
+        storedMagneticHeading = magneticHeading
+        storedTrueHeading = trueHeading
+        storedHeadingAccuracy = headingAccuracy
+        storedX = x
+        storedY = y
+        storedZ = z
+        storedTimestamp = timestamp
         super.init()
     }
 
@@ -44,11 +44,11 @@ final class StubCLHeading: CLHeading, @unchecked Sendable {
         fatalError("init(coder:) is not used by tests")
     }
 
-    override var magneticHeading: CLLocationDirection { _magneticHeading }
-    override var trueHeading: CLLocationDirection { _trueHeading }
-    override var headingAccuracy: CLLocationDirection { _headingAccuracy }
-    override var x: CLHeadingComponentValue { _x }
-    override var y: CLHeadingComponentValue { _y }
-    override var z: CLHeadingComponentValue { _z }
-    override var timestamp: Date { _timestamp }
+    override var magneticHeading: CLLocationDirection { storedMagneticHeading }
+    override var trueHeading: CLLocationDirection { storedTrueHeading }
+    override var headingAccuracy: CLLocationDirection { storedHeadingAccuracy }
+    override var x: CLHeadingComponentValue { storedX }
+    override var y: CLHeadingComponentValue { storedY }
+    override var z: CLHeadingComponentValue { storedZ }
+    override var timestamp: Date { storedTimestamp }
 }


### PR DESCRIPTION
Continues the `RadarLocationManager` ObjC→Swift migration behind the `useSwiftLocationManager` seam (follows #615 / #621 / #631).

## What changed

**1. Port `locationManager:didUpdateHeading:`** — the one **pure leaf** among the remaining `CLLocationManagerDelegate` callbacks. Its only side effect is transforming a `CLHeading` into a dictionary and storing it; the other delegate callbacks route into the large unported `handleLocation:` / completion-handler / `RadarBeaconManager` machinery, so this is the natural next chunk.

- **`RadarLocationManager+Swift.swift`** — new `@objc(didUpdateHeading:)` static twin. It takes the heading rather than the manager, so it uses a plain selector instead of the `...OnLocationManager:` convention.
- **`RadarLocationManager.m`** — `useSwiftLocationManager` guard-and-return shim at the top of the ObjC method; the ObjC body is left intact so both implementations coexist until the port is trusted.
- **`RadarLocationManagerSwift.h`** — declares the twin in the hand-maintained header.
- **`RadarState.swift`** — new `lastHeadingData` computed property backed by `RadarUserDefaults`, mirroring the existing `registeredNotifications` precedent. The Swift `RadarState` shadows the ObjC class in-module, so the twin can't call the ObjC `setLastHeadingData:`.

**2. Route the ObjC `RadarState` heading accessors through `RadarUserDefaults`** — so the storage funnel is consistent across the ObjC/Swift boundary (see below).

- **`RadarUserDefaults.swift`** — now `@objc(RadarUserDefaults)` with an `@objc static var sharedUserDefaults` exposing the app-group-aware backing store.
- **`RadarUserDefaults.h`** — new hand-maintained bridge header (Project visibility, like `RadarLocationManagerSwift.h`), since internal Swift classes aren't in the public `RadarSDK-Swift.h`.
- **`RadarState.m`** — `+lastHeadingData` and `+setLastHeadingData:` now read/write `[RadarUserDefaults sharedUserDefaults]` instead of `standardUserDefaults`.

**Tests** — new `StubCLHeading` (a `CLHeading` subclass mock, same technique as `TrackingCLLocationManager`) and a `RadarLocationManagerSwiftHeadingTests` behavior suite; both registered in the `RadarSDKTests` target.

## Why the RadarUserDefaults routing matters

The Swift twin writes heading through `RadarUserDefaults` (which resolves to the **app-group suite** when a customer configures one via `Radar.initializeWithAppGroup:`). The sole reader — `RadarAPIClient` → `[RadarState lastHeadingData]` — plus the flag-off ObjC writer previously used `standardUserDefaults` directly. So with `useSwiftLocationManager` on **and** an app group configured, the Swift write landed in the shared suite while the ObjC read came from `standard`, silently dropping the heading from the location payload.

Both the getter and setter had to move together: migrating only the reader would have broken the flag-**off** path under an app group. After this change, all four paths — Swift twin write (flag-on), ObjC write (flag-off), the ObjC reader, and the Swift test getter — resolve to the same store in both app-group and non-app-group modes.

## Manual test steps (Example app)

These verify heading is captured and flows into the `/v1/track` payload as `locationMetadata.heading` — the behavior this PR touches. The Example app already configures an app group (`Radar.setAppGroup("group.waypoint.data")` in `Example/Example/AppDelegate.swift`, matching `Example.entitlements`), so it exercises the exact app-group condition this fix addresses.

**Prerequisites**
- A **physical device** — the Simulator has no magnetometer, so `didUpdateHeading:` doesn't fire (the `heading` key comes back null; Simulator is only good for confirming the plumbing, not real values).
- A signing team that can use the `group.waypoint.data` app group (or change the id in both `Example/Example/Example.entitlements` and the `Radar.setAppGroup(...)` call).

**Setup**

1. **Valid publishable key:** there's no key field in the UI, so set `SettingsStore.defaultPublishableKey` (`Example/Example/Services/SettingsStore.swift:44`) to a real test key. The placeholder won't sync to the dashboard.
2. **Force the Swift path on.** This PR's code only runs when `useSwiftLocationManager` is set, which is server-driven. Force it locally by flipping the default at `RadarSdkConfiguration.swift:60`:
   ```swift
   useSwiftLocationManager = dict?["useSwiftLocationManager"] as? Bool ?? true
   ```
   (Or hardcode the ObjC guard in `RadarLocationManager.m:1508` to `if (YES)`.)
4. **Debug logging:** Debug builds default to `.debug`; to be safe, add `Radar.setLogLevel(.debug)` right after `Radar.initialize(...)` in `AppDelegate.swift`.

**Run**
1. Open `Example/Example.xcodeproj`, run the **Example** scheme on the device.
2. Grant **Always** location and **Motion & Fitness** permissions.
3. Ensure `useMotion` is on for local or server tracking options
4. `startTracking()`
5. Move / rotate the device so heading updates fire (`headingFilter` is 5°).

**Verify**
- Open the **Debug** tab → **Logs** filter → expand the `📍 Radar API request | method = POST; url = …/v1/track` entry → confirm `locationMetadata.heading` contains real values (`magneticHeading`, `trueHeading`, `x`, `y`, `z`, `headingAccuracy`, `timestamp`), not null. Use the entry's Copy/Share button to grab the full body.
- Optional: with a valid key, cross-check the location event's heading in the Radar dashboard.
