### PR TITLE
added jwe encryption for fraud responses

### DIFF
--- a/Example/Example/Panels/VerifiedPanel.swift
+++ b/Example/Example/Panels/VerifiedPanel.swift
@@ -42,7 +42,7 @@ struct VerifiedPanel: View {
             }
             ActionButton("revealRisk") {
                 Radar.revealRisk { (status, token) in
-                    let tokenDesc = token?.dictionaryValue().description ?? "no token"
+                    let tokenDesc = token?.dictionaryValue()?.description ?? "no token"
                     logStream.write(
                         status,
                         summary: "revealRisk: \(Radar.stringForStatus(status))",

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		F6843C503005A79E00213092 /* RadarSDKFraud.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C4F3005A79E00213092 /* RadarSDKFraud.swift */; };
 		F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C86300696A200213092 /* RadarRevealRiskTests.swift */; };
 		F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */; };
+		F6843C8B300696A200213094 /* RadarTokenPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */; };
 		F686B72D2E4D27EB00D3D614 /* RadarInAppMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */; };
 		F686B7312E4D29C400D3D614 /* RadarInAppMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
@@ -517,6 +518,7 @@
 		F6843C51300602BE00213092 /* RadarSDKFraud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RadarSDKFraud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6843C86300696A200213092 /* RadarRevealRiskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarRevealRiskTests.swift; sourceTree = "<group>"; };
 		F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarVerifiedLocationTokenTests.swift; sourceTree = "<group>"; };
+		F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarTokenPublicAPITests.swift; sourceTree = "<group>"; };
 		F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessage.swift; sourceTree = "<group>"; };
 		F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarInAppMessageDelegate.h; sourceTree = "<group>"; };
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
@@ -806,6 +808,7 @@
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
 				F6843C86300696A200213092 /* RadarRevealRiskTests.swift */,
 				F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */,
+				F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */,
 				F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */,
 				F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */,
 				F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */,
@@ -1250,6 +1253,7 @@
 				BA8D153D300EA41900022EB3 /* RadarEventNotificationsTestHelpers.swift in Sources */,
 				F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */,
 				F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */,
+				F6843C8B300696A200213094 /* RadarTokenPublicAPITests.swift in Sources */,
 				F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */,
 				F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */,
 				F6FA1104000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift in Sources */,

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		F6843C3A3005539300213092 /* RadarRevealRiskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F6843C393005538D00213092 /* RadarRevealRiskManager.h */; };
 		F6843C503005A79E00213092 /* RadarSDKFraud.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C4F3005A79E00213092 /* RadarSDKFraud.swift */; };
 		F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C86300696A200213092 /* RadarRevealRiskTests.swift */; };
+		F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */; };
 		F686B72D2E4D27EB00D3D614 /* RadarInAppMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */; };
 		F686B7312E4D29C400D3D614 /* RadarInAppMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
@@ -515,6 +516,7 @@
 		F6843C4F3005A79E00213092 /* RadarSDKFraud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSDKFraud.swift; sourceTree = "<group>"; };
 		F6843C51300602BE00213092 /* RadarSDKFraud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RadarSDKFraud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6843C86300696A200213092 /* RadarRevealRiskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarRevealRiskTests.swift; sourceTree = "<group>"; };
+		F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarVerifiedLocationTokenTests.swift; sourceTree = "<group>"; };
 		F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessage.swift; sourceTree = "<group>"; };
 		F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarInAppMessageDelegate.h; sourceTree = "<group>"; };
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 				61FFFC29F8BCE53F30E3180F /* RadarIndoorsUpdateTrackingTests.swift */,
 				F6B7E3BC2F758A0D006A5A24 /* MockRadarState.swift */,
 				F6843C86300696A200213092 /* RadarRevealRiskTests.swift */,
+				F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */,
 				F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */,
 				F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */,
 				F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */,
@@ -1246,6 +1249,7 @@
 				F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */,
 				BA8D153D300EA41900022EB3 /* RadarEventNotificationsTestHelpers.swift in Sources */,
 				F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */,
+				F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */,
 				F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */,
 				F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */,
 				F6FA1104000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift in Sources */,

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C86300696A200213092 /* RadarRevealRiskTests.swift */; };
 		F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */; };
 		F6843C8B300696A200213094 /* RadarTokenPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */; };
+		F6843C8D300696A200213095 /* RadarTrackBeaconRegionRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6843C8C300696A200213095 /* RadarTrackBeaconRegionRegistrationTests.swift */; };
 		F686B72D2E4D27EB00D3D614 /* RadarInAppMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */; };
 		F686B7312E4D29C400D3D614 /* RadarInAppMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
@@ -519,6 +520,7 @@
 		F6843C86300696A200213092 /* RadarRevealRiskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarRevealRiskTests.swift; sourceTree = "<group>"; };
 		F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarVerifiedLocationTokenTests.swift; sourceTree = "<group>"; };
 		F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarTokenPublicAPITests.swift; sourceTree = "<group>"; };
+		F6843C8C300696A200213095 /* RadarTrackBeaconRegionRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarTrackBeaconRegionRegistrationTests.swift; sourceTree = "<group>"; };
 		F686B72C2E4D27EB00D3D614 /* RadarInAppMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessage.swift; sourceTree = "<group>"; };
 		F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarInAppMessageDelegate.h; sourceTree = "<group>"; };
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
@@ -809,6 +811,7 @@
 				F6843C86300696A200213092 /* RadarRevealRiskTests.swift */,
 				F6843C88300696A200213093 /* RadarVerifiedLocationTokenTests.swift */,
 				F6843C8A300696A200213094 /* RadarTokenPublicAPITests.swift */,
+				F6843C8C300696A200213095 /* RadarTrackBeaconRegionRegistrationTests.swift */,
 				F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */,
 				F6B7E3C12F7600CC006A5A24 /* RadarNotificationHelperRefreshTest.swift */,
 				F6B7E3BE2F760001006A5A24 /* RadarNotificationTest.swift */,
