### PR TITLE
FENCE-2991: Improve iOS app kill detection for trip issues

### DIFF
--- a/Example/Example/Logs/LogsView.swift
+++ b/Example/Example/Logs/LogsView.swift
@@ -11,6 +11,8 @@ import UIKit
 
 struct LogsView: View {
     @EnvironmentObject var logStream: LogStream
+    @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
     @State private var filter: Filter = .all
     @State private var expandedIds: Set<UUID> = []
     @State private var isShowingShareSheet = false
@@ -39,9 +41,18 @@ struct LogsView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+            searchRow
             filterRow
             Divider()
             content
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") {
+                    isSearchFocused = false
+                }
+            }
         }
         .sheet(isPresented: $isShowingShareSheet) {
             ActivityShareSheet(activityItems: [ConsoleEntry.formatForExport(filtered)])
@@ -86,6 +97,38 @@ struct LogsView: View {
         .padding(.top, 12)
         .padding(.bottom, 8)
     }
+    private var searchRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+            TextField("Search logs", text: $searchText)
+                .textFieldStyle(.plain)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused($isSearchFocused)
+                .submitLabel(.done)
+                .onSubmit {
+                    isSearchFocused = false
+                }
+                .accessibilityLabel("Search logs")
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color(.tertiarySystemFill))
+        .cornerRadius(10)
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
 
     private var filterRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -112,8 +155,10 @@ struct LogsView: View {
 
     @ViewBuilder
     private var content: some View {
-        if filtered.isEmpty {
+        if logStream.entries.isEmpty {
             emptyState
+        } else if filtered.isEmpty {
+            noMatchesState
         } else {
             List {
                 ForEach(filtered) { entry in
@@ -140,11 +185,37 @@ struct LogsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+    private var noMatchesState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+            Text("No matches")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            Text("Change the selected filter or search term to see more logs.")
+                .font(.callout)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 
     // MARK: - Helpers
 
+    private var searchQuery: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var filtered: [ConsoleEntry] {
-        logStream.entries.reversed().filter { filter.includes($0.kind) }
+        let query = searchQuery
+        return logStream.entries.reversed().filter { entry in
+            guard filter.includes(entry.kind) else { return false }
+            guard !query.isEmpty else { return true }
+            return entry.summary.localizedCaseInsensitiveContains(query)
+                || entry.detail?.localizedCaseInsensitiveContains(query) == true
+        }
     }
 
     private func expansionBinding(for entry: ConsoleEntry) -> Binding<Bool> {

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		F64FF0D92E4D2B9100DF3926 /* RadarInAppMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0D82E4D2B9100DF3926 /* RadarInAppMessageManager.swift */; };
 		F64FF0DB2E4D2BC600DF3926 /* RadarInAppMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0DA2E4D2BC600DF3926 /* RadarInAppMessageView.swift */; };
 		F64FF0DD2E4D2BEA00DF3926 /* RadarLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0DC2E4D2BEA00DF3926 /* RadarLogger.swift */; };
+		F6AC00012F00000100523472 /* RadarLifecycleMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AC00002F00000100523472 /* RadarLifecycleMarker.swift */; };
 		F64FF0DF2E4D2C2A00DF3926 /* RadarSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0DE2E4D2C2A00DF3926 /* RadarSettings.swift */; };
 		F64FF0E32E4D2E1100DF3926 /* InAppMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64FF0E22E4D2E1100DF3926 /* InAppMessageTest.swift */; };
 		F6513DDC2E54F63100523472 /* RadarAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6513DDB2E54F63100523472 /* RadarAPIClient.swift */; };
@@ -259,6 +260,7 @@
 		F686B7312E4D29C400D3D614 /* RadarInAppMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F686B7372E4D2AFC00D3D614 /* RadarAPIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */; };
 		F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */; };
+		F6AC00032F00000100523472 /* RadarLifecycleMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AC00022F00000100523472 /* RadarLifecycleMarkerTests.swift */; };
 		F6A2DDE52EE8A23000ABA650 /* RadarIndoors.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A2DDE42EE8A22500ABA650 /* RadarIndoors.h */; };
 		F6A2DDE62EE8A71800ABA650 /* RadarIndoors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED7C1D2EDF917700D3E6E6 /* RadarIndoors.swift */; };
 		F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */; };
@@ -519,6 +521,7 @@
 		F64FF0D82E4D2B9100DF3926 /* RadarInAppMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessageManager.swift; sourceTree = "<group>"; };
 		F64FF0DA2E4D2BC600DF3926 /* RadarInAppMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarInAppMessageView.swift; sourceTree = "<group>"; };
 		F64FF0DC2E4D2BEA00DF3926 /* RadarLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLogger.swift; sourceTree = "<group>"; };
+		F6AC00002F00000100523472 /* RadarLifecycleMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLifecycleMarker.swift; sourceTree = "<group>"; };
 		F64FF0DE2E4D2C2A00DF3926 /* RadarSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSettings.swift; sourceTree = "<group>"; };
 		F64FF0E12E4D2E1100DF3926 /* RadarSDKTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RadarSDKTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		F64FF0E22E4D2E1100DF3926 /* InAppMessageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageTest.swift; sourceTree = "<group>"; };
@@ -541,6 +544,7 @@
 		F686B7302E4D29C400D3D614 /* RadarInAppMessageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarInAppMessageDelegate.h; sourceTree = "<group>"; };
 		F686B7362E4D2AFC00D3D614 /* RadarAPIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarAPIHelper.swift; sourceTree = "<group>"; };
 		F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSettingsTest.swift; sourceTree = "<group>"; };
+		F6AC00022F00000100523472 /* RadarLifecycleMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLifecycleMarkerTests.swift; sourceTree = "<group>"; };
 		F6A2DDE42EE8A22500ABA650 /* RadarIndoors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarIndoors.h; sourceTree = "<group>"; };
 		F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationInsightsModelTests.swift; sourceTree = "<group>"; };
 		F6B7E3462F7429CC006A5A24 /* RadarNotificationHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarNotificationHelperTest.swift; sourceTree = "<group>"; };
@@ -753,6 +757,7 @@
 				82D04ABA29722ED20036619F /* RadarReplayBuffer.h */,
 				F6843C393005538D00213092 /* RadarRevealRiskManager.h */,
 				FE10A6092F2BC9160058ECD4 /* RadarRevealRiskManager.swift */,
