### PR TITLE
docs(revealRisk): add inline API docs for reveal risk

### DIFF
--- a/RadarSDK/Include/Radar.h
+++ b/RadarSDK/Include/Radar.h
@@ -605,7 +605,7 @@ typedef void (^_Nonnull RadarIndoorsScanCompletionHandler)(NSString *_Nullable r
 + (void)trackVerifiedWithCompletionHandler:(RadarTrackVerifiedCompletionHandler _Nullable)completionHandler NS_SWIFT_NAME(trackVerified(completionHandler:));
 
 /**
- Gets a reveal risk assessment for the current device, including device, network, and risk signals.
+ Reveals device and network risk signals for this device.
 
  @warning Note that you must configure SSL pinning before calling this method.
 

--- a/RadarSDK/Include/RadarRevealRiskToken.h
+++ b/RadarSDK/Include/RadarRevealRiskToken.h
@@ -6,11 +6,6 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
-/**
- Represents device and network risk signals.
-
- @see https://radar.com/documentation/fraud
- */
 @interface RadarRevealRiskTokenRisk : NSObject
 @property (nonatomic, readonly, copy) NSString * _Nonnull level;
 @property (nonatomic, readonly, copy) NSArray<NSString *> * _Nonnull reasons;
@@ -83,6 +78,11 @@
 @property (nonatomic, readonly, copy) NSString * _Nullable appBuild;
 @end
 
+/**
+ Represents device and network risk signals.
+
+ @see https://radar.com/documentation/fraud
+ */
 @interface RadarRevealRiskToken : NSObject
 @property (nonatomic, readonly, copy) NSString * _Nonnull _id;
 @property (nonatomic, readonly, copy) NSString * _Nullable token;

--- a/RadarSDK/Include/RadarRevealRiskToken.h
+++ b/RadarSDK/Include/RadarRevealRiskToken.h
@@ -6,6 +6,11 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+/**
+ Represents device and network risk signals.
+
+ @see https://radar.com/documentation/fraud
+ */
 @interface RadarRevealRiskTokenRisk : NSObject
 @property (nonatomic, readonly, copy) NSString * _Nonnull level;
 @property (nonatomic, readonly, copy) NSArray<NSString *> * _Nonnull reasons;


### PR DESCRIPTION
## Summary
Inline API documentation for the reveal risk interface — **no behavior changes**, `RadarSDK/` only.

- `RadarSDK/Include/Radar.h`: tighten the `revealRisk()` doc-comment summary
- `RadarSDK/Include/RadarRevealRiskToken.h`: add a class-level doc comment to `RadarRevealRiskTokenRisk` describing device/network risk signals, with a link to the fraud docs

## Notes
- Based on `briansiebert/fra-2079-reveal-risk-ios-sdk-interface` (PR #644), since `RadarRevealRiskToken.h` doesn't exist on `master` yet — this keeps the diff to just the doc changes.
- Excludes the example app and the `RadarSDKFraud`/`RadarSDKIndoors` submodule pointer changes from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)