### PR TITLE
FENCE-2966: Improve indoor survey upload failure handling

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate, UN
     /// (for example, "http://192.168.0.24:8081") for a physical device. Replace the example
     /// with your own address. Overrides the API + verified hosts on launch; leave blank to use
     /// the SDK defaults.
-    static let TARGET_HOST = "http://192.168.0.24:8081"
+    static let TARGET_HOST = ""
 
     let locationManager = CLLocationManager()
     var window: UIWindow?  // required for UIWindowSceneDelegate

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -15,10 +15,12 @@ import UserNotifications
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate, RadarVerifiedDelegate {
 
-    /// Point the SDK at a dev server by setting this to its address, e.g.
-    /// "http://192.168.1.10:8081" (device) or "http://localhost:8081" (simulator). Overrides
-    /// the API + verified hosts on launch; leave blank to use the SDK defaults.
-    static let TARGET_HOST = ""
+    /// Point the SDK at a dev server by setting this to its address.
+    /// Use "http://localhost:8081" for the Simulator, or your Mac's current LAN IP
+    /// (for example, "http://192.168.0.24:8081") for a physical device. Replace the example
+    /// with your own address. Overrides the API + verified hosts on launch; leave blank to use
+    /// the SDK defaults.
+    static let TARGET_HOST = "http://192.168.0.24:8081"
 
     let locationManager = CLLocationManager()
     var window: UIWindow?  // required for UIWindowSceneDelegate

--- a/Example/Example/SurveyApi.swift
+++ b/Example/Example/SurveyApi.swift
@@ -186,24 +186,25 @@ class SurveyApi {
             request.addTextField(named: "key", value: pathString)
             request.addDataField(named: "file", data: data, mimeType: "application/octet-stream")
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (responseData, response) = try await URLSession.shared.data(for: request)
 
             if let httpResponse = response as? HTTPURLResponse {
                 if (200...299).contains(httpResponse.statusCode) {
                     // The upload was successful and the server returned a success status code.
                     print("Upload successful! Status code: \(httpResponse.statusCode)")
-                    // Process 'data' if the server returned any response data.
                 } else {
                     // The upload completed, but the server returned an error status code.
                     print("Server error: Status code \(httpResponse.statusCode)")
-                    print("Server error: \(String(data: data, encoding: .utf8) ?? "<non-utf8 response>")")
+                    let responseBody = String(data: responseData, encoding: .utf8) ?? "<non-utf8 response>"
+                    print("Server error: \(responseBody)")
+                    return "S3 upload failed for \(data.count) bytes (HTTP \(httpResponse.statusCode)): \(responseBody)"
                 }
             } else {
                 // An unexpected scenario, potentially a non-HTTP response.
                 return "Unexpected response type."
             }
         } catch {
-            return "Failed to upload"
+            return "S3 upload failed for \(data.count) bytes: \(error.localizedDescription)"
         }
 
         // update status to completed

--- a/Example/Example/SurveyApi.swift
+++ b/Example/Example/SurveyApi.swift
@@ -99,6 +99,17 @@ extension URLSession {
 }
 
 class SurveyApi {
+    private static func httpFailureMessage(_ response: URLResponse, data: Data, operation: String) -> String? {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return "\(operation) returned an unexpected response."
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "<non-utf8 response>"
+            return "\(operation) failed (HTTP \(httpResponse.statusCode)): \(responseBody)"
+        }
+        return nil
+    }
+
     static func createSurvey(data: Data, publishableKey: String) async -> String {
         // Host follows the SDK (see Utils.radarHost); the publishable key is passed in from
         // SettingsStore.resolvedPublishableKey. Everything else comes from SurveyConfig.
@@ -130,7 +141,11 @@ class SurveyApi {
             request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
             // send the request
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let failure = Self.httpFailureMessage(response, data: data, operation: "Survey creation") {
+                return failure
+            }
 
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return "Failed to json serialize response"
@@ -139,7 +154,7 @@ class SurveyApi {
             print(json)
             surveyId = (json["indoorSurvey"] as? [String: Any])?["_id"] as? String
         } catch {
-            print("SurveyService: Failed: \(error.localizedDescription)")
+            return "SurveyService: Failed to create survey: \(error.localizedDescription)"
         }
 
         do {
@@ -155,7 +170,11 @@ class SurveyApi {
             request.httpMethod = "GET"
             request.setValue(publishableKey, forHTTPHeaderField: "Authorization")
 
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let failure = Self.httpFailureMessage(response, data: data, operation: "Upload URL request") {
+                return failure
+            }
 
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return "Failed to json serialize response"
@@ -164,7 +183,7 @@ class SurveyApi {
             print(json)
             uploadParams = json
         } catch {
-            print("SurveyService: Error getting asset upload url")
+            return "SurveyService: Error getting asset upload URL: \(error.localizedDescription)"
         }
 
         // upload to s3 via presigned url
@@ -227,7 +246,13 @@ class SurveyApi {
             ]
             request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
 
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (responseData, response) = try await URLSession.shared.data(for: request)
+
+            if let failure = Self.httpFailureMessage(response, data: responseData, operation: "Survey completion") {
+                return failure
+            }
+
+            let data = responseData
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return "failed to json serialize response"
             }

--- a/Example/Example/SurveyView.swift
+++ b/Example/Example/SurveyView.swift
@@ -127,6 +127,9 @@ struct SurveyView: View {
     @State
     var sending = false
 
+    @State
+    var uploadError: String? = nil
+
     let site: RadarSite? = {
         do {
             let dateFormatter = DateFormatter()
@@ -334,8 +337,8 @@ struct SurveyView: View {
                                 if sending {
                                     return
                                 }
-                                sending = true
                                 success = false
+                                uploadError = nil
                                 logStream.write(action: "Send data: \(collectedData.count) points of data with \(collectedBeaconList.count) beacons")
 
                                 // convert collected data into csv
@@ -349,13 +352,14 @@ struct SurveyView: View {
                                 }
 
                                 guard let data = csv.data(using: .utf8) else {
-                                    print("invalid conversion to Data")
+                                    uploadError = "Unable to encode survey data."
                                     return
                                 }
                                 guard let compressed = try? data.gzipped(level: .bestCompression) else {
-                                    print("unable to compress")
+                                    uploadError = "Unable to compress survey data."
                                     return
                                 }
+                                sending = true
                                 let publishableKey = settingsStore.resolvedPublishableKey
                                 Task {
                                     let status = await SurveyApi.createSurvey(data: compressed, publishableKey: publishableKey)
@@ -363,6 +367,7 @@ struct SurveyView: View {
                                     await MainActor.run {
                                         let uploadSucceeded = status == "Success"
                                         success = uploadSucceeded
+                                        uploadError = uploadSucceeded ? nil : status
                                         sending = false
                                         if uploadSucceeded {
                                             collectedBeaconList.removeAll()
@@ -379,6 +384,14 @@ struct SurveyView: View {
                                     .clipShape(Circle())
                             }
                             .disabled(sending)
+                        }
+                        if let uploadError {
+                            Text(uploadError)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(8)
+                                .frame(maxWidth: 200)
                         }
 
                     }.frame(width: 200)

--- a/Example/Example/SurveyView.swift
+++ b/Example/Example/SurveyView.swift
@@ -124,6 +124,9 @@ struct SurveyView: View {
     @State
     var success = false
 
+    @State
+    var sending = false
+
     let site: RadarSite? = {
         do {
             let dateFormatter = DateFormatter()
@@ -328,6 +331,11 @@ struct SurveyView: View {
                                     logStream.write(action: "Send data: no data collected")
                                     return
                                 }
+                                if sending {
+                                    return
+                                }
+                                sending = true
+                                success = false
                                 logStream.write(action: "Send data: \(collectedData.count) points of data with \(collectedBeaconList.count) beacons")
 
                                 // convert collected data into csv
@@ -352,19 +360,25 @@ struct SurveyView: View {
                                 Task {
                                     let status = await SurveyApi.createSurvey(data: compressed, publishableKey: publishableKey)
                                     logStream.write(action: "createSurvey: \(status)")
-                                    await MainActor.run { success = (status == "Success") }
+                                    await MainActor.run {
+                                        let uploadSucceeded = status == "Success"
+                                        success = uploadSucceeded
+                                        sending = false
+                                        if uploadSucceeded {
+                                            collectedBeaconList.removeAll()
+                                            collectedData.removeAll()
+                                        }
+                                    }
                                 }
-
-                                collectedBeaconList.removeAll()
-                                collectedData.removeAll()
                             }) {
-                                Text("Send data")
+                                Text(sending ? "Uploading..." : "Send data")
                                     .font(.title)
                                     .foregroundColor(.white)
                                     .frame(width: 80, height: 80)
-                                    .background(collectedData.isEmpty ? Color.gray : Color.green)
+                                    .background(collectedData.isEmpty || sending ? Color.gray : Color.green)
                                     .clipShape(Circle())
                             }
+                            .disabled(sending)
                         }
 
                     }.frame(width: 200)


### PR DESCRIPTION
## Summary

- Treat non-2xx responses from survey creation, upload-URL generation, S3 upload, and completion as failures.
- Show upload failures inline in the survey view with the HTTP status and server error.
- Preserve collected survey data after a failed upload and clear it only after a successful upload.
- Example app only changes

## What we learned

Indoor survey uploads happen in multiple steps: the app creates a survey, requests a presigned S3 upload, uploads directly to S3, and then marks the survey completed. The client previously ignored S3 errors and still sent the completion request, creating database records that appeared completed even though their S3 objects were missing.

The observed S3 response was `ExpiredToken`. This is a temporary AWS credential issued by the API, not the user’s local AWS profile and not a file-size rejection. Intermittent success was consistent with uploads reaching processes or pods with different credential state, or with a presigned upload expiring during a network interruption. The app now exposes the actual failure at the point of upload and keeps the collected data available for retry.

## Test Plan

- Open the indoor survey tool, collect data, tap Send, and confirm a successful upload reports success and clears the collected data.
- Force an upload failure by using an expired upload authorization or interrupting connectivity after the upload begins; confirm the error appears below the Send button and the collected data remains available.
- Restore connectivity and tap Send again; confirm the retry succeeds and the collected data is then cleared.
- Tap Send repeatedly while an upload is in progress; confirm the control prevents duplicate uploads.

NOTE: Successful surveys are blocked right now by https://github.com/radarlabs/server/pull/8460

<img width="585" height="1266" alt="Screenshot 2026-08-28 at 4 42 53 PM" src="https://github.com/user-attachments/assets/a9b95d07-3d9e-4cf7-960a-59d3a17f8d14" />