+				F6AC00002F00000100523472 /* RadarLifecycleMarker.swift */,
 				BA264CFE2FF31FAF000EDFE6 /* RadarReplayBuffer.swift */,
 				8227EF0B2CDAB69B00C47290 /* RadarRouteMode.m */,
 				F667F8282BFBF3D1001F2F67 /* RadarSdkConfiguration.h */,
@@ -830,6 +835,7 @@
 				B0A0F0312FBC000100111111 /* RadarLocationManagerSwiftLocationTests.swift */,
 				F6AF00002FE1000000000001 /* RadarLocationInsightsModelTests.swift */,
 				F6A0DAC72EF087A100BC10B4 /* RadarSettingsTest.swift */,
+				F6AC00022F00000100523472 /* RadarLifecycleMarkerTests.swift */,
 				F6FA1101000000000000A001 /* RadarVerifiedHostOverrideTests.swift */,
 				F6FA1103000000000000A001 /* RadarIndoorLocationTrackParamsTests.swift */,
 				61FFFC29F8BCE53F30E3180F /* RadarIndoorsUpdateTrackingTests.swift */,
@@ -1254,6 +1260,7 @@
 				0107AA7A26220128008AB52F /* RadarAddress.m in Sources */,
 				0107AABC26220178008AB52F /* RadarRegion.m in Sources */,
 				F64FF0DD2E4D2BEA00DF3926 /* RadarLogger.swift in Sources */,
+				F6AC00012F00000100523472 /* RadarLifecycleMarker.swift in Sources */,
 				0107AB26262201F0008AB52F /* RadarState.m in Sources */,
 				0107AAA126220159008AB52F /* RadarEvent.m in Sources */,
 				F64FF0DF2E4D2C2A00DF3926 /* RadarSettings.swift in Sources */,
@@ -1279,6 +1286,7 @@
 			files = (
 				BA561CDA2FD3869500D7A3E3 /* RadarOperatingHoursEvaluatorTest.swift in Sources */,
 				F6A0DAC82EF087AC00BC10B4 /* RadarSettingsTest.swift in Sources */,
+				F6AC00032F00000100523472 /* RadarLifecycleMarkerTests.swift in Sources */,
 				BA8D153D300EA41900022EB3 /* RadarEventNotificationsTestHelpers.swift in Sources */,
 				F6843C87300696A200213092 /* RadarRevealRiskTests.swift in Sources */,
 				F6AF00012FE1000000000001 /* RadarLocationInsightsModelTests.swift in Sources */,

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -45,8 +45,6 @@
 + (instancetype)sharedMarker;
 - (BOOL)beginProcess;
 + (NSString *)appTerminatingMessage;
-- (void)markBackground;
-- (void)markCleanTermination;
 
 @end
 
@@ -140,11 +138,6 @@ BOOL _initialized = NO;
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
                                              selector:@selector(applicationWillEnterForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
-                                               object:nil];
-
-    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
-                                             selector:@selector(applicationWillTerminate)
-                                                 name:UIApplicationWillTerminateNotification
                                                object:nil];
 
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
@@ -1480,8 +1473,7 @@ BOOL _initialized = NO;
     [RadarSdkConfiguration_ObjC updateSdkConfigurationFromServer];
 }
 
-+ (void)logTermination { 
-    [[RadarLifecycleMarker sharedMarker] markCleanTermination];
++ (void)logTermination {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:YES append:YES];
 }
 
@@ -1749,9 +1741,6 @@ BOOL _initialized = NO;
     return [message toDictionary];
 }
 
-- (void)applicationWillTerminate {
-    [[RadarLifecycleMarker sharedMarker] markCleanTermination];
-}
 
 - (void)applicationWillEnterForeground {
     BOOL updated = [RadarSettings updateSessionId];

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -37,7 +37,6 @@
 @interface Radar ()
 
 @property (nullable, weak, nonatomic) id<RadarDelegate> delegate;
-+ (void)logUncleanPreviousProcessIfNeeded;
 
 @end
 
@@ -45,6 +44,7 @@
 
 + (instancetype)sharedMarker;
 - (BOOL)beginProcess;
+- (void)logUncleanPreviousProcessIfNeeded;
 + (NSString *)appTerminatingMessage;
 
 @end
@@ -111,28 +111,10 @@ BOOL _initialized = NO;
     [Radar initializeWithPublishableKey:[RadarSettings publishableKey]];
 }
 
-+ (void)logUncleanPreviousProcessIfNeeded {
-
-    // App extensions share the app group's defaults but run in separate processes.
-    // If an extension updates this marker, its launch looks like a killed app and
-    // creates a duplicate app_killed issue. The marker belongs to the main app.
-    BOOL isMainAppProcess = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSExtension"] == nil;
-    if (!isMainAppProcess) {
-        return;
-    }
-
-    RadarLifecycleMarker *lifecycleMarker = [RadarLifecycleMarker sharedMarker];
-    BOOL uncleanPreviousProcess = [lifecycleMarker beginProcess];
-    // The app was killed not gracefully (user swiped away, killed in background etc.) and a trip was active
-    if (uncleanPreviousProcess && [RadarSettings tripOptions] != nil) {
-        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:NO append:YES];
-    }
-}
-
 + (void)initializeWithOptions:(RadarInitializeOptions *)options {
     [RadarSwift setBridge:[[RadarSwiftBridge alloc] init]];
 
-    [self logUncleanPreviousProcessIfNeeded];
+    [[RadarLifecycleMarker sharedMarker] logUncleanPreviousProcessIfNeeded];
 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"initialize()"];
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -215,7 +215,6 @@ BOOL _initialized = NO;
                                                 [Radar trackOnceWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyMedium beacons:[Radar getTrackingOptions].beacons completionHandler:nil];
                                             }
 
-                                            [self flushLogs];
                                         }];
     }];
     

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -40,6 +40,15 @@
 
 @end
 
+@interface RadarLifecycleMarker : NSObject
+
++ (instancetype)sharedMarker;
+- (BOOL)beginProcess;
+- (void)markBackground;
+- (void)markCleanTermination;
+
+@end
+
 @implementation Radar
 
 #pragma mark - Initialization
@@ -105,6 +114,12 @@ BOOL _initialized = NO;
 + (void)initializeWithOptions:(RadarInitializeOptions *)options {
     [RadarSwift setBridge:[[RadarSwiftBridge alloc] init]];
 
+    RadarLifecycleMarker *lifecycleMarker = [RadarLifecycleMarker sharedMarker];
+    BOOL uncleanPreviousProcess = [lifecycleMarker beginProcess];
+    if (uncleanPreviousProcess && [RadarSettings tripOptions] != nil) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:NO append:YES];
+    }
+
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"initialize()"];
 
     Class RadarSDKMotion = NSClassFromString(@"RadarSDKMotion");
