### PR TITLE
add event types for user insights

### DIFF
--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */; };
 		F6A2DDE52EE8A23000ABA650 /* RadarIndoors.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A2DDE42EE8A22500ABA650 /* RadarIndoors.h */; };
 		F6A2DDE62EE8A71800ABA650 /* RadarIndoors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED7C1D2EDF917700D3E6E6 /* RadarIndoors.swift */; };
+		F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */; };
 		F6B7E3472F7429D6006A5A24 /* RadarNotificationHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */; };
 		F6B7E3492F745E49006A5A24 /* RadarNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3482F745E44006A5A24 /* RadarNotification.swift */; };
 		F6B7E3BD2F758A13006A5A24 /* MockRadarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */; };
@@ -504,6 +505,7 @@
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
 		F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSettingsTest.swift; sourceTree = "<group>"; };
 		F6A2DDE42EE8A22500ABA650 /* RadarIndoors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarIndoors.h; sourceTree = "<group>"; };
+		F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationInsightsModelTests.swift; sourceTree = "<group>"; };
 		F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationHelperTest.swift; sourceTree = "<group>"; };
 		F6B7E3482F745E44006A5A24 /* RadarNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotification.swift; sourceTree = "<group>"; };
 		F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRadarState.swift; sourceTree = "<group>"; };
@@ -771,6 +773,7 @@
 				B0A0F0232FBC000100111111 /* StubCLHeading.swift */,
 				B0A0F0252FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift */,
 				B0A0F0292FBC000100111111 /* RadarLocationManagerSwiftAuthTests.swift */,
+				F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
 				F6FA1103000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift */,
@@ -1214,6 +1217,7 @@
 				BA561CDA2FD3869500D7A3E3 /* RadarOperatingHoursEvaluatorTest.swift in Sources */,
 				F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */,
 				F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */,
+				F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */,
 				F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */,
 				F6FA1104000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift in Sources */,
 				DD8E2F7424018C17002D51AB /* RadarPermissionsHelperMock.m in Sources */,

--- a/RadarSDK/Include/RadarEvent.h
+++ b/RadarSDK/Include/RadarEvent.h
@@ -73,7 +73,23 @@ typedef NS_ENUM(NSInteger, RadarEventType) {
     /// `user.failed_fraud`
     RadarEventTypeUserFailedFraud NS_SWIFT_NAME(userFailedFraud),
     /// `user.fired_trip_orders`
-    RadarEventTypeUserFiredTripOrders NS_SWIFT_NAME(userFiredTripOrders)
+    RadarEventTypeUserFiredTripOrders NS_SWIFT_NAME(userFiredTripOrders),
+    /// `user.entered_home`
+    RadarEventTypeUserEnteredHome NS_SWIFT_NAME(userEnteredHome),
+    /// `user.exited_home`
+    RadarEventTypeUserExitedHome NS_SWIFT_NAME(userExitedHome),
+    /// `user.entered_work`
+    RadarEventTypeUserEnteredWork NS_SWIFT_NAME(userEnteredWork),
+    /// `user.exited_work`
+    RadarEventTypeUserExitedWork NS_SWIFT_NAME(userExitedWork),
+    /// `user.started_traveling`
+    RadarEventTypeUserStartedTraveling NS_SWIFT_NAME(userStartedTraveling),
+    /// `user.stopped_traveling`
+    RadarEventTypeUserStoppedTraveling NS_SWIFT_NAME(userStoppedTraveling),
+    /// `user.started_commuting`
+    RadarEventTypeUserStartedCommuting NS_SWIFT_NAME(userStartedCommuting),
+    /// `user.stopped_commuting`
+    RadarEventTypeUserStoppedCommuting NS_SWIFT_NAME(userStoppedCommuting)
 };
 
 /**

--- a/RadarSDK/Include/RadarUser.h
+++ b/RadarSDK/Include/RadarUser.h
@@ -19,6 +19,36 @@ typedef NS_ENUM(NSInteger, RadarLocationSource);
 typedef NS_ENUM(NSInteger, RadarActivityType);
 
 /**
+ Represents learned home, work, and travel state returned with a track response.
+ */
+@interface RadarUserLocationInsights : NSObject
+
+/**
+ A boolean indicating whether the user is currently at their learned home location.
+ */
+@property (assign, nonatomic, readonly) BOOL atHome;
+
+/**
+ A boolean indicating whether the user is currently at their learned work location.
+ */
+@property (assign, nonatomic, readonly) BOOL atWork;
+
+/**
+ A boolean indicating whether the user is currently traveling away from home.
+ */
+@property (assign, nonatomic, readonly) BOOL traveling;
+
+/**
+ A nullable boolean indicating whether the user is currently commuting.
+ */
+@property (nullable, strong, nonatomic, readonly) NSNumber *commuting;
+
+- (NSDictionary *_Nonnull)dictionaryValue;
+- (instancetype _Nullable)initWithObject:(id _Nonnull)object;
+
+@end
+
+/**
  Represents the current user state.
  */
 @interface RadarUser : NSObject
