### PR TITLE
FENCE-2938: Use a GitHub App installation token for the nightly migration workflow

### DIFF
--- a/.github/workflows/objc-to-swift-nightly.yml
+++ b/.github/workflows/objc-to-swift-nightly.yml
@@ -16,9 +16,11 @@ concurrency:
   group: objc-to-swift-nightly
   cancel-in-progress: false
 
-# Pushes and PR creation use MIGRATION_GH_TOKEN (a PAT), NOT the default
+# Pushes and PR creation use a GitHub App installation token, NOT the default
 # GITHUB_TOKEN — PRs opened with GITHUB_TOKEN would not trigger the
-# build-and-test.yml pull_request workflow that verifies the migration.
+# build-and-test.yml pull_request workflow that verifies the migration. The
+# App is org-owned (not tied to any one person's PAT) via the
+# radarlabs-swift-migration-bot GitHub App.
 permissions:
   contents: read
 
@@ -28,10 +30,19 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MIGRATION_GH_APP_ID }}
+          private-key: ${{ secrets.MIGRATION_GH_APP_PRIVATE_KEY }}
+          owner: radarlabs
+          repositories: radar-sdk-ios,clankers
+
       - name: Skip if a migration PR is already open (WIP cap = 1)
         id: guard
         env:
-          GH_TOKEN: ${{ secrets.MIGRATION_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           OPEN=$(gh pr list --repo "$GITHUB_REPOSITORY" --label swift-migration --state open --json number --jq 'length')
           echo "open=$OPEN" >> "$GITHUB_OUTPUT"
@@ -43,8 +54,8 @@ jobs:
         if: steps.guard.outputs.open == '0'
         uses: actions/checkout@v5
         with:
-          # PAT (not GITHUB_TOKEN) so the pushed branch + PR trigger CI.
-          token: ${{ secrets.MIGRATION_GH_TOKEN }}
+          # GitHub App token (not GITHUB_TOKEN) so the pushed branch + PR trigger CI.
+          token: ${{ steps.app-token.outputs.token }}
           # No submodules: the conversion only touches RadarSDK sources + pbxproj.
 
       - name: Checkout the objc-to-swift skill (radarlabs/clankers)
@@ -52,7 +63,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: radarlabs/clankers
-          token: ${{ secrets.MIGRATION_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: clankers-skill
 
       - name: Install the skill for this run
@@ -73,10 +84,10 @@ jobs:
         if: steps.guard.outputs.open == '0'
         uses: anthropics/claude-code-action@v1
         env:
-          GH_TOKEN: ${{ secrets.MIGRATION_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.MIGRATION_GH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             /objc-to-swift batch
 


### PR DESCRIPTION
## Summary

Replaces the `MIGRATION_GH_TOKEN` PAT (added in #656) with a GitHub App installation token, so the credential authenticating the nightly ObjC→Swift migration workflow is org-owned rather than tied to whichever person generated the PAT.

- Adds a `Generate GitHub App token` step (`actions/create-github-app-token@v2`) as the first step in the job, scoped to `radar-sdk-ios` and `clankers`.
- Swaps all 4 uses of `secrets.MIGRATION_GH_TOKEN` (guard step, both checkouts, migration-agent step) for `steps.app-token.outputs.token`.
- Updates the explanatory comments accordingly.

## One-time setup required before merging/enabling

- Create a GitHub App (e.g. `radarlabs-swift-migration-bot`) with `Contents: Read & write` and `Pull requests: Read & write` permissions, installed on `radarlabs/radar-sdk-ios` and `radarlabs/clankers`.
- Add repo secrets `MIGRATION_GH_APP_ID` and `MIGRATION_GH_APP_PRIVATE_KEY`.
- Once verified working, remove the now-unused `MIGRATION_GH_TOKEN` secret.