@@ -1254,6 +1257,7 @@
 				F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */,
 				F6843C89300696A200213093 /* RadarVerifiedLocationTokenTests.swift in Sources */,
 				F6843C8B300696A200213094 /* RadarTokenPublicAPITests.swift in Sources */,
+				F6843C8D300696A200213095 /* RadarTrackBeaconRegionRegistrationTests.swift in Sources */,
 				F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */,
 				F6FA1102000000000000A001 /* RadarVerifiedHostOverrideTests.swift in Sources */,
 				F6FA1104000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift in Sources */,

--- a/RadarSDK/Include/RadarRevealRiskToken.h
+++ b/RadarSDK/Include/RadarRevealRiskToken.h
@@ -6,6 +6,10 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
+#import "RadarVerifiedLocationToken.h"
+
 typedef NS_ENUM(NSInteger, RadarRevealRiskLevel) {
     RadarRevealRiskLevelNone = 0,
     RadarRevealRiskLevelLow,
@@ -15,7 +19,10 @@ typedef NS_ENUM(NSInteger, RadarRevealRiskLevel) {
 
 @interface RadarRevealRiskTokenRisk : NSObject
 @property (nonatomic, readonly) RadarRevealRiskLevel level;
-@property (nonatomic, readonly, copy) NSArray<NSString *> * _Nonnull reasons;
+/**
+ The risk reasons. `nil` when `format` is `RadarTokenFormatJWE`, since reasons only exist inside the encrypted token.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSString *> * _Nullable reasons;
 @end
 
 @interface RadarRevealRiskTokenNetworkAsn : NSObject
@@ -33,6 +40,7 @@ typedef NS_ENUM(NSInteger, RadarRevealRiskLevel) {
 @end
 
 @interface RadarRevealRiskTokenNetworkIpAddress : NSObject
+@property (nonatomic, readonly, copy) NSString * _Nullable ip;
 @property (nonatomic, readonly, copy) NSString * _Nullable countryCode;
 @property (nonatomic, readonly, copy) NSString * _Nullable country;
 @property (nonatomic, readonly, copy) NSString * _Nullable countryFlag;
@@ -92,12 +100,27 @@ typedef NS_ENUM(NSInteger, RadarRevealRiskLevel) {
  */
 @interface RadarRevealRiskToken : NSObject
 @property (nonatomic, readonly, copy) NSString * _Nonnull _id;
+/**
+ A signed JSON Web Token (JWT). When `format` is `RadarTokenFormatJWE`, an encrypted (JWE) token that must be
+ decrypted with your private key and verified against Radar's JWKS server-side.
+ */
 @property (nonatomic, readonly, copy) NSString * _Nullable token;
 @property (nonatomic, readonly, copy) NSDate * _Nullable expiresAt;
 @property (nonatomic, readonly, strong) NSNumber * _Nullable expiresIn;
 @property (nonatomic, readonly, strong) RadarRevealRiskTokenRisk * _Nonnull risk;
-@property (nonatomic, readonly, strong) RadarRevealRiskTokenNetwork * _Nonnull network;
-@property (nonatomic, readonly, strong) RadarRevealRiskTokenDevice * _Nonnull device;
+/**
+ The network signals. `nil` when `format` is `RadarTokenFormatJWE`, since the payload only exists inside the encrypted token.
+ */
+@property (nonatomic, readonly, strong) RadarRevealRiskTokenNetwork * _Nullable network;
+/**
+ The device signals. `nil` when `format` is `RadarTokenFormatJWE`, since the payload only exists inside the encrypted token.
+ */
+@property (nonatomic, readonly, strong) RadarRevealRiskTokenDevice * _Nullable device;
+/**
+ The wire format of the token, controlled by a server-side project setting. `RadarTokenFormatJWS` unless the server
+ indicates otherwise.
+ */
+@property (nonatomic, readonly) RadarTokenFormat format;
 
--(NSDictionary*_Nonnull) dictionaryValue;
+- (NSDictionary * _Nullable)dictionaryValue;
 @end

--- a/RadarSDK/Include/RadarVerifiedLocationToken.h
+++ b/RadarSDK/Include/RadarVerifiedLocationToken.h
@@ -10,6 +10,19 @@
 #import <Foundation/Foundation.h>
 
 /**
+ The wire format of a verified response token, controlled by a server-side project setting.
+
+ @see https://radar.com/documentation/fraud
+ */
+typedef NS_ENUM(NSInteger, RadarTokenFormat) {
+    /// A signed JSON Web Token (JWT). Verify the token server-side using your secret key.
+    RadarTokenFormatJWS NS_SWIFT_NAME(jws) = 0,
+    /// A signed JWT nested in an encrypted JWE. Opaque to the SDK; decrypt with your private key
+    /// and verify against Radar's JWKS server-side.
+    RadarTokenFormatJWE NS_SWIFT_NAME(jwe) = 1,
+};
+
+/**
  Represents a user's verified location.
 
  @see https://radar.com/documentation/fraud
@@ -17,17 +30,18 @@
 @interface RadarVerifiedLocationToken : NSObject
 
 /**
- The user.
+ The user. `nil` when `format` is `RadarTokenFormatJWE`, since the payload only exists inside the encrypted token.
  */
 @property (nullable, strong, nonatomic, readonly) RadarUser *user;
 
 /**
- An array of events.
+ An array of events. `nil` when `format` is `RadarTokenFormatJWE`, since the payload only exists inside the encrypted token.
  */
 @property (nullable, strong, nonatomic, readonly) NSArray<RadarEvent *> *events;
 
 /**
- A signed JSON Web Token (JWT) containing the user and array of events. Verify the token server-side using your secret key.
+ A signed JSON Web Token (JWT) containing the user and array of events. When `format` is `RadarTokenFormatJWE`, an encrypted
+ JWE instead. Verify (and, for JWE, decrypt) the token server-side.
  */
 @property (nullable, copy, nonatomic, readonly) NSString *token;
 
@@ -55,6 +69,11 @@
  The Radar ID of the location check.
  */
 @property (nullable, copy, nonatomic, readonly) NSString *_id;
+
+/**
+ The wire format of the token. `RadarTokenFormatJWS` unless the server indicates otherwise.
+ */
+@property (assign, nonatomic, readonly) RadarTokenFormat format;
 
 /**
  The full dictionary value of the token.

--- a/RadarSDK/Include/RadarVerifiedLocationToken.h
+++ b/RadarSDK/Include/RadarVerifiedLocationToken.h
@@ -61,7 +61,8 @@ typedef NS_ENUM(NSInteger, RadarTokenFormat) {
 @property (assign, nonatomic, readonly) bool passed;
 
 /**
- An array of failure reasons for jurisdiction and fraud detection checks.
+ An array of failure reasons for jurisdiction and fraud detection checks. `nil` when `format` is
+ `RadarTokenFormatJWE`, since the reasons only exist inside the encrypted token.
  */
 @property (nullable, copy, nonatomic, readonly) NSArray<NSString *> *failureReasons;
 

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -701,6 +701,14 @@
             
                             [RadarOfflineEventManager reset];
 
+                            // nearbyBeaconRegions is not verdict-bearing, so protected (JWE) responses still
+                            // include it in plaintext — register before branching on the response format
+                            id nearbyBeaconRegionsObj = res[@"nearbyBeaconRegions"];
+                            if (nearbyBeaconRegionsObj && [nearbyBeaconRegionsObj isKindOfClass:[NSArray class]]) {
+                                NSArray<NSDictionary<NSString *, NSString *> *> *beaconRegions = (NSArray<NSDictionary<NSString *, NSString *> *> *)nearbyBeaconRegionsObj;
+                                [[RadarBeaconManagerSwift shared] registerBeaconRegionNotificationsFromArray:beaconRegions];
+                            }
+
                             if (events && user) {
                                 [RadarSettings setId:user._id];
                                 [RadarState setRadarUser:user];
@@ -730,12 +738,6 @@
                                     [[RadarDelegateHolder sharedInstance] didUpdateToken:token];
                                 }
 
-                                id nearbyBeaconRegionsObj = res[@"nearbyBeaconRegions"];
-                                if (nearbyBeaconRegionsObj && [nearbyBeaconRegionsObj isKindOfClass:[NSArray class]]) {
-                                    NSArray<NSDictionary<NSString *, NSString *> *> *beaconRegions = (NSArray<NSDictionary<NSString *, NSString *> *> *)nearbyBeaconRegionsObj;
-                                    [[RadarBeaconManagerSwift shared] registerBeaconRegionNotificationsFromArray:beaconRegions];
-                                }
-                                
                                 return completionHandler(RadarStatusSuccess, res, events, user, nearbyGeofences, config, token);
                             } else if (token && token.format == RadarTokenFormatJWE) {
                                 // protected mode: user and events are omitted from the plaintext response

--- a/RadarSDK/RadarAPIClient.m
+++ b/RadarSDK/RadarAPIClient.m
@@ -737,6 +737,12 @@
                                 }
                                 
                                 return completionHandler(RadarStatusSuccess, res, events, user, nearbyGeofences, config, token);
+                            } else if (token && token.format == RadarTokenFormatJWE) {
+                                // protected mode: user and events are omitted from the plaintext response
+                                // and only exist inside the encrypted token
+                                [[RadarDelegateHolder sharedInstance] didUpdateToken:token];
+
+                                return completionHandler(RadarStatusSuccess, res, nil, nil, nearbyGeofences, config, token);
                             } else {
                                 [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo message:[NSString stringWithFormat:@"Setting %lu notifications remaining", (unsigned long)notificationsRemaining.count]];
                                 [RadarState setRegisteredNotifications:notificationsRemaining];

--- a/RadarSDK/RadarRevealRiskToken.swift
+++ b/RadarSDK/RadarRevealRiskToken.swift
@@ -22,8 +22,16 @@ final class RadarRevealRiskToken: NSObject, Decodable, @unchecked Sendable {
     let expiresIn: Double?
     @objc(expiresIn) var _expiresIn: NSNumber? { expiresIn.map { NSNumber(value: $0) } }
     let risk: RadarRevealRiskTokenRisk
-    let network: RadarRevealRiskTokenNetwork
-    let device: RadarRevealRiskTokenDevice
+    /// `nil` when `format` is JWE, since the payload only exists inside the encrypted token.
+    let network: RadarRevealRiskTokenNetwork?
+    /// `nil` when `format` is JWE, since the payload only exists inside the encrypted token.
+    let device: RadarRevealRiskTokenDevice?
+
+    private let rawFormat: String?
+    /// The wire format of the token, controlled by a server-side project setting. When JWE, the
+    /// token is opaque to the SDK: decrypt with your private key and verify against Radar's JWKS
+    /// server-side.
+    @objc(format) var format: RadarTokenFormat { rawFormat?.uppercased() == "JWE" ? .jwe : .jws }
 
     // unchecked sendable, set on init, should not be modified afterwards
     var dictionaryValue: [String: Sendable]?
@@ -36,6 +44,7 @@ final class RadarRevealRiskToken: NSObject, Decodable, @unchecked Sendable {
         case risk
         case network
         case device
+        case rawFormat = "format"
     }
 
     nonisolated(unsafe) private static let isoFormatter: ISO8601DateFormatter = {
@@ -111,7 +120,8 @@ enum RadarRevealRiskLevel: Int, Sendable, Decodable {
 @objc(RadarRevealRiskTokenRisk) @objcMembers
 final class RadarRevealRiskTokenRisk: NSObject, Decodable, Sendable {
     let level: RadarRevealRiskLevel
-    let reasons: [String]
+    /// `nil` when the token format is JWE, since reasons only exist inside the encrypted token.
+    let reasons: [String]?
 }
 
 @objc(RadarRevealRiskTokenNetwork) @objcMembers

--- a/RadarSDK/RadarRevealRiskToken.swift
+++ b/RadarSDK/RadarRevealRiskToken.swift
@@ -85,6 +85,14 @@ final class RadarRevealRiskToken: NSObject, Decodable, @unchecked Sendable {
         guard let decoded = try? decoder.decode(RadarRevealRiskToken.self, from: data) else {
             return nil
         }
+        // The verdict-bearing fields are only allowed to be absent in protected (JWE) mode,
+        // where they exist inside the encrypted token. A JWS response missing them is malformed,
+        // so fail parsing rather than returning partial data (mirrors RadarVerifiedLocationToken,
+        // which requires user and events unless the format is JWE).
+        if decoded.format == .jws
+            && (decoded.risk.reasons == nil || decoded.network == nil || decoded.device == nil) {
+            return nil
+        }
         var dict: [String: Sendable]? = (try? JSONSerialization.jsonObject(with: data)) as? [String: Sendable]
         // raw data from response returns with a meta field for the http status, ignore this for reveal risk response dict
         dict?["meta"] = nil

--- a/RadarSDK/RadarVerificationManager.m
+++ b/RadarSDK/RadarVerificationManager.m
@@ -382,6 +382,13 @@
         return NO;
     }
 
+    if (self.lastToken.format == RadarTokenFormatJWE) {
+        // JWE (protected) tokens are opaque to the SDK: without user.state.distanceToBorder the
+        // border check below is impossible, so they are never reused and every retrieval re-tracks
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Last token invalid | JWE tokens are never reused"];
+        return NO;
+    }
+
     NSTimeInterval lastTokenElapsed = [NSProcessInfo processInfo].systemUptime - self.lastTokenSystemUptime;
     double lastDistanceToStateBorder = -1;
     if (self.lastToken.user && self.lastToken.user.state) {

--- a/RadarSDK/RadarVerifiedLocationToken+Internal.h
+++ b/RadarSDK/RadarVerifiedLocationToken+Internal.h
@@ -16,7 +16,7 @@
                              expiresAt:(NSDate *_Nonnull)expiresAt
                              expiresIn:(NSTimeInterval)expiresIn
                                 passed:(BOOL)passed
-                        failureReasons:(NSArray<NSString *> *_Nonnull)failureReasons
+                        failureReasons:(NSArray<NSString *> *_Nullable)failureReasons
                                    _id:(NSString *_Nonnull)_id
                                 format:(RadarTokenFormat)format
                               fullDict:(NSDictionary *_Nonnull)fullDict;

--- a/RadarSDK/RadarVerifiedLocationToken+Internal.h
+++ b/RadarSDK/RadarVerifiedLocationToken+Internal.h
@@ -10,14 +10,15 @@
 
 @interface RadarVerifiedLocationToken ()
 
-- (instancetype _Nullable)initWithUser:(RadarUser *_Nonnull)user
-                                events:(NSArray<RadarEvent *> *_Nonnull)events
+- (instancetype _Nullable)initWithUser:(RadarUser *_Nullable)user
+                                events:(NSArray<RadarEvent *> *_Nullable)events
                                  token:(NSString *_Nonnull)token
                              expiresAt:(NSDate *_Nonnull)expiresAt
                              expiresIn:(NSTimeInterval)expiresIn
                                 passed:(BOOL)passed
                         failureReasons:(NSArray<NSString *> *_Nonnull)failureReasons
                                    _id:(NSString *_Nonnull)_id
+                                format:(RadarTokenFormat)format
                               fullDict:(NSDictionary *_Nonnull)fullDict;
 - (instancetype _Nullable)initWithObject:(id _Nonnull)object;
 

--- a/RadarSDK/RadarVerifiedLocationToken.m
+++ b/RadarSDK/RadarVerifiedLocationToken.m
@@ -13,14 +13,15 @@
 
 @implementation RadarVerifiedLocationToken
 
-- (instancetype _Nullable)initWithUser:(RadarUser *_Nonnull)user
-                                events:(NSArray<RadarEvent *> *_Nonnull)events
+- (instancetype _Nullable)initWithUser:(RadarUser *_Nullable)user
+                                events:(NSArray<RadarEvent *> *_Nullable)events
                                  token:(NSString *_Nonnull)token
                              expiresAt:(NSDate *_Nonnull)expiresAt
                              expiresIn:(NSTimeInterval)expiresIn
                                 passed:(BOOL)passed
                         failureReasons:(NSArray<NSString *> * _Nonnull)failureReasons
                                    _id:(NSString * _Nonnull)_id
+                                format:(RadarTokenFormat)format
                                fullDict:(NSDictionary *_Nonnull)fullDict {
     self = [super init];
     if (self) {
@@ -32,6 +33,7 @@
         _passed = passed;
         _failureReasons = failureReasons;
         __id = _id;
+        _format = format;
         _fullDict = fullDict;
     }
     return self;
@@ -96,8 +98,16 @@
         _id = (NSString *)idObj;
     }
     
-    if (user && events && token && expiresAt) {
-        return [[RadarVerifiedLocationToken alloc] initWithUser:user events:events token:token expiresAt:expiresAt expiresIn:expiresIn passed:passed failureReasons:failureReasons _id:_id fullDict:dict];
+    RadarTokenFormat format = RadarTokenFormatJWS;
+    id formatObj = dict[@"format"];
+    if (formatObj && [formatObj isKindOfClass:[NSString class]] && [[(NSString *)formatObj uppercaseString] isEqualToString:@"JWE"]) {
+        format = RadarTokenFormatJWE;
+    }
+    
+    // in JWE (protected) mode the user and events only exist inside the encrypted token
+    BOOL hasRequiredFields = token && expiresAt && (format == RadarTokenFormatJWE || (user && events));
+    if (hasRequiredFields) {
+        return [[RadarVerifiedLocationToken alloc] initWithUser:user events:events token:token expiresAt:expiresAt expiresIn:expiresIn passed:passed failureReasons:failureReasons _id:_id format:format fullDict:dict];
     }
     
     return nil;

--- a/RadarSDK/RadarVerifiedLocationToken.m
+++ b/RadarSDK/RadarVerifiedLocationToken.m
@@ -19,7 +19,7 @@
                              expiresAt:(NSDate *_Nonnull)expiresAt
                              expiresIn:(NSTimeInterval)expiresIn
                                 passed:(BOOL)passed
-                        failureReasons:(NSArray<NSString *> * _Nonnull)failureReasons
+                        failureReasons:(NSArray<NSString *> * _Nullable)failureReasons
                                    _id:(NSString * _Nonnull)_id
                                 format:(RadarTokenFormat)format
                                fullDict:(NSDictionary *_Nonnull)fullDict {
@@ -52,7 +52,7 @@
     NSDate *expiresAt;
     NSTimeInterval expiresIn = 0;
     BOOL passed = NO;
-    NSArray<NSString *> *failureReasons = @[];
+    NSArray<NSString *> *failureReasons;
     NSString *_id;
     
     id tokenObj = dict[@"token"];
@@ -102,6 +102,13 @@
     id formatObj = dict[@"format"];
     if (formatObj && [formatObj isKindOfClass:[NSString class]] && [[(NSString *)formatObj uppercaseString] isEqualToString:@"JWE"]) {
         format = RadarTokenFormatJWE;
+    }
+
+    // legacy JWS behavior: default absent failureReasons to an empty array. In JWE (protected)
+    // mode the reasons only exist inside the encrypted token, so keep nil rather than reporting
+    // "no failures" — the token can have passed == NO with reasons that are simply unavailable.
+    if (format == RadarTokenFormatJWS && !failureReasons) {
+        failureReasons = @[];
     }
     
     // in JWE (protected) mode the user and events only exist inside the encrypted token

--- a/RadarSDKTests/RadarRevealRiskTests.swift
+++ b/RadarSDKTests/RadarRevealRiskTests.swift
@@ -133,13 +133,40 @@ extension RadarSerializedTests {
             #expect(token.expiresIn == 3600)
             #expect(token.risk.level == .medium)
             #expect(token.risk.reasons == ["proxy_detected", "vpn_detected"])
-            #expect(token.network.ipAddress?.countryCode == "US")
-            #expect(token.network.ipAddress?.city == "New York")
-            #expect(token.network.privacy?.proxy == true)
-            #expect(token.network.privacy?.vpn == true)
-            #expect(token.network.asn?.name == "CLOUDFLARENET")
-            #expect(token.device.deviceType == "iOS")
-            #expect(token.device.installId == "install-xyz")
+            #expect(token.format == .jws)
+            #expect(token.network?.ipAddress?.countryCode == "US")
+            #expect(token.network?.ipAddress?.city == "New York")
+            #expect(token.network?.privacy?.proxy == true)
+            #expect(token.network?.privacy?.vpn == true)
+            #expect(token.network?.asn?.name == "CLOUDFLARENET")
+            #expect(token.device?.deviceType == "iOS")
+            #expect(token.device?.installId == "install-xyz")
+        }
+
+        @Test("revealRisk parses a protected (JWE) response that omits reasons, network, and device")
+        func revealRiskParsesProtectedResponse() async throws {
+            // in protected mode the verdict-bearing fields only exist inside the encrypted token
+            let protectedResponse: [String: Any] = [
+                "_id": "risk-token-456",
+                "token": "a.b.c.d.e",
+                "expiresAt": "2026-07-14T12:00:00.000Z",
+                "expiresIn": 1200,
+                "risk": ["level": "low"],
+                "format": "JWE",
+            ]
+            let session = MockURLSession()
+            session.on(RadarRevealRiskTests.revealRiskURL, protectedResponse)
+
+            let manager = makeManager(fraudResult: ["payload": "mock-fraud-payload"], session: session)
+            let token = try await manager.revealRisk(useSecondaryVerifiedHost: false)
+
+            #expect(token.id == "risk-token-456")
+            #expect(token.token == "a.b.c.d.e")
+            #expect(token.format == .jwe)
+            #expect(token.risk.level == .low)
+            #expect(token.risk.reasons == nil)
+            #expect(token.network == nil)
+            #expect(token.device == nil)
         }
 
         @Test("revealRisk surfaces the token through the completion-handler API")
@@ -158,6 +185,7 @@ extension RadarSerializedTests {
             #expect(status == .success)
             #expect(token?.id == "risk-token-123")
             #expect(token?.risk.level == .medium)
+            #expect(token?.format == .jws)
         }
 
         @Test("revealRisk passes the product up in the X-Radar-Product header when it is set")

--- a/RadarSDKTests/RadarRevealRiskTests.swift
+++ b/RadarSDKTests/RadarRevealRiskTests.swift
@@ -169,6 +169,25 @@ extension RadarSerializedTests {
             #expect(token.device == nil)
         }
 
+        @Test("revealRisk rejects a JWS response missing verdict-bearing fields")
+        func revealRiskRejectsIncompleteJwsResponse() async throws {
+            // reasons, network, and device may only be absent in protected (JWE) mode; a JWS
+            // response without them is malformed and must fail instead of parsing partially
+            var incompleteResponse = RadarRevealRiskTests.revealRiskResponse
+            incompleteResponse["network"] = nil
+            incompleteResponse["device"] = nil
+            incompleteResponse["risk"] = ["level": "medium"]
+
+            let session = MockURLSession()
+            session.on(RadarRevealRiskTests.revealRiskURL, incompleteResponse)
+
+            let manager = makeManager(fraudResult: ["payload": "mock-fraud-payload"], session: session)
+
+            await #expect(throws: Error.self) {
+                _ = try await manager.revealRisk(useSecondaryVerifiedHost: false)
+            }
+        }
+
         @Test("revealRisk surfaces the token through the completion-handler API")
         func revealRiskCompletionHandlerSucceeds() async throws {
             let session = MockURLSession()

--- a/RadarSDKTests/RadarSDKTests-Bridging-Header.h
+++ b/RadarSDKTests/RadarSDKTests-Bridging-Header.h
@@ -14,3 +14,4 @@
 #import "../RadarSDK/RadarEvent+Internal.h"
 #import "../RadarSDK/RadarTrip+Internal.h"
 #import "../RadarSDK/RadarBeacon+Internal.h"
+#import "../RadarSDK/RadarVerifiedLocationToken+Internal.h"

--- a/RadarSDKTests/RadarTokenPublicAPITests.swift
+++ b/RadarSDKTests/RadarTokenPublicAPITests.swift
@@ -1,0 +1,75 @@
+//
+//  RadarTokenPublicAPITests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+// Deliberately NOT @testable: this file compiles against the SDK's public interface — the
+// hand-written Objective-C headers — not the internal Swift implementations. Those headers are
+// the only API customers see, and nothing else keeps them in sync with the implementation.
+// The surface checks below fail to compile if the headers drift again: optional chaining and
+// nil-coalescing are compile errors on non-optional values, so a field that is nil in JWE mode
+// but declared nonnull in the header breaks the build, as does removing `format`.
+import RadarSDK
+
+struct RadarTokenPublicAPITests {
+
+    /// Never called — compiling it is the assertion.
+    private func revealRiskTokenPublicSurface(token: RadarRevealRiskToken) {
+        // the wire format must be exposed publicly
+        let format: RadarTokenFormat = token.format
+        _ = format
+
+        // nil in JWE mode, so the public header must declare these nullable
+        _ = token.risk.reasons?.count
+        _ = token.network?.ipAddress?.ip
+        _ = token.network?.privacy?.vpn
+        _ = token.network?.asn?.name
+        _ = token.device?.deviceId
+        _ = token.dictionaryValue()?.count
+
+        // always present
+        let tokenId: String = token._id
+        _ = tokenId
+        let risk: RadarRevealRiskTokenRisk = token.risk
+        _ = risk.level == .high
+
+        // optional metadata
+        _ = token.token?.count
+        _ = token.expiresAt?.timeIntervalSince1970
+        _ = token.expiresIn?.doubleValue
+    }
+
+    /// Never called — compiling it is the assertion.
+    private func verifiedLocationTokenPublicSurface(token: RadarVerifiedLocationToken) {
+        // the wire format must be exposed publicly
+        let format: RadarTokenFormat = token.format
+        _ = format
+
+        // nil in JWE mode, so the public header must declare these nullable
+        _ = token.user?.userId
+        _ = token.events?.count
+        _ = token.failureReasons?.count
+
+        _ = token.token?.count
+        _ = token.expiresAt?.timeIntervalSince1970
+        let expiresIn: TimeInterval = token.expiresIn
+        _ = expiresIn
+        let passed: Bool = token.passed
+        _ = passed
+    }
+
+    @Test("RadarTokenFormat exposes stable JWS and JWE cases")
+    func tokenFormatEnumIsStable() {
+        #expect(RadarTokenFormat.jws.rawValue == 0)
+        #expect(RadarTokenFormat.jwe.rawValue == 1)
+
+        // reference the surface checks so they are part of the compiled, linted code paths
+        _ = revealRiskTokenPublicSurface(token:)
+        _ = verifiedLocationTokenPublicSurface(token:)
+    }
+}

--- a/RadarSDKTests/RadarTrackBeaconRegionRegistrationTests.swift
+++ b/RadarSDKTests/RadarTrackBeaconRegionRegistrationTests.swift
@@ -1,0 +1,154 @@
+//
+//  RadarTrackBeaconRegionRegistrationTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import XCTest
+
+@testable import RadarSDK
+
+/// nearbyBeaconRegions is not verdict-bearing, so it stays in the plaintext response in both
+/// formats. These tests pin that beacon-region registration happens before the JWS/JWE response
+/// branches in RadarAPIClient — a protected (JWE) response must register regions even though it
+/// returns early with nil user and events.
+final class RadarTrackBeaconRegionRegistrationTests: XCTestCase {
+
+    private static let beaconUUID = "2F234454-CF6D-4A0F-ADF2-F4911BA9FFA6"
+
+    private static var nearbyBeaconRegions: [[String: Any]] {
+        [
+            [
+                "uuid": beaconUUID,
+                "metadata": ["radar:campaignId": "campaign-1"],
+            ]
+        ]
+    }
+
+    private var apiHelperMock: RadarAPIHelperMock!
+
+    override func setUp() {
+        super.setUp()
+        Radar.initialize(publishableKey: "prj_test_pk_radar_sdk_ios")
+
+        apiHelperMock = RadarAPIHelperMock()
+        apiHelperMock.mockStatus = .success
+        RadarAPIClient.sharedInstance().apiHelper = apiHelperMock
+    }
+
+    /// Replaces the implementation of the beacon-region registration method with a capturing
+    /// block for the duration of `body`. The production call site is Objective-C, so the call
+    /// dispatches through objc_msgSend and is guaranteed to hit the swapped implementation.
+    private func captureRegisteredBeaconRegions(during body: () -> Void) -> [[String: Any]]? {
+        let selector = NSSelectorFromString("registerBeaconRegionNotificationsFromArray:")
+        guard let method = class_getInstanceMethod(RadarBeaconManagerSwift.self, selector) else {
+            XCTFail("registerBeaconRegionNotificationsFromArray: not found on RadarBeaconManagerSwift")
+            return nil
+        }
+
+        var captured: [[String: Any]]?
+        let block: @convention(block) (AnyObject, NSArray) -> Void = { _, regions in
+            captured = regions as? [[String: Any]]
+        }
+        let originalIMP = method_setImplementation(method, imp_implementationWithBlock(block))
+        defer { method_setImplementation(method, originalIMP) }
+
+        body()
+        return captured
+    }
+
+    private func track(completionHandler: @escaping RadarTrackAPICompletionHandler) {
+        RadarAPIClient.sharedInstance().track(
+            with: CLLocation(latitude: 40.7043, longitude: -73.9867),
+            stopped: false,
+            foreground: true,
+            source: .foregroundLocation,
+            replayed: false,
+            beacons: nil,
+            indoorLocation: nil,
+            verified: true,
+            fraudPayload: nil,
+            expectedCountryCode: nil,
+            expectedStateCode: nil,
+            reason: nil,
+            transactionId: nil,
+            useSecondaryVerifiedHost: false,
+            completionHandler: completionHandler
+        )
+    }
+
+    func test_track_jweResponse_registersNearbyBeaconRegions() {
+        // protected mode: user and events only exist inside the encrypted token,
+        // but nearbyBeaconRegions is still present in plaintext
+        apiHelperMock.mockResponse = [
+            "meta": ["code": 200],
+            "_id": "location-789",
+            "token": "aaa.bbb.ccc.ddd.eee",
+            "expiresAt": "2026-08-20T12:00:00.000Z",
+            "expiresIn": 1200,
+            "passed": true,
+            "format": "JWE",
+            "nearbyBeaconRegions": Self.nearbyBeaconRegions,
+        ]
+
+        let exp = expectation(description: "track completes")
+        var capturedStatus: RadarStatus?
+        var capturedToken: RadarVerifiedLocationToken?
+        var capturedUser: RadarUser?
+        var capturedEvents: [RadarEvent]?
+
+        let registeredRegions = captureRegisteredBeaconRegions {
+            track { status, _, events, user, _, _, token in
+                capturedStatus = status
+                capturedToken = token
+                capturedUser = user
+                capturedEvents = events
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 1)
+        }
+
+        XCTAssertEqual(capturedStatus, .success)
+        XCTAssertEqual(capturedToken?.format, .jwe)
+        XCTAssertNil(capturedUser)
+        XCTAssertNil(capturedEvents)
+
+        XCTAssertEqual(registeredRegions?.count, 1)
+        XCTAssertEqual(registeredRegions?.first?["uuid"] as? String, Self.beaconUUID)
+    }
+
+    func test_track_jwsResponse_stillRegistersNearbyBeaconRegions() {
+        apiHelperMock.mockResponse = [
+            "meta": ["code": 200],
+            "user": [
+                "_id": "user-123",
+                "userId": "verified-user",
+                "location": ["type": "Point", "coordinates": [-73.9867, 40.7043]],
+                "locationAccuracy": 20,
+            ],
+            "events": [],
+            "nearbyBeaconRegions": Self.nearbyBeaconRegions,
+        ]
+
+        let exp = expectation(description: "track completes")
+        var capturedStatus: RadarStatus?
+        var capturedUser: RadarUser?
+
+        let registeredRegions = captureRegisteredBeaconRegions {
+            track { status, _, _, user, _, _, _ in
+                capturedStatus = status
+                capturedUser = user
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 1)
+        }
+
+        XCTAssertEqual(capturedStatus, .success)
+        XCTAssertNotNil(capturedUser)
+
+        XCTAssertEqual(registeredRegions?.count, 1)
+        XCTAssertEqual(registeredRegions?.first?["uuid"] as? String, Self.beaconUUID)
+    }
+}

--- a/RadarSDKTests/RadarVerifiedLocationTokenTests.swift
+++ b/RadarSDKTests/RadarVerifiedLocationTokenTests.swift
@@ -1,0 +1,122 @@
+//
+//  RadarVerifiedLocationTokenTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+struct RadarVerifiedLocationTokenTests {
+
+    private static var userDict: [String: Any] {
+        [
+            "_id": "user-123",
+            "userId": "verified-user",
+            "location": ["type": "Point", "coordinates": [-73.9867, 40.7043]],
+            "locationAccuracy": 20,
+        ]
+    }
+
+    /// A legacy (JWS) verified track response: user and events in plaintext next to the token.
+    private static var jwsResponse: [String: Any] {
+        [
+            "_id": "location-123",
+            "user": userDict,
+            "events": [],
+            "token": "aaa.bbb.ccc",
+            "expiresAt": "2026-08-13T12:00:00.000Z",
+            "expiresIn": 86400,
+            "passed": true,
+            "failureReasons": [],
+            "format": "JWS",
+        ]
+    }
+
+    /// A protected (JWE) verified track response: user, events, and failure reasons only exist
+    /// inside the encrypted token.
+    private static var jweResponse: [String: Any] {
+        [
+            "_id": "location-456",
+            "token": "aaa.bbb.ccc.ddd.eee",
+            "expiresAt": "2026-08-13T12:00:00.000Z",
+            "expiresIn": 1200,
+            "passed": true,
+            "format": "JWE",
+        ]
+    }
+
+    @Test("parses a legacy JWS response with user and events")
+    func parsesJwsResponse() {
+        let token = RadarVerifiedLocationToken(object: RadarVerifiedLocationTokenTests.jwsResponse)
+
+        #expect(token != nil)
+        #expect(token?.format == .jws)
+        #expect(token?.user != nil)
+        #expect(token?.user?._id == "user-123")
+        #expect(token?.events != nil)
+        #expect(token?.token == "aaa.bbb.ccc")
+        #expect(token?.passed == true)
+    }
+
+    @Test("a response without a format field defaults to JWS")
+    func missingFormatDefaultsToJws() {
+        var response = RadarVerifiedLocationTokenTests.jwsResponse
+        response["format"] = nil
+
+        let token = RadarVerifiedLocationToken(object: response)
+
+        #expect(token != nil)
+        #expect(token?.format == .jws)
+    }
+
+    @Test("parses a protected JWE response without user and events")
+    func parsesJweResponse() {
+        let token = RadarVerifiedLocationToken(object: RadarVerifiedLocationTokenTests.jweResponse)
+
+        #expect(token != nil)
+        #expect(token?.format == .jwe)
+        #expect(token?.user == nil)
+        #expect(token?.events == nil)
+        #expect(token?.token == "aaa.bbb.ccc.ddd.eee")
+        #expect(token?.expiresIn == 1200)
+        #expect(token?.passed == true)
+        #expect(token?._id == "location-456")
+    }
+
+    @Test("the format field is parsed case-insensitively")
+    func parsesLowercaseJweFormat() {
+        var response = RadarVerifiedLocationTokenTests.jweResponse
+        response["format"] = "jwe"
+
+        let token = RadarVerifiedLocationToken(object: response)
+
+        #expect(token != nil)
+        #expect(token?.format == .jwe)
+    }
+
+    @Test("a JWS response without user and events does not parse")
+    func jwsResponseRequiresUserAndEvents() {
+        var response = RadarVerifiedLocationTokenTests.jwsResponse
+        response["user"] = nil
+        response["events"] = nil
+
+        let token = RadarVerifiedLocationToken(object: response)
+
+        #expect(token == nil)
+    }
+
+    @Test("a JWE response still requires token and expiresAt")
+    func jweResponseRequiresTokenAndExpiresAt() {
+        var missingToken = RadarVerifiedLocationTokenTests.jweResponse
+        missingToken["token"] = nil
+        #expect(RadarVerifiedLocationToken(object: missingToken) == nil)
+
+        var missingExpiresAt = RadarVerifiedLocationTokenTests.jweResponse
+        missingExpiresAt["expiresAt"] = nil
+        #expect(RadarVerifiedLocationToken(object: missingExpiresAt) == nil)
+    }
+}

--- a/RadarSDKTests/RadarVerifiedLocationTokenTests.swift
+++ b/RadarSDKTests/RadarVerifiedLocationTokenTests.swift
@@ -81,10 +81,38 @@ struct RadarVerifiedLocationTokenTests {
         #expect(token?.format == .jwe)
         #expect(token?.user == nil)
         #expect(token?.events == nil)
+        #expect(token?.failureReasons == nil)
         #expect(token?.token == "aaa.bbb.ccc.ddd.eee")
         #expect(token?.expiresIn == 1200)
         #expect(token?.passed == true)
         #expect(token?._id == "location-456")
+    }
+
+    @Test("a failed JWE response keeps failureReasons nil rather than reporting no failures")
+    func failedJweResponsePreservesNilFailureReasons() {
+        // in protected mode the reasons only exist inside the encrypted token, so a failed
+        // check must surface nil (unavailable), not an empty array (no failures)
+        var response = RadarVerifiedLocationTokenTests.jweResponse
+        response["passed"] = false
+
+        let token = RadarVerifiedLocationToken(object: response)
+
+        #expect(token != nil)
+        #expect(token?.format == .jwe)
+        #expect(token?.passed == false)
+        #expect(token?.failureReasons == nil)
+    }
+
+    @Test("a JWS response without failureReasons defaults to an empty array")
+    func jwsResponseDefaultsFailureReasonsToEmpty() {
+        var response = RadarVerifiedLocationTokenTests.jwsResponse
+        response["failureReasons"] = nil
+
+        let token = RadarVerifiedLocationToken(object: response)
+
+        #expect(token != nil)
+        #expect(token?.format == .jws)
+        #expect(token?.failureReasons == [])
     }
 
     @Test("the format field is parsed case-insensitively")


### PR DESCRIPTION
see https://github.com/radarlabs/server/pull/8355

## Summary

Adds support for JWE-encrypted (protected mode) response tokens for verified tracking and reveal risk, controlled by a server-side project setting. When a project has protected responses enabled, the server omits `user`, `events`, and other verdict-bearing fields from the plaintext response and returns an encrypted JWE instead of a signed JWS — the token is opaque to the SDK and the customer decrypts it server-side with their private key, then verifies it against Radar's JWKS.

## Linear ticket (Radar internal)

FRA-1913

## Changes

New public API:

- `RadarTokenFormat` enum (`jws` / `jwe`) exposed on both `RadarVerifiedLocationToken` and `RadarRevealRiskToken` via a new `format` property. Parsed from the response's `format` field, case-insensitively, defaulting to JWS so existing projects are unaffected.

`RadarVerifiedLocationToken`:

- `user` and `events` are now nullable in the initializer, since in JWE mode they only exist inside the encrypted token. Parsing still requires `token` and `expiresAt` in both modes, and still requires `user` + `events` in JWS mode.

`RadarAPIClient`:

- A verified track response with a JWE token short-circuits before user/event parsing: it fires `didUpdateToken:` and completes with success, the token, and nearby geofences, but `nil` user and events.

`RadarVerificationManager`:

- `isLastTokenValid` always returns `NO` for JWE tokens. The reuse check depends on `user.state.distanceToBorder`, which is inside the encrypted payload, so JWE tokens are never reused and every retrieval re-tracks.

`RadarRevealRiskToken`:

- `network`, `device`, and `risk.reasons` are now optional — `nil` in JWE mode for the same reason.

Tests:

- New `RadarVerifiedLocationTokenTests.swift`: JWS parsing, JWE parsing without user/events, default-to-JWS when `format` is missing, case-insensitive format parsing, and required-field validation in both modes.
- `RadarRevealRiskTests.swift`: new test for a protected response that omits reasons/network/device, plus `format` assertions on existing tests.

## Manual test steps

see server pr

## Checklist

- [x] New code is written in Swift (the SDK is migrating off Objective-C) — new tests are Swift; model/manager changes edit existing ObjC files
- [x] Added or updated unit tests (`make test`)
- [ ] `make lint-swift` and `make format-check` pass locally
- [ ] For breaking changes: added a `MIGRATION.md` entry and bumped the version with `./set-version.sh`
- [ ] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/format violations on lines I changed; removed any now-stale `.swiftlint-baseline.json` entries