@@ -124,6 +139,16 @@ BOOL _initialized = NO;
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
                                              selector:@selector(applicationWillEnterForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
+                                             selector:@selector(applicationDidEnterBackground)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
+                                             selector:@selector(applicationWillTerminate)
+                                                 name:UIApplicationWillTerminateNotification
                                                object:nil];
 
     RadarSdkConfiguration *sdkConfiguration = [RadarSettings sdkConfiguration];
@@ -1460,6 +1485,7 @@ BOOL _initialized = NO;
 }
 
 + (void)logTermination { 
+    [[RadarLifecycleMarker sharedMarker] markCleanTermination];
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:YES append:YES];
 }
 
@@ -1470,6 +1496,7 @@ BOOL _initialized = NO;
 + (void)logResigningActive {
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"App resigning active" includeDate:YES includeBattery:YES];
 }
+
 
 
 #pragma mark - Indoors
@@ -1724,6 +1751,14 @@ BOOL _initialized = NO;
 
 + (NSDictionary *)dictionaryForInAppMessage:(RadarInAppMessage *)message {
     return [message toDictionary];
+}
+
+- (void)applicationDidEnterBackground {
+    [[RadarLifecycleMarker sharedMarker] markBackground];
+}
+
+- (void)applicationWillTerminate {
+    [[RadarLifecycleMarker sharedMarker] markCleanTermination];
 }
 
 - (void)applicationWillEnterForeground {

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -37,6 +37,7 @@
 @interface Radar ()
 
 @property (nullable, weak, nonatomic) id<RadarDelegate> delegate;
++ (void)logUncleanPreviousProcessIfNeeded;
 
 @end
 
@@ -110,14 +111,31 @@ BOOL _initialized = NO;
     [Radar initializeWithPublishableKey:[RadarSettings publishableKey]];
 }
 
-+ (void)initializeWithOptions:(RadarInitializeOptions *)options {
-    [RadarSwift setBridge:[[RadarSwiftBridge alloc] init]];
++ (void)logUncleanPreviousProcessIfNeeded {
+
+    // App extensions share the app group's defaults but run in separate processes.
+    // If an extension updates this marker, its launch looks like a killed app and
+    // creates a duplicate app_killed issue. The marker belongs to the main app.
+    BOOL isMainAppProcess = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSExtension"] == nil;
+    if (!isMainAppProcess) {
+        return;
+    }
 
     RadarLifecycleMarker *lifecycleMarker = [RadarLifecycleMarker sharedMarker];
     BOOL uncleanPreviousProcess = [lifecycleMarker beginProcess];
+    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[NSString stringWithFormat:@"STOV: Unclean previous state: %d", uncleanPreviousProcess]];
+    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[NSString stringWithFormat:@"STOV: Trip options: %d", [RadarSettings tripOptions] != nil]];
+    // The app was killed not gracefully (user swiped away, killed in background etc.) and a trip was active
     if (uncleanPreviousProcess && [RadarSettings tripOptions] != nil) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"STOV: Spewing terminating message"];
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:NO append:YES];
     }
+}
+
++ (void)initializeWithOptions:(RadarInitializeOptions *)options {
+    [RadarSwift setBridge:[[RadarSwiftBridge alloc] init]];
+
+    [self logUncleanPreviousProcessIfNeeded];
 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"initialize()"];
 

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -44,6 +44,7 @@
 
 + (instancetype)sharedMarker;
 - (BOOL)beginProcess;
++ (NSString *)appTerminatingMessage;
 - (void)markBackground;
 - (void)markCleanTermination;
 
@@ -117,7 +118,7 @@ BOOL _initialized = NO;
     RadarLifecycleMarker *lifecycleMarker = [RadarLifecycleMarker sharedMarker];
     BOOL uncleanPreviousProcess = [lifecycleMarker beginProcess];
     if (uncleanPreviousProcess && [RadarSettings tripOptions] != nil) {
-        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:NO append:YES];
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:NO append:YES];
     }
 
     [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelInfo type:RadarLogTypeSDKCall message:@"initialize()"];
@@ -1486,7 +1487,7 @@ BOOL _initialized = NO;
 
 + (void)logTermination { 
     [[RadarLifecycleMarker sharedMarker] markCleanTermination];
-    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"App terminating" includeDate:YES includeBattery:YES append:YES];
+    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:YES append:YES];
 }
 
 + (void)logBackgrounding {

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -143,11 +143,6 @@ BOOL _initialized = NO;
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
-                                             selector:@selector(applicationDidEnterBackground)
-                                                 name:UIApplicationDidEnterBackgroundNotification
-                                               object:nil];
-
-    [[NSNotificationCenter defaultCenter] addObserver:[self sharedInstance]
                                              selector:@selector(applicationWillTerminate)
                                                  name:UIApplicationWillTerminateNotification
                                                object:nil];
@@ -1752,10 +1747,6 @@ BOOL _initialized = NO;
 
 + (NSDictionary *)dictionaryForInAppMessage:(RadarInAppMessage *)message {
     return [message toDictionary];
-}
-
-- (void)applicationDidEnterBackground {
-    [[RadarLifecycleMarker sharedMarker] markBackground];
 }
 
 - (void)applicationWillTerminate {

--- a/RadarSDK/Radar.m
+++ b/RadarSDK/Radar.m
@@ -123,11 +123,8 @@ BOOL _initialized = NO;
 
     RadarLifecycleMarker *lifecycleMarker = [RadarLifecycleMarker sharedMarker];
     BOOL uncleanPreviousProcess = [lifecycleMarker beginProcess];
-    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[NSString stringWithFormat:@"STOV: Unclean previous state: %d", uncleanPreviousProcess]];
-    [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[NSString stringWithFormat:@"STOV: Trip options: %d", [RadarSettings tripOptions] != nil]];
     // The app was killed not gracefully (user swiped away, killed in background etc.) and a trip was active
     if (uncleanPreviousProcess && [RadarSettings tripOptions] != nil) {
-        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:@"STOV: Spewing terminating message"];
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug type:RadarLogTypeNone message:[RadarLifecycleMarker appTerminatingMessage] includeDate:YES includeBattery:NO append:YES];
     }
 }

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -20,23 +20,23 @@ final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
 
     private let userDefaults: UserDefaults
     private let lock = NSLock()
