### PR TITLE
FENCE-2804: Fully port location update delegate to Swift

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -95,6 +95,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		17C814CC302CC79400425933 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DFA6F045F184B94C6F334DFB /* RadarSDKIndoors.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FE9415002E0DE3E6008ECBEB;
+			remoteInfo = RadarSDKIndoorsTests;
+		};
 		5B085ACBE42C1F343A80AFB6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DFA6F045F184B94C6F334DFB /* RadarSDKIndoors.xcodeproj */;
@@ -285,14 +292,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		BA51988E2ED10AEB004A3B35 /* Exceptions for "TripActivityExtension" folder in "TripActivityExtensionExtension" target */ = {
+		BA51988E2ED10AEB004A3B35 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = BA5198792ED10AEA004A3B35 /* TripActivityExtensionExtension */;
 		};
-		BA5198982EDE1106004A3B35 /* Exceptions for "TripActivityExtension" folder in "Example" target */ = {
+		BA5198982EDE1106004A3B35 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				"Extensions/UIColor+Hex.swift",
@@ -306,7 +313,7 @@
 			);
 			target = DD236D22230A006700EB88F9 /* Example */;
 		};
-		F6513E7A2E60A5F600523472 /* Exceptions for "LocationPushExtension" folder in "LocationPushExtension" target */ = {
+		F6513E7A2E60A5F600523472 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -316,31 +323,8 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		BA51987F2ED10AEA004A3B35 /* TripActivityExtension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				BA5198982EDE1106004A3B35 /* Exceptions for "TripActivityExtension" folder in "Example" target */,
-				BA51988E2ED10AEB004A3B35 /* Exceptions for "TripActivityExtension" folder in "TripActivityExtensionExtension" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = TripActivityExtension;
-			sourceTree = "<group>";
-		};
-		F6513E732E60A5F600523472 /* LocationPushExtension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				F6513E7A2E60A5F600523472 /* Exceptions for "LocationPushExtension" folder in "LocationPushExtension" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = LocationPushExtension;
-			sourceTree = "<group>";
-		};
+		BA51987F2ED10AEA004A3B35 /* TripActivityExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (BA5198982EDE1106004A3B35 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, BA51988E2ED10AEB004A3B35 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TripActivityExtension; sourceTree = "<group>"; };
+		F6513E732E60A5F600523472 /* LocationPushExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (F6513E7A2E60A5F600523472 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LocationPushExtension; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -385,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				FD361BF33854ED123BC40BAB /* RadarSDKIndoors.framework */,
+				17C814CD302CC79400425933 /* RadarSDKIndoorsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -709,12 +694,12 @@
 					ProjectRef = F64C7FB22F645A9F00943B7A /* RadarSDKFraud.xcodeproj */;
 				},
 				{
-					ProductGroup = F64C7F0C2F64564F00943B7A /* Products */;
-					ProjectRef = E698B7382C626AE600084371 /* RadarSDKMotion.xcodeproj */;
-				},
-				{
 					ProductGroup = 6FD78D530E6296330B1235BA /* Products */;
 					ProjectRef = DFA6F045F184B94C6F334DFB /* RadarSDKIndoors.xcodeproj */;
+				},
+				{
+					ProductGroup = F64C7F0C2F64564F00943B7A /* Products */;
+					ProjectRef = E698B7382C626AE600084371 /* RadarSDKMotion.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -727,6 +712,13 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		17C814CD302CC79400425933 /* RadarSDKIndoorsTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RadarSDKIndoorsTests.xctest;
+			remoteRef = 17C814CC302CC79400425933 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		F64C7F092F64564F00943B7A /* RadarSDKTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
@@ -1088,7 +1080,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 96GHH65B9D;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1120,7 +1112,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 96GHH65B9D;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -11,6 +11,36 @@ import Foundation
 // The `CLLocationManagerDelegate` half of `RadarLocationManager`
 extension RadarLocationManagerSwift {
 
+    @objc(didUpdateLocations:completionHandlerCount:)
+    static func didUpdateLocations(_ updates: [CLLocation]?, completionHandlerCount: UInt) {
+        guard let location = updates?.last else {
+            return
+        }
+
+        let source = locationSource(completionHandlerCount: completionHandlerCount)
+        guard source != .unknown else {
+            return
+        }
+
+        RadarSwift.bridge?.handleLocation(location, source: source)
+    }
+
+    private static func locationSource(completionHandlerCount: UInt) -> RadarLocationSource {
+        let configuration = RadarSettings.sdkConfiguration
+        if completionHandlerCount > 0,
+            configuration?.skipForegroundCheck == true || RadarSwift.bridge?.isForeground() == true
+        {
+            return .foregroundLocation
+        }
+
+        guard RadarSettings.tracking else {
+            RadarLogger.shared.debug("🦅 Ignoring location: not tracking")
+            return .unknown
+        }
+
+        return .backgroundLocation
+    }
+
     @objc(didUpdateHeading:)
     static func didUpdateHeading(_ heading: CLHeading) {
         RadarState().lastHeadingData = [

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -13,6 +13,7 @@ extension RadarLocationManagerSwift {
 
     @objc(didUpdateLocations:completionHandlerCount:)
     static func didUpdateLocations(_ updates: [CLLocation]?, completionHandlerCount: UInt) {
+        // At least one location update exists. Last one is the one we care about
         guard let location = updates?.last else {
             return
         }

--- a/RadarSDK/RadarLocationManager.h
+++ b/RadarSDK/RadarLocationManager.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateTracking;
 - (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta;
 - (void)updateTrackingFromInitialize;
+- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source;
 
 /**
  If `[RadarSettings previousTrackingOptions]` is not `nil`, remove them and

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1303,6 +1303,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 #pragma mark - CLLocationManagerDelegate
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didUpdateLocations:locations completionHandlerCount:self.completionHandlers.count];
+        return;
+    }
+
     if (!locations || !locations.count) {
         return;
     }

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)shouldHandleRegionWithIdentifier:(NSString *)identifier action:(NSString *)action;
 
++ (void)didUpdateLocations:(nullable NSArray<CLLocation *> *)updates completionHandlerCount:(NSUInteger)completionHandlerCount;
+
 + (void)didUpdateHeading:(CLHeading *)newHeading;
 + (void)didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
 + (void)didFailWithError:(NSError *)error;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -35,6 +35,7 @@
 - (RadarUser * _Nullable)radarUser;
 - (void)didReceiveEvents:(NSArray<RadarEvent *> * _Nonnull)events user:(RadarUser * _Nonnull)user;
 - (void)didUpdateClientLocation:(CLLocation * _Nonnull)location stopped:(BOOL)stopped source:(RadarLocationSource)source;
+- (void)handleLocation:(CLLocation * _Nonnull)location source:(RadarLocationSource)source;
 - (void)didFailWithStatus:(RadarStatus)status;
 - (RadarBeacon * _Nonnull)createBeaconWithUuid:(NSString * _Nonnull)uuid major:(NSString * _Nonnull)major minor:(NSString * _Nonnull)minor rssi:(NSInteger)rssi;
 - (RadarBeacon * _Nonnull)createBeaconFromRegion:(CLBeaconRegion * _Nonnull)region;

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -16,6 +16,7 @@
 #import "RadarUtils.h"
 #import "RadarDelegateHolder.h"
 #import "RadarAPIClient.h"
+#import "RadarLocationManager.h"
 
 @implementation RadarSwiftBridge
 
@@ -80,6 +81,10 @@
 
 - (void)didUpdateClientLocation:(CLLocation *)location stopped:(BOOL)stopped source:(RadarLocationSource)source {
     [[RadarDelegateHolder sharedInstance] didUpdateClientLocation:location stopped:stopped source:source];
+}
+
+- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
+    [[RadarLocationManager sharedInstance] handleLocation:location source:source];
 }
 
 - (RadarUser * _Nullable)radarUser {

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -28,6 +28,7 @@ protocol RadarSwiftBridgeProtocol {
     func isForeground() -> Bool
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser)
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource)
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource)
     func radarUser() -> RadarUser?
     func didFail(status: RadarStatus)
     func createBeacon(uuid: String, major: String, minor: String, rssi: Int) -> RadarBeacon

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -36,7 +36,8 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     func createEvent(dict: [String: Any]) -> RadarEvent? { nil }
     func createUser(dict: [String: Any]) -> RadarUser? { nil }
     func createGeofence(dict: [String: Any]) -> RadarGeofence? { nil }
-    func isForeground() -> Bool { false }
+    var mockIsForeground = false
+    func isForeground() -> Bool { mockIsForeground }
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser) {}
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource) {}
     private(set) var lastHandledLocation: CLLocation?

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -39,6 +39,12 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     func isForeground() -> Bool { false }
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser) {}
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource) {}
+    private(set) var lastHandledLocation: CLLocation?
+    private(set) var lastHandledSource: RadarLocationSource?
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
+        lastHandledLocation = location
+        lastHandledSource = source
+    }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?
     func didFail(status: RadarStatus) { lastFailStatus = status }

--- a/RadarSDKTests/RadarLocationManagerSwiftLocationTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLocationTests.swift
@@ -15,6 +15,91 @@ extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftLocationTests {
 
+        // MARK: - didUpdateLocations(_:completionHandlerCount:)
+
+        @Test("location updates with no locations are ignored")
+        func locationUpdatesIgnoreEmptyUpdates() {
+            let mock = MockRadarSwiftBridge()
+            let original = RadarSwift.bridge
+            RadarSwift.bridge = mock
+            defer { RadarSwift.bridge = original }
+
+            RadarLocationManagerSwift.didUpdateLocations([], completionHandlerCount: 1)
+
+            #expect(mock.lastHandledLocation == nil)
+        }
+
+        @Test("location updates requested by a completion handler use the foreground source when the foreground check is skipped")
+        func locationUpdatesUseForegroundSourceWhenForegroundCheckIsSkipped() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let mock = MockRadarSwiftBridge()
+            let original = RadarSwift.bridge
+            RadarSwift.bridge = mock
+            defer {
+                RadarSwift.bridge = original
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["skipForegroundCheck": true])
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+
+            RadarLocationManagerSwift.didUpdateLocations([location], completionHandlerCount: 1)
+
+            #expect(mock.lastHandledLocation === location)
+            #expect(mock.lastHandledSource == .foregroundLocation)
+        }
+
+        @Test("location updates requested in the foreground use the foreground source")
+        func locationUpdatesUseForegroundSourceWhenAppIsForeground() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let mock = MockRadarSwiftBridge()
+            mock.mockIsForeground = true
+            let original = RadarSwift.bridge
+            RadarSwift.bridge = mock
+            defer {
+                RadarSwift.bridge = original
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["skipForegroundCheck": false])
+
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+            RadarLocationManagerSwift.didUpdateLocations([location], completionHandlerCount: 1)
+
+            #expect(mock.lastHandledLocation === location)
+            #expect(mock.lastHandledSource == .foregroundLocation)
+        }
+
+        @Test("tracked location updates use the background source")
+        func trackedLocationUpdatesUseBackgroundSource() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = true
+            let mock = MockRadarSwiftBridge()
+            let original = RadarSwift.bridge
+            RadarSwift.bridge = mock
+            defer { RadarSwift.bridge = original }
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+
+            RadarLocationManagerSwift.didUpdateLocations([location], completionHandlerCount: 0)
+
+            #expect(mock.lastHandledLocation === location)
+            #expect(mock.lastHandledSource == .backgroundLocation)
+        }
+
+        @Test("untracked background location updates are ignored")
+        func untrackedBackgroundLocationUpdatesAreIgnored() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            defer { RadarLocationManagerSwiftTestHelpers.clearState() }
+            RadarSettings.tracking = false
+            let mock = MockRadarSwiftBridge()
+            let original = RadarSwift.bridge
+            RadarSwift.bridge = mock
+            defer { RadarSwift.bridge = original }
+
+            RadarLocationManagerSwift.didUpdateLocations([CLLocation(latitude: 40.7, longitude: -74.0)], completionHandlerCount: 0)
+
+            #expect(mock.lastHandledLocation == nil)
+        }
+
         // MARK: - effectiveLocation(for:)
 
         @Test("effectiveLocation prefers the manager's current valid location")


### PR DESCRIPTION
## Summary

Fully ports `RadarLocationManager`'s `didUpdateLocation`s delegate callback to Swift.

- Swift handles empty updates, foreground/background source selection, and ignored untracked updates.
- The ObjC delegate method is now only the `useSwiftLocationManager` dispatcher.
- `RadarSwiftBridge` forwards the final `handleLocation` call to the singleton manager, keeping the Swift static helper independent of the private ObjC class interface.
- End-to-end Swift tests assert the bridge receives the latest location and the correct source.

## Manual test

With `useSwiftLocationManager` and debug logging enabled, tap `trackOnce` in Example and simulate a location; expect `FOREGROUND_LOCATION`. Start responsive tracking, background the app; expect `BACKGROUND_LOCATION`.