@@ -158,6 +188,10 @@ typedef NS_ENUM(NSInteger, RadarActivityType);
  */
 @property (nullable, copy, nonatomic, readonly) RadarFraud *fraud;
 
+/**
+ The user's learned home, work, and travel state. May be `nil` if location insights are not enabled.
+ */
+@property (nullable, strong, nonatomic, readonly) RadarUserLocationInsights *locationInsights;
 
 @property (assign, nonatomic, readonly) double altitude;
 

--- a/RadarSDK/RadarEvent.m
+++ b/RadarSDK/RadarEvent.m
@@ -184,6 +184,22 @@
             type = RadarEventTypeUserFailedFraud;
         } else if ([typeStr isEqualToString:@"user.fired_trip_orders"]) {
             type = RadarEventTypeUserFiredTripOrders;
+        } else if ([typeStr isEqualToString:@"user.entered_home"]) {
+            type = RadarEventTypeUserEnteredHome;
+        } else if ([typeStr isEqualToString:@"user.exited_home"]) {
+            type = RadarEventTypeUserExitedHome;
+        } else if ([typeStr isEqualToString:@"user.entered_work"]) {
+            type = RadarEventTypeUserEnteredWork;
+        } else if ([typeStr isEqualToString:@"user.exited_work"]) {
+            type = RadarEventTypeUserExitedWork;
+        } else if ([typeStr isEqualToString:@"user.started_traveling"]) {
+            type = RadarEventTypeUserStartedTraveling;
+        } else if ([typeStr isEqualToString:@"user.stopped_traveling"]) {
+            type = RadarEventTypeUserStoppedTraveling;
+        } else if ([typeStr isEqualToString:@"user.started_commuting"]) {
+            type = RadarEventTypeUserStartedCommuting;
+        } else if ([typeStr isEqualToString:@"user.stopped_commuting"]) {
+            type = RadarEventTypeUserStoppedCommuting;
         } else {
             type = RadarEventTypeConversion;
             conversionName = typeStr;
@@ -415,6 +431,22 @@
         return @"user.failed_fraud";
     case RadarEventTypeUserFiredTripOrders:
         return @"user.fired_trip_orders";
+    case RadarEventTypeUserEnteredHome:
+        return @"user.entered_home";
+    case RadarEventTypeUserExitedHome:
+        return @"user.exited_home";
+    case RadarEventTypeUserEnteredWork:
+        return @"user.entered_work";
+    case RadarEventTypeUserExitedWork:
+        return @"user.exited_work";
+    case RadarEventTypeUserStartedTraveling:
+        return @"user.started_traveling";
+    case RadarEventTypeUserStoppedTraveling:
+        return @"user.stopped_traveling";
+    case RadarEventTypeUserStartedCommuting:
+        return @"user.started_commuting";
+    case RadarEventTypeUserStoppedCommuting:
+        return @"user.stopped_commuting";
     case RadarEventTypeConversion:
         return @"custom";
     default:

--- a/RadarSDK/RadarUser.m
+++ b/RadarSDK/RadarUser.m
@@ -18,6 +18,58 @@
 #import "RadarUser+Internal.h"
 #import "RadarLogger.h"
 
+@implementation RadarUserLocationInsights
+
+- (instancetype _Nullable)initWithAtHome:(BOOL)atHome atWork:(BOOL)atWork traveling:(BOOL)traveling commuting:(NSNumber *_Nullable)commuting {
+    self = [super init];
+    if (self) {
+        _atHome = atHome;
+        _atWork = atWork;
+        _traveling = traveling;
+        _commuting = commuting;
+    }
+    return self;
+}
+
+- (instancetype _Nullable)initWithObject:(NSObject *)object {
+    if (!object || ![object isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+
+    NSDictionary *dict = (NSDictionary *)object;
+    NSNumber *commuting = nil;
+    id commutingObj = dict[@"commuting"];
+    if (commutingObj && [commutingObj isKindOfClass:[NSNumber class]]) {
+        commuting = (NSNumber *)commutingObj;
+    }
+
+    return [[RadarUserLocationInsights alloc] initWithAtHome:[self asBool:dict[@"atHome"]]
+                                                      atWork:[self asBool:dict[@"atWork"]]
+                                                   traveling:[self asBool:dict[@"traveling"]]
+                                                   commuting:commuting];
+}
+
+- (NSDictionary *)dictionaryValue {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    [dict setValue:@(self.atHome) forKey:@"atHome"];
+    [dict setValue:@(self.atWork) forKey:@"atWork"];
+    [dict setValue:@(self.traveling) forKey:@"traveling"];
+    [dict setValue:self.commuting forKey:@"commuting"];
+    return dict;
+}
+
+- (BOOL)asBool:(NSObject *)object {
+    if (object && [object isKindOfClass:[NSNumber class]]) {
+        NSNumber *number = (NSNumber *)object;
+
+        return [number boolValue];
+    } else {
+        return false;
+    }
+}
+
+@end
+
 @implementation RadarUser
 
 - (instancetype _Nullable)initWithId:(NSString *)_id
@@ -43,6 +95,7 @@
                                 trip:(RadarTrip *_Nullable)trip
                                debug:(BOOL)debug
                                fraud:(RadarFraud *_Nullable)fraud 
+                   locationInsights:(RadarUserLocationInsights *_Nullable)locationInsights
                             altitude:(double)altitude {
     self = [super init];
     if (self) {
@@ -69,6 +122,7 @@
         _trip = trip;
         _debug = debug;
         _fraud = fraud;
+        _locationInsights = locationInsights;
         _altitude = altitude;
     }
     return self;
@@ -103,6 +157,7 @@
     RadarLocationSource source = RadarLocationSourceUnknown;
     RadarTrip *trip;
     RadarFraud *fraud;
+    RadarUserLocationInsights *locationInsights;
     BOOL debug = NO;
     double altitude = NAN;
 
@@ -302,6 +357,9 @@
     id fraudObj = dict[@"fraud"];
     fraud = [[RadarFraud alloc] initWithObject:fraudObj];
 
+    id locationInsightsObj = dict[@"locationInsights"];
+    locationInsights = [[RadarUserLocationInsights alloc] initWithObject:locationInsightsObj];
+
     id barometricAltitudeObj = dict[@"barometricAltitude"];
     if (barometricAltitudeObj && [barometricAltitudeObj isKindOfClass:[NSNumber class]]) {
         altitude = [((NSNumber *)barometricAltitudeObj) doubleValue];
@@ -336,6 +394,7 @@
                                         trip:trip
                                        debug:debug
                                        fraud:fraud
+                            locationInsights:locationInsights
                                     altitude:altitude];
     }
 
@@ -396,6 +455,9 @@
     [dict setValue:@(self.debug) forKey:@"debug"];
     if (self.fraud) {
         [dict setValue:[self.fraud dictionaryValue] forKey:@"fraud"];
+    }
+    if (self.locationInsights) {
+        [dict setValue:[self.locationInsights dictionaryValue] forKey:@"locationInsights"];
     }
     if (!isnan(self.altitude)) {
         [dict setValue:@(self.altitude) forKey:@"altitude"];

--- a/RadarSDK/RadarUser.m
+++ b/RadarSDK/RadarUser.m
@@ -31,7 +31,7 @@
     return self;
 }
 
-- (instancetype _Nullable)initWithObject:(NSObject *)object {
+- (instancetype _Nullable)initWithObject:(id _Nonnull)object {
     if (!object || ![object isKindOfClass:[NSDictionary class]]) {
         return nil;
     }

--- a/RadarSDKTests/RadarLocationInsightsModelTests.swift
+++ b/RadarSDKTests/RadarLocationInsightsModelTests.swift
@@ -1,0 +1,103 @@
+//
+//  RadarLocationInsightsModelTests.swift
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    struct RadarLocationInsightsModelTests {
+
+        @Test("Parses location insight event types")
+        func parsesLocationInsightEventTypes() {
+            let cases: [(String, RadarEventType)] = [
+                ("user.entered_home", .userEnteredHome),
+                ("user.exited_home", .userExitedHome),
+                ("user.entered_work", .userEnteredWork),
+                ("user.exited_work", .userExitedWork),
+                ("user.started_traveling", .userStartedTraveling),
+                ("user.stopped_traveling", .userStoppedTraveling),
+                ("user.started_commuting", .userStartedCommuting),
+                ("user.stopped_commuting", .userStoppedCommuting),
+            ]
+
+            for (eventTypeString, eventType) in cases {
+                let event = RadarEvent(object: eventDict(type: eventTypeString))
+
+                #expect(event?.type == eventType)
+                #expect(event?.dictionaryValue()["type"] as? String == eventTypeString)
+            }
+        }
+
+        @Test("Parses and serializes user location insights")
+        func parsesUserLocationInsights() {
+            let user = RadarUser(
+                object: userDict(locationInsights: [
+                    "atHome": true,
+                    "atWork": false,
+                    "traveling": true,
+                    "commuting": false,
+                ]))
+
+            #expect(user?.locationInsights?.atHome == true)
+            #expect(user?.locationInsights?.atWork == false)
+            #expect(user?.locationInsights?.traveling == true)
+            #expect(user?.locationInsights?.commuting == false)
+
+            let serializedLocationInsights = user?.dictionaryValue()["locationInsights"] as? [String: Any]
+            #expect(serializedLocationInsights?["atHome"] as? Bool == true)
+            #expect(serializedLocationInsights?["atWork"] as? Bool == false)
+            #expect(serializedLocationInsights?["traveling"] as? Bool == true)
+            #expect(serializedLocationInsights?["commuting"] as? Bool == false)
+        }
+
+        @Test("Allows commuting to be omitted from location insights")
+        func omitsNilCommuting() {
+            let locationInsights = RadarUserLocationInsights(object: [
+                "atHome": false,
+                "atWork": true,
+                "traveling": false,
+            ])
+
+            #expect(locationInsights?.atHome == false)
+            #expect(locationInsights?.atWork == true)
+            #expect(locationInsights?.traveling == false)
+            #expect(locationInsights?.commuting == nil)
+            #expect(locationInsights?.dictionaryValue()["commuting"] == nil)
+        }
+
+        private func eventDict(type: String) -> [String: Any] {
+            return [
+                "_id": "evt_test",
+                "createdAt": "2026-06-26T12:00:00.000Z",
+                "actualCreatedAt": "2026-06-26T12:00:00.000Z",
+                "live": false,
+                "type": type,
+                "confidence": 3,
+                "location": [
+                    "type": "Point",
+                    "coordinates": [-73.975365, 40.783825],
+                ],
+            ]
+        }
+
+        private func userDict(locationInsights: [String: Any]) -> [String: Any] {
+            return [
+                "_id": "user_test",
+                "userId": "user-id",
+                "deviceId": "device-id",
+                "location": [
+                    "type": "Point",
+                    "coordinates": [-73.975365, 40.783825],
+                ],
+                "locationInsights": locationInsights,
+            ]
+        }
+    }
+}

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -8,5 +8,6 @@
 #import "../RadarSDK/RadarGeofence+Internal.h"
 #import "../RadarSDK/RadarCircleGeometry+Internal.h"
 #import "../RadarSDK/RadarPolygonGeometry+Internal.h"
+#import "../RadarSDK/RadarEvent+Internal.h"
 #import "RadarAPIHelperMock.h"
 #import "RadarPermissionsHelperMock.h"


### PR DESCRIPTION
## Summary

Adds the event types for user location insights (entered/exited home and work, commuting, traveling).

## Linear ticket (Radar internal)

FENCE-2939

## Checklist

- [ ] New code is written in Swift (the SDK is migrating off Objective-C)
- [x] Added or updated unit tests (`make test`)
- [x] `make lint-swift` and `make format-check` pass locally
- [ ] For breaking changes: added a `MIGRATION.md` entry and bumped the version with `./set-version.sh`
- [ ] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/format violations on lines I changed; removed any now-stale `.swiftlint-baseline.json` entries

## Screenshots / recordings (optional)

<!-- For example-app or other user-visible changes. -->