+    private var didBeginProcess = false
 
     init(userDefaults: UserDefaults = RadarUserDefaults.sharedUserDefaults) {
         self.userDefaults = userDefaults
         super.init()
     }
 
+    // iOS may kill a background app without a callback, so this marker stays set.
     @objc func beginProcess() -> Bool {
         withSynchronizedDefaults { defaults in
+            guard !didBeginProcess else { return false }
+
+            RadarLogger.shared.debug("STOV: Begin process")
             let previousValue = defaults.bool(forKey: Self.markerKey)
             defaults.set(true, forKey: Self.markerKey)
+            didBeginProcess = true
             return previousValue
-        }
-    }
-
-    @objc func markCleanTermination() {
-        withSynchronizedDefaults { defaults in
-            defaults.removeObject(forKey: Self.markerKey)
         }
     }
 

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -7,43 +7,52 @@
 
 import Foundation
 
-@objc(RadarLifecycleMarker) final class RadarLifecycleMarker: NSObject {
+@objc(RadarLifecycleMarker)
+final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
     private static let markerKey = "radar-appLifecycleMarker"
-    // The server uses this prefix to turn uploaded logs into app_killed issues.
-    @objc(appTerminatingMessage) static let appTerminatingMessage = "App terminating"
 
-    @objc(sharedMarker) nonisolated(unsafe) static let shared = RadarLifecycleMarker()
+    // The server uses this prefix to turn uploaded logs into app_killed issues.
+    @objc(appTerminatingMessage)
+    static let appTerminatingMessage = "App terminating"
+
+    @objc(sharedMarker)
+    static let shared = RadarLifecycleMarker()
 
     private let userDefaults: UserDefaults
     private let lock = NSLock()
 
     init(userDefaults: UserDefaults = RadarUserDefaults.sharedUserDefaults) {
         self.userDefaults = userDefaults
+        super.init()
     }
 
     @objc func beginProcess() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let previousValue = userDefaults.bool(forKey: Self.markerKey)
-        userDefaults.set(true, forKey: Self.markerKey)
-        userDefaults.synchronize()
-        return previousValue
+        withSynchronizedDefaults { defaults in
+            let previousValue = defaults.bool(forKey: Self.markerKey)
+            defaults.set(true, forKey: Self.markerKey)
+            return previousValue
+        }
     }
 
     @objc func markBackground() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        userDefaults.set(true, forKey: Self.markerKey)
-        userDefaults.synchronize()
+        withSynchronizedDefaults { defaults in
+            defaults.set(true, forKey: Self.markerKey)
+        }
     }
 
     @objc func markCleanTermination() {
+        withSynchronizedDefaults { defaults in
+            defaults.removeObject(forKey: Self.markerKey)
+        }
+    }
+
+    private func withSynchronizedDefaults<T>(
+        _ operation: (UserDefaults) -> T
+    ) -> T {
         lock.lock()
         defer { lock.unlock() }
+        defer { userDefaults.synchronize() }
 
-        userDefaults.removeObject(forKey: Self.markerKey)
-        userDefaults.synchronize()
+        return operation(userDefaults)
     }
 }

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -34,14 +34,6 @@ final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
         }
     }
 
-    @objc func markBackground() {
-        // Backgrounding is not an app kill. Keep the marker so a later kill of the
-        // suspended process can be detected on the next initialize.
-        withSynchronizedDefaults { defaults in
-            defaults.set(true, forKey: Self.markerKey)
-        }
-    }
-
     @objc func markCleanTermination() {
         withSynchronizedDefaults { defaults in
             defaults.removeObject(forKey: Self.markerKey)

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -39,6 +39,25 @@ final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
         }
     }
 
+    @objc func logUncleanPreviousProcessIfNeeded() {
+        // App extensions share the app group's defaults but run in separate processes.
+        // Only the main app owns this marker; otherwise an extension launch looks like a killed app.
+        guard Bundle.main.object(forInfoDictionaryKey: "NSExtension") == nil else {
+            return
+        }
+
+        let uncleanPreviousProcess = beginProcess()
+        guard uncleanPreviousProcess, RadarSettings.tripOptions != nil else {
+            return
+        }
+
+        RadarLogger.shared.debug(
+            Self.appTerminatingMessage,
+            includeDate: true,
+            append: true
+        )
+    }
+
     private func withSynchronizedDefaults<T>(
         _ operation: (UserDefaults) -> T
     ) -> T {

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -1,0 +1,47 @@
+//
+//  RadarLifecycleMarker.swift
+//  RadarSDK
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+
+@objc(RadarLifecycleMarker) final class RadarLifecycleMarker: NSObject {
+    private static let markerKey = "radar-appLifecycleMarker"
+
+    @objc(sharedMarker) nonisolated(unsafe) static let shared = RadarLifecycleMarker()
+
+    private let userDefaults: UserDefaults
+    private let lock = NSLock()
+
+    init(userDefaults: UserDefaults = RadarUserDefaults.sharedUserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    @objc func beginProcess() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let previousValue = userDefaults.bool(forKey: Self.markerKey)
+        userDefaults.set(true, forKey: Self.markerKey)
+        userDefaults.synchronize()
+        return previousValue
+    }
+
+    @objc func markBackground() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        userDefaults.set(true, forKey: Self.markerKey)
+        userDefaults.synchronize()
+    }
+
+    @objc func markCleanTermination() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        userDefaults.removeObject(forKey: Self.markerKey)
+        userDefaults.synchronize()
+    }
+}

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -11,7 +11,7 @@ import Foundation
 final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
     private static let markerKey = "radar-appLifecycleMarker"
 
-    // The server uses this prefix to turn uploaded logs into app_killed issues.
+    // The server uses this prefix to turn uploaded logs into app_killed issues. Be very careful changing it.
     @objc(appTerminatingMessage)
     static let appTerminatingMessage = "App terminating"
 
