### PR TITLE
FENCE-2982: Fix merge queue CI trigger

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,8 @@ name: Xcode - Build, Analyze, & Test
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 # Cancel superseded runs when a PR branch is re-pushed
 concurrency:
@@ -37,6 +39,7 @@ jobs:
           swiftlint lint --strict --baseline .swiftlint-baseline.json
 
       - name: Format Swift
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           SWIFT_FORMAT_VERSION: "603.0.0"


### PR DESCRIPTION
## Summary

- run the build-and-test workflow for merge queue `merge_group` events
- skip the PR-diff-dependent Swift formatting step for merge-group runs

Follows the guidance that I missed in https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

## Root cause

The workflow only subscribed to `pull_request`, so GitHub could not create the required CI check for merge queue merge groups. The formatting step also depends on a pull-request event payload, which merge groups do not provide.