### PR TITLE
FENCE-2938: Update nightly migration PR guidance

### DIFF
--- a/.github/workflows/objc-to-swift-nightly.yml
+++ b/.github/workflows/objc-to-swift-nightly.yml
@@ -3,8 +3,8 @@ name: Nightly ObjC to Swift migration
 # Converts ONE safe Objective-C file to Swift per run and opens a PR for human
 # review. Approval happens at PR review (see AGENTS.md "Language Policy") — the
 # agent only picks conservative leaf files, and skips the run entirely while a
-# previous migration PR is still open. The PR's own CI (build-and-test.yml on
-# macOS) is the build/test verifier; this job runs on Linux and does not build.
+# previous migration PR is still open. This job runs the same macOS validation
+# as PR CI before publication; PR CI remains the independent verifier.
 
 on:
   schedule:
@@ -119,26 +119,6 @@ jobs:
             /objc-to-swift batch
 
             This is the unattended nightly migration run. Follow the skill's
-            "Batch mode (unattended CI runs)" section exactly:
-            - The finder ranks most-trivial-first. Convert the single top
-              flag-free candidate (smallest, least-coupled; Strategy D or A
-              only), skipping Route*/Trip* clusters. If none is eligible, print
-              why and exit WITHOUT editing anything or opening a PR.
-            - You are on macOS with Xcode 26.3, swift-format, swiftlint, and
-              plutil installed. Before pushing, you MUST verify the migration:
-              1. Create a local commit on claude/migrate-<FileName> (do not
-                 push yet), so make lint-swift can diff the committed changes
-                 against origin/master.
-              2. Run make lint-swift, make format-check, and
-                 plutil -lint RadarSDK.xcodeproj/project.pbxproj.
-              3. Run `make build DESTINATION="$MIGRATION_DESTINATION"` and
-                 `make test DESTINATION="$MIGRATION_DESTINATION"`.
-              4. If any command fails, diagnose and fix the migration, amend
-                 the local commit, then rerun every failed check. Do not push
-                 or open a PR unless all four checks pass. If validation is
-                 unavailable, exit without pushing or opening a PR.
-            - Only after successful validation, push and open a PR labeled
-              swift-migration using gh (GH_TOKEN is set), filling
-              .github/PULL_REQUEST_TEMPLATE.md. In the PR description, report
-              the commands that passed; do not claim validation was skipped.
+            "Batch mode (unattended CI runs)" section exactly. The workflow
+            provides GH_TOKEN and MIGRATION_DESTINATION for that procedure.
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep" --max-turns 80'

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 17,OS=26.4.1"
+DESTINATION ?= platform=iOS Simulator,name=iPhone 17,OS=26.4.1
 PROJECT := RadarSDK
 PROJECT_EXAMPLE := Example/Example
 SCHEME := XCFramework
 SCHEME_EXAMPLE := Example
 SWIFTLINT := $(firstword $(wildcard .tools/swiftlint) swiftlint)
-XC_ARGS := -sdk $(SDK) -project $(PROJECT).xcodeproj -scheme $(SCHEME) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO OTHER_CFLAGS="-fembed-bitcode"
+XC_ARGS := -sdk $(SDK) -project $(PROJECT).xcodeproj -scheme $(SCHEME) -destination "$(DESTINATION)" ONLY_ACTIVE_ARCH=NO OTHER_CFLAGS="-fembed-bitcode"
 XC_TEST_ARGS := $(XC_ARGS) GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
 # The example app links MapLibre (swiftui-dsl), which needs two accommodations in a
 # non-interactive build:
 #   -skipMacroValidation      skips the one-time MapLibreSwiftMacros trust prompt.
-XC_EXAMPLE_ARGS := -project $(PROJECT_EXAMPLE).xcodeproj -scheme $(SCHEME_EXAMPLE) -destination $(DESTINATION) -skipMacroValidation ONLY_ACTIVE_ARCH=NO OTHER_CFLAGS="-fembed-bitcode"
+XC_EXAMPLE_ARGS := -project $(PROJECT_EXAMPLE).xcodeproj -scheme $(SCHEME_EXAMPLE) -destination "$(DESTINATION)" -skipMacroValidation ONLY_ACTIVE_ARCH=NO OTHER_CFLAGS="-fembed-bitcode"
 CI_SCHEME ?= RadarSDK
 CI_WORKSPACE ?= Example/Example.xcodeproj/project.xcworkspace
 CI_DESTINATION ?= platform=iOS Simulator,name=iPhone 17,OS=26.4.1


### PR DESCRIPTION
## Summary

- Make the Makefile quote simulator destinations so callers pass a plain value.
- Centralize nightly migration validation and PR-body guidance in the installed migration skill.
- Reduce the nightly workflow to credentials and simulator handoff.

## Motivation

The workflow had become a second, diverging copy of the migration procedure and required callers to inject destination quotes manually. This keeps build mechanics in the Makefile and migration policy in the skill.

## Related

- Companion skill update: [radarlabs/clankers#18](https://github.com/radarlabs/clankers/pull/18)