@@ -35,6 +35,8 @@ final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
     }
 
     @objc func markBackground() {
+        // Backgrounding is not an app kill. Keep the marker so a later kill of the
+        // suspended process can be detected on the next initialize.
         withSynchronizedDefaults { defaults in
             defaults.set(true, forKey: Self.markerKey)
         }

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -32,7 +32,6 @@ final class RadarLifecycleMarker: NSObject, @unchecked Sendable {
         withSynchronizedDefaults { defaults in
             guard !didBeginProcess else { return false }
 
-            RadarLogger.shared.debug("STOV: Begin process")
             let previousValue = defaults.bool(forKey: Self.markerKey)
             defaults.set(true, forKey: Self.markerKey)
             didBeginProcess = true

--- a/RadarSDK/RadarLifecycleMarker.swift
+++ b/RadarSDK/RadarLifecycleMarker.swift
@@ -9,6 +9,8 @@ import Foundation
 
 @objc(RadarLifecycleMarker) final class RadarLifecycleMarker: NSObject {
     private static let markerKey = "radar-appLifecycleMarker"
+    // The server uses this prefix to turn uploaded logs into app_killed issues.
+    @objc(appTerminatingMessage) static let appTerminatingMessage = "App terminating"
 
     @objc(sharedMarker) nonisolated(unsafe) static let shared = RadarLifecycleMarker()
 

--- a/RadarSDK/RadarLogBuffer.swift
+++ b/RadarSDK/RadarLogBuffer.swift
@@ -13,6 +13,18 @@ actor RadarLogBuffer {
 
     var logs = [RadarLog]()
 
+    // A second flush can start while the first upload waits on the network.
+    private var isFlushing = false
+
+    private struct LogIdentity: Hashable {
+        let createdAt: Date
+        let level: String
+        let type: String
+        let message: String
+        let includeDate: Bool
+        let battery: Float?
+    }
+
     // the logs file is a full reflection of the logs
     let logsFile: RadarFileStorage?
 
@@ -57,6 +69,12 @@ actor RadarLogBuffer {
         } catch {
 
         }
+
+        let uniqueLogs = deduplicated(logs)
+        if uniqueLogs.count != logs.count {
+            logs = uniqueLogs
+            rewriteLogsFile()
+        }
     }
 
     func log(_ log: RadarLog) {
@@ -82,15 +100,54 @@ actor RadarLogBuffer {
         }
     }
 
-    func flush() async {
-        do {
-            try await apiClient.sendLogs(logs: logs)
-            logs = []
-            if useLogPersistence, let logsFile {
-                logsFile.write(data: Data())
+    // A killed process can leave a log to be replayed from persistent storage.
+    private func deduplicated(_ logs: [RadarLog]) -> [RadarLog] {
+        var seen = Set<LogIdentity>()
+        return logs.filter { log in
+            let identity = LogIdentity(
+                createdAt: log.createdAt,
+                level: log.level.toString(),
+                type: log.type.toString(),
+                message: log.message,
+                includeDate: log.includeDate,
+                battery: log.battery
+            )
+            return seen.insert(identity).inserted
+        }
+    }
+
+    private func rewriteLogsFile() {
+        guard let logsFile else { return }
+        logsFile.write(data: Data())
+        for log in logs {
+            if let data = try? JSONEncoder().encode(log) {
+                logsFile.append(data: data + NEW_LINE)
             }
+        }
+    }
+
+    private func persistLogs() {
+        guard useLogPersistence else { return }
+        rewriteLogsFile()
+    }
+
+    func flush() async {
+        guard !isFlushing else { return }
+
+        logs = deduplicated(logs)
+        guard !logs.isEmpty else { return }
+
+        isFlushing = true
+        let logsToSend = logs
+        logs.removeAll()
+        defer { isFlushing = false }
+
+        do {
+            try await apiClient.sendLogs(logs: logsToSend)
+            persistLogs()
         } catch {
-            // failed to flush logs, keep existing buffer
+            logs.insert(contentsOf: logsToSend, at: 0)
+            persistLogs()
         }
     }
 }

--- a/RadarSDKTests/RadarLifecycleMarkerTests.swift
+++ b/RadarSDKTests/RadarLifecycleMarkerTests.swift
@@ -11,6 +11,11 @@ import Testing
 @testable import RadarSDK
 
 struct RadarLifecycleMarkerTests {
+
+    @Test("The app terminating message matches the server contract")
+    func appTerminatingMessageMatchesServerContract() {
+        #expect(RadarLifecycleMarker.appTerminatingMessage == "App terminating")
+    }
     private func makeUserDefaults() -> UserDefaults {
         let suiteName = "RadarLifecycleMarkerTests.\(UUID().uuidString)"
         let userDefaults = UserDefaults(suiteName: suiteName)!

--- a/RadarSDKTests/RadarLifecycleMarkerTests.swift
+++ b/RadarSDKTests/RadarLifecycleMarkerTests.swift
@@ -42,16 +42,6 @@ struct RadarLifecycleMarkerTests {
         #expect(secondMarker.beginProcess() == true)
     }
 
-    @Test("Backgrounding restores the lifecycle marker")
-    func backgroundingRestoresMarker() {
-        let userDefaults = makeUserDefaults()
-        let marker = RadarLifecycleMarker(userDefaults: userDefaults)
-
-        marker.markBackground()
-
-        #expect(RadarLifecycleMarker(userDefaults: userDefaults).beginProcess() == true)
-    }
-
     @Test("Clean termination removes the lifecycle marker")
     func cleanTerminationRemovesMarker() {
         let userDefaults = makeUserDefaults()

--- a/RadarSDKTests/RadarLifecycleMarkerTests.swift
+++ b/RadarSDKTests/RadarLifecycleMarkerTests.swift
@@ -42,14 +42,13 @@ struct RadarLifecycleMarkerTests {
         #expect(secondMarker.beginProcess() == true)
     }
 
-    @Test("Clean termination removes the lifecycle marker")
-    func cleanTerminationRemovesMarker() {
+    @Test("Repeated initialization in one process is idempotent")
+    func repeatedBeginProcessIsIdempotent() {
         let userDefaults = makeUserDefaults()
         let marker = RadarLifecycleMarker(userDefaults: userDefaults)
 
-        _ = marker.beginProcess()
-        marker.markCleanTermination()
-
-        #expect(RadarLifecycleMarker(userDefaults: userDefaults).beginProcess() == false)
+        #expect(marker.beginProcess() == false)
+        #expect(marker.beginProcess() == false)
+        #expect(userDefaults.bool(forKey: "radar-appLifecycleMarker") == true)
     }
 }

--- a/RadarSDKTests/RadarLifecycleMarkerTests.swift
+++ b/RadarSDKTests/RadarLifecycleMarkerTests.swift
@@ -1,0 +1,60 @@
+//
+//  RadarLifecycleMarkerTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import RadarSDK
+
+struct RadarLifecycleMarkerTests {
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "RadarLifecycleMarkerTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+
+    @Test("A fresh process records its lifecycle marker")
+    func freshProcessRecordsMarker() {
+        let userDefaults = makeUserDefaults()
+        let marker = RadarLifecycleMarker(userDefaults: userDefaults)
+
+        #expect(marker.beginProcess() == false)
+        #expect(userDefaults.bool(forKey: "radar-appLifecycleMarker") == true)
+    }
+
+    @Test("A subsequent process finds the lifecycle marker")
+    func subsequentProcessFindsMarker() {
+        let userDefaults = makeUserDefaults()
+        let firstMarker = RadarLifecycleMarker(userDefaults: userDefaults)
+        let secondMarker = RadarLifecycleMarker(userDefaults: userDefaults)
+
+        #expect(firstMarker.beginProcess() == false)
+        #expect(secondMarker.beginProcess() == true)
+    }
+
+    @Test("Backgrounding restores the lifecycle marker")
+    func backgroundingRestoresMarker() {
+        let userDefaults = makeUserDefaults()
+        let marker = RadarLifecycleMarker(userDefaults: userDefaults)
+
+        marker.markBackground()
+
+        #expect(RadarLifecycleMarker(userDefaults: userDefaults).beginProcess() == true)
+    }
+
+    @Test("Clean termination removes the lifecycle marker")
+    func cleanTerminationRemovesMarker() {
+        let userDefaults = makeUserDefaults()
+        let marker = RadarLifecycleMarker(userDefaults: userDefaults)
+
+        _ = marker.beginProcess()
+        marker.markCleanTermination()
+
+        #expect(RadarLifecycleMarker(userDefaults: userDefaults).beginProcess() == false)
+    }
+}

--- a/RadarSDKTests/RadarLogBufferTests.swift
+++ b/RadarSDKTests/RadarLogBufferTests.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 Radar Labs, Inc. All rights reserved.
 //
 
+import Foundation
 import Testing
 
 @testable import RadarSDK
@@ -14,6 +15,29 @@ private func waitUntil(timeout: TimeInterval = 5.0, _ check: () async -> Bool) a
     while Date() < deadline {
         if await check() { return }
         try? await Task.sleep(nanoseconds: 25_000_000)
+    }
+}
+
+private final class RequestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+
+    func increment() {
+        lock.lock()
+        storedValue += 1
+        lock.unlock()
+    }
+
+    func set(_ value: Int) {
+        lock.lock()
+        storedValue = value
+        lock.unlock()
     }
 }
 
@@ -100,6 +124,77 @@ struct RadarLogBufferTests {
         #expect(fileLogs.count == 0)
 
         try? FileManager.default.removeItem(at: file)
+    }
+
+    @Test func concurrentFlushesSendOneBatch() async throws {
+        RadarSettings.publishableKey = "test-key"
+        let session = MockURLSession()
+        let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
+        let requestCounter = RequestCounter()
+
+        session.on({ request in
+            requestCounter.increment()
+            Thread.sleep(forTimeInterval: 0.1)
+            return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+        }, Data("{}".utf8))
+
+        let buffer = RadarLogBuffer(logsFile: "test/logs-concurrent.txt", logPersistence: false, apiClient: client)
+        await buffer.log(simpleLog("test"))
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await buffer.flush() }
+            group.addTask { await buffer.flush() }
+            await group.waitForAll()
+        }
+
+        #expect(requestCounter.value == 1)
+        #expect(await buffer.logs.count == 0)
+    }
+
+    @Test func deduplicatesIdenticalLogsBeforeFlush() async throws {
+        RadarSettings.publishableKey = "test-key"
+        let session = MockURLSession()
+        let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
+        let capturedLogCount = RequestCounter()
+
+        session.on({ request in
+            if let body = request.httpBody,
+               let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+               let logs = object["logs"] as? [[String: Any]]
+            {
+                capturedLogCount.set(logs.count)
+            }
+            return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+        }, Data("{}".utf8))
+
+        let buffer = RadarLogBuffer(logsFile: "test/logs-deduplicate.txt", logPersistence: false, apiClient: client)
+        let log = simpleLog("duplicate")
+        await buffer.log(log)
+        await buffer.log(log)
+
+        await buffer.flush()
+
+        #expect(capturedLogCount.value == 1)
+    }
+
+    @Test func deduplicatesPersistedLogsOnLoad() async throws {
+        let logsFile = "test/logs-deduplicate-persisted.txt"
+        let storage = RadarFileStorage(fileName: logsFile)
+        let log = simpleLog("duplicate")
+        let encodedLog = try! JSONEncoder().encode(log)  // swiftlint:disable:this force_try
+        let line = encodedLog + "\n".data(using: .utf8)!  // swiftlint:disable:this non_optional_string_data_conversion
+        storage?.write(data: line + line)
+
+        let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: true)
+        await waitUntil { await buffer.logs.count == 1 }
+
+        #expect(await buffer.logs.count == 1)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        if let file = file(logsFile) {
+            #expect(logsFrom(url: file).count == 1)
+        }
+        storage?.delete()
     }
 
     @Test func initializeWithLogPersistenceLoadsBuffer() async throws {

--- a/RadarSDKTests/RadarLogBufferTests.swift
+++ b/RadarSDKTests/RadarLogBufferTests.swift
@@ -10,14 +10,6 @@ import Testing
 
 @testable import RadarSDK
 
-private func waitUntil(timeout: TimeInterval = 5.0, _ check: () async -> Bool) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-        if await check() { return }
-        try? await Task.sleep(nanoseconds: 25_000_000)
-    }
-}
-
 private final class RequestCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var storedValue = 0
@@ -41,8 +33,25 @@ private final class RequestCounter: @unchecked Sendable {
     }
 }
 
-@Suite
+@Suite(.serialized)
 struct RadarLogBufferTests {
+
+    func makeLogsFile(_ name: String) -> String {
+        return "test/\(name)-\(UUID().uuidString).txt"
+    }
+
+    func removeLogsFile(_ logsFile: String) {
+        if let url = file(logsFile) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    func withTestPublishableKey(_ operation: () async -> Void) async {
+        let previousPublishableKey = RadarSettings.publishableKey
+        RadarSettings.publishableKey = "test-key"
+        defer { RadarSettings.publishableKey = previousPublishableKey }
+        await operation()
+    }
 
     func simpleLog(_ message: String) -> RadarLog {
         return RadarLog(level: .info, message: message, type: .none, createdAt: Date(), includeDate: true, battery: 1.0)
@@ -74,7 +83,8 @@ struct RadarLogBufferTests {
     }
 
     @Test func logsSavesToBuffer() async throws {
-        let logsFile = "test/logs1.txt"
+        let logsFile = makeLogsFile("logs1")
+        defer { removeLogsFile(logsFile) }
         let buffer = RadarLogBuffer(logsFile: logsFile, maxLogs: 10, keep: 10, logPersistence: true)
         try? await Task.sleep(nanoseconds: 1_000_000_000)
 
@@ -91,140 +101,101 @@ struct RadarLogBufferTests {
 
         let fileLogs = logsFrom(url: file)
         #expect(fileLogs.count == 3)
-
-        try? FileManager.default.removeItem(at: file)
     }
 
     @Test func flushingBufferResets() async throws {
-        RadarSettings.publishableKey = "test-key"
-        let session = MockURLSession()
-        let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
+        await withTestPublishableKey {
+            let session = MockURLSession()
+            let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
 
-        session.on("\(RadarSettings.host)/v1/logs", [:])
+            session.on("\(RadarSettings.host)/v1/logs", [:])
 
-        let logsFile = "test/logs2.txt"
-        let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: true, apiClient: client)
-        // buffer initialization is async, wait for logs to be loaded
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+            let logsFile = makeLogsFile("logs2")
+            defer { removeLogsFile(logsFile) }
+            let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: true, apiClient: client)
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
 
-        await buffer.log(simpleLog("test1"))
-        await buffer.log(simpleLog("test2"))
-        await buffer.log(simpleLog("test3"))
+            await buffer.log(simpleLog("test1"))
+            await buffer.log(simpleLog("test2"))
+            await buffer.log(simpleLog("test3"))
 
-        await buffer.flush()
+            await buffer.flush()
 
-        #expect(await buffer.logs.count == 0)
+            #expect(await buffer.logs.count == 0)
 
-        guard let file = file(logsFile) else {
-            Issue.record("logsFile should not produce invalid URL")
-            return
+            guard let file = file(logsFile) else {
+                Issue.record("logsFile should not produce invalid URL")
+                return
+            }
+
+            let fileLogs = logsFrom(url: file)
+            #expect(fileLogs.count == 0)
         }
-
-        let fileLogs = logsFrom(url: file)
-        #expect(fileLogs.count == 0)
-
-        try? FileManager.default.removeItem(at: file)
     }
 
     @Test func concurrentFlushesSendOneBatch() async throws {
-        RadarSettings.publishableKey = "test-key"
-        let session = MockURLSession()
-        let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
-        let requestCounter = RequestCounter()
+        await withTestPublishableKey {
+            let session = MockURLSession()
+            let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
+            let requestCounter = RequestCounter()
 
-        session.on(
-            { request in
-                requestCounter.increment()
-                Thread.sleep(forTimeInterval: 0.1)
-                return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
-            }, Data("{}".utf8))
+            session.on(
+                { request in
+                    requestCounter.increment()
+                    Thread.sleep(forTimeInterval: 0.1)
+                    return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+                }, Data("{}".utf8))
 
-        let buffer = RadarLogBuffer(logsFile: "test/logs-concurrent.txt", logPersistence: false, apiClient: client)
-        await buffer.log(simpleLog("test"))
+            let logsFile = makeLogsFile("logs-concurrent")
+            defer { removeLogsFile(logsFile) }
+            let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: false, apiClient: client)
+            await buffer.log(simpleLog("test"))
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { await buffer.flush() }
-            group.addTask { await buffer.flush() }
-            await group.waitForAll()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { await buffer.flush() }
+                group.addTask { await buffer.flush() }
+                await group.waitForAll()
+            }
+
+            #expect(requestCounter.value == 1)
+            #expect(await buffer.logs.count == 0)
         }
-
-        #expect(requestCounter.value == 1)
-        #expect(await buffer.logs.count == 0)
     }
 
     @Test func deduplicatesIdenticalLogsBeforeFlush() async throws {
-        RadarSettings.publishableKey = "test-key"
-        let session = MockURLSession()
-        let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
-        let capturedLogCount = RequestCounter()
+        await withTestPublishableKey {
+            let session = MockURLSession()
+            let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
+            let capturedLogCount = RequestCounter()
 
-        session.on(
-            { request in
-                if let body = request.httpBody,
-                    let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
-                    let logs = object["logs"] as? [[String: Any]]
-                {
-                    capturedLogCount.set(logs.count)
-                }
-                return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
-            }, Data("{}".utf8))
+            session.on(
+                { request in
+                    if let body = request.httpBody,
+                        let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                        let logs = object["logs"] as? [[String: Any]]
+                    {
+                        capturedLogCount.set(logs.count)
+                    }
+                    return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+                }, Data("{}".utf8))
 
-        let buffer = RadarLogBuffer(logsFile: "test/logs-deduplicate.txt", logPersistence: false, apiClient: client)
-        let log = simpleLog("duplicate")
-        await buffer.log(log)
-        await buffer.log(log)
+            let logsFile = makeLogsFile("logs-deduplicate")
+            defer { removeLogsFile(logsFile) }
+            let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: false, apiClient: client)
+            let log = simpleLog("duplicate")
+            await buffer.log(log)
+            await buffer.log(log)
 
-        await buffer.flush()
+            await buffer.flush()
 
-        #expect(capturedLogCount.value == 1)
-    }
-
-    @Test func deduplicatesPersistedLogsOnLoad() async throws {
-        let logsFile = "test/logs-deduplicate-persisted.txt"
-        let storage = RadarFileStorage(fileName: logsFile)
-        let log = simpleLog("duplicate")
-        let encodedLog = try! JSONEncoder().encode(log)  // swiftlint:disable:this force_try
-        let line = encodedLog + "\n".data(using: .utf8)!  // swiftlint:disable:this non_optional_string_data_conversion
-        storage?.write(data: line + line)
-
-        let buffer = RadarLogBuffer(logsFile: logsFile, logPersistence: true)
-        await waitUntil { await buffer.logs.count == 1 }
-
-        #expect(await buffer.logs.count == 1)
-        try? await Task.sleep(nanoseconds: 100_000_000)
-
-        if let file = file(logsFile) {
-            #expect(logsFrom(url: file).count == 1)
+            #expect(capturedLogCount.value == 1)
         }
-        storage?.delete()
-    }
-
-    @Test func initializeWithLogPersistenceLoadsBuffer() async throws {
-        let logsFile = "test/logs3.txt"
-        let file = RadarFileStorage(fileName: "\(logsFile)")
-
-        let logs = Data(
-            [
-                try! JSONEncoder().encode(simpleLog("persist1")),  // swiftlint:disable:this force_try
-                try! JSONEncoder().encode(simpleLog("persist2")),  // swiftlint:disable:this force_try
-                try! JSONEncoder().encode(simpleLog("persist3")),  // swiftlint:disable:this force_try
-            ].map { $0 + "\n".data(using: .utf8)! }.joined())  // swiftlint:disable:this non_optional_string_data_conversion
-
-        file?.write(data: logs)
-
-        let buffer = RadarLogBuffer(logsFile: logsFile, maxLogs: 10, keep: 5, logPersistence: true)
-
-        await waitUntil { await buffer.logs.count >= 3 }
-        try? await Task.sleep(nanoseconds: 200_000_000)
-        #expect(await buffer.logs.count == 3)
-
-        file?.delete()
     }
 
     @Test func purgesBufferWhenFilled() async throws {
-        let logsFile = "test/logs4.txt"
+        let logsFile = makeLogsFile("logs4")
+        defer { removeLogsFile(logsFile) }
         let buffer = RadarLogBuffer(logsFile: logsFile, maxLogs: 10, keep: 5, logPersistence: true)
-        // buffer initialization is async, wait for logs to be loaded
         try? await Task.sleep(nanoseconds: 1_000_000_000)
 
         guard let file = file(logsFile) else {
@@ -254,7 +225,5 @@ struct RadarLogBufferTests {
 
         let fileLogsAfterPurge = logsFrom(url: file)
         #expect(fileLogsAfterPurge.count == 5)
-
-        try? FileManager.default.removeItem(at: file)
     }
 }

--- a/RadarSDKTests/RadarLogBufferTests.swift
+++ b/RadarSDKTests/RadarLogBufferTests.swift
@@ -132,11 +132,12 @@ struct RadarLogBufferTests {
         let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
         let requestCounter = RequestCounter()
 
-        session.on({ request in
-            requestCounter.increment()
-            Thread.sleep(forTimeInterval: 0.1)
-            return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
-        }, Data("{}".utf8))
+        session.on(
+            { request in
+                requestCounter.increment()
+                Thread.sleep(forTimeInterval: 0.1)
+                return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+            }, Data("{}".utf8))
 
         let buffer = RadarLogBuffer(logsFile: "test/logs-concurrent.txt", logPersistence: false, apiClient: client)
         await buffer.log(simpleLog("test"))
@@ -157,15 +158,16 @@ struct RadarLogBufferTests {
         let client = RadarAPIClient(apiHelper: RadarAPIHelper(session: session))
         let capturedLogCount = RequestCounter()
 
-        session.on({ request in
-            if let body = request.httpBody,
-               let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
-               let logs = object["logs"] as? [[String: Any]]
-            {
-                capturedLogCount.set(logs.count)
-            }
-            return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
-        }, Data("{}".utf8))
+        session.on(
+            { request in
+                if let body = request.httpBody,
+                    let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                    let logs = object["logs"] as? [[String: Any]]
+                {
+                    capturedLogCount.set(logs.count)
+                }
+                return request.url?.absoluteString == "\(RadarSettings.host)/v1/logs"
+            }, Data("{}".utf8))
 
         let buffer = RadarLogBuffer(logsFile: "test/logs-deduplicate.txt", logPersistence: false, apiClient: client)
         let log = simpleLog("duplicate")


### PR DESCRIPTION
## Summary

This PR improves app-killed detection for active trips and adds searchable Example logs.

Lifecycle detection: 
- Adds an SDK-owned durable lifecycle marker at `radar-appLifecycleMarker`.
- Records the main app process before initialization and emits the existing `App terminating` message on the next main-app launch when the prior process ended unexpectedly while trip options were persisted.
- Keeps the marker set through backgrounding and does not clear it from `applicationWillTerminate` or `Radar.logTermination`, because iOS does not provide a reliable clean-process-exit callback for background-capable apps.
- Excludes app extensions from lifecycle tracking. Extensions share app-group defaults but run as separate processes; allowing them to update the marker creates false or duplicate `app_killed` issues.
- Makes lifecycle initialization idempotent within one process.

Log deduplication:
- Prevents duplicate log uploads by making log flushes single-flight, removing the redundant initialization flush, and preserving logs created during an in-flight upload.
- Deduplicates identical persisted and in-memory logs using their timestamp and full log identity before upload. This addresses replayed persistent logs with identical `createdAt` values.

Debugging improvements:
- Adds live text search to the Example Logs view across summaries and details while preserving kind filters, count, copy, share, expansion, and clear behavior.

The server's existing `App terminating` message contract is unchanged. 

## What we discovered

- A backgrounded iOS app can be removed without a termination callback, so a durable marker is required to detect the next unclean launch.
- The Example app embeds a Location Push extension that initializes Radar in a separate process. Both processes share app-group defaults, which caused extension initialization to look like an app termination. (calls Radar.initalize more than once)
- The log buffer can replay persistent records after a killed process. The same termination record and other messages can therefore appear more than once before upload.
- Initialization had two independent flush triggers. Because flushing was asynchronous, both could submit the same batch before the buffer was cleared.

## Test Plan

1. Configure the Example app with a valid publishable key and enable trip issue detection and SDK logging for the project.
2. Install the Example app with fresh app data, start a trip, background the app, swipe it away from the app switcher, relaunch it, and wait for initialization and log flushing to finish.
3. Refresh the dashboard Trips view, filter by **App killed**, and confirm the trip has exactly one `app_killed` issue.
4. Start another trip, background and foreground the app without swiping it away, and confirm no inferred `app_killed` issue is added.
5. Open the Example app's Debug tab, trigger actions that produce different log kinds, and confirm All, Actions, Events, Locations, and Logs still show their documented kinds.
6. Enter a mixed-case summary term in `Search logs`, clear it, enter only spaces or newlines, and confirm the selected kind filter's full list returns.
7. Expand an entry, search for a term present only in its detail, and confirm it remains visible. Search for a term absent from both fields and confirm **No matches** appears without a crash.
8. Use Copy and Share after searching and confirm the exported content contains only visible matches. Tap Clear and confirm the complete timeline is cleared and **Nothing yet** returns.
