### PR TITLE
FENCE-2804: Port location manager lifecycle methods to Swift

### DIFF
--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -63,6 +63,40 @@ final class RadarLocationManagerSwift: NSObject {
         RadarSettings.previousTrackingOptions = nil
     }
 
+    @objc(stopTrackingOnLocationManager:activityManager:)
+    static func stopTracking(locationManager: CLLocationManager, activityManager: AnyObject?) {
+        RadarSettings.tracking = false
+
+        RadarSwift.bridge?.stopIndoorTracking()
+
+        if RadarSettings.sdkConfiguration?.extendFlushReplays == true {
+            RadarLogger.shared.info("Flushing replays from stopTracking()", type: .sdkCall)
+            RadarSwift.bridge?.flushReplays()
+        }
+
+        let trackingOptions = RadarSettings.trackingOptions ?? .presetEfficient
+        if trackingOptions.useMotion || trackingOptions.usePressure {
+            locationManager.stopUpdatingHeading()
+
+            if let activityManager {
+                // This class is internal, so call its existing Objective-C selectors without exposing it to Swift.
+                if trackingOptions.usePressure {
+                    (activityManager as? NSObject)?.perform(#selector(RadarMotionProtocol.stopRelativeAltitudeUpdates))
+                    (activityManager as? NSObject)?.perform(#selector(RadarMotionProtocol.stopAbsoluteAltitudeUpdates))
+                }
+                if trackingOptions.useMotion {
+                    (activityManager as? NSObject)?.perform(#selector(RadarMotionProtocol.stopActivityUpdates))
+                }
+            }
+        }
+
+        trackingOptions.startTrackingAfter = nil
+        trackingOptions.stopTrackingAfter = nil
+        RadarSettings.trackingOptions = trackingOptions
+
+        RadarSwift.bridge?.updateTracking()
+    }
+
     @objc(matchBeaconIdsWithRanged:synced:)
     static func matchBeaconIds(ranged: [RadarBeacon], synced: [RadarBeacon]) -> [String] {
         var syncedMap: [String: String] = [:]

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -358,4 +358,10 @@ extension RadarLocationManagerSwift {
             RadarLogger.shared.debug("🦅 Removed remote tracking options | trackingOptions = \(Radar.getTrackingOptions())")
         }
     }
+
+    @objc(updateTrackingFromMeta:)
+    static func updateTrackingFromMeta(_ meta: RadarMeta?) {
+        applyRemoteTrackingOptions(meta)
+        RadarSwift.bridge?.updateTrackingFromInitialize()
+    }
 }

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -550,8 +550,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
 - (void)updateTrackingFromMeta:(RadarMeta *_Nullable)meta {
     if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        [RadarLocationManagerSwift applyRemoteTrackingOptions:meta];
-    } else if (meta) {
+        [RadarLocationManagerSwift updateTrackingFromMeta:meta];
+        return;
+    }
+
+    if (meta) {
         if ([meta trackingOptions]) {
             [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug
                                                message:[NSString stringWithFormat:@"Setting remote tracking options | trackingOptions = %@", meta.trackingOptions]];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -220,6 +220,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)stopTracking {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift stopTrackingOnLocationManager:self.locationManager activityManager:self.activityManager];
+        return;
+    }
+
     [RadarSettings setTracking:NO];
 
     // Stops indoor scanning

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable CLLocation *)effectiveLocationForLocationManager:(CLLocationManager *)locationManager;
 
 + (void)applyRemoteTrackingOptions:(nullable RadarMeta *)meta;
++ (void)updateTrackingFromMeta:(nullable RadarMeta *)meta;
 
 + (BOOL)shouldHandleRegionWithIdentifier:(NSString *)identifier action:(NSString *)action;
 

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)startTrackingWithOptions:(RadarTrackingOptions *)trackingOptions;
 
 + (void)restartPreviousTrackingOptions;
++ (void)stopTrackingOnLocationManager:(CLLocationManager *)locationManager
+                      activityManager:(nullable id)activityManager;
 
 + (NSArray<NSString *> *)matchBeaconIdsWithRanged:(NSArray<RadarBeacon *> *)rangedBeacons
                                            synced:(NSArray<RadarBeacon *> *)syncedBeacons;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -22,6 +22,7 @@
           completionHandler:(void (^_Nullable)(RadarStatus status, NSDictionary * _Nullable res))completionHandler;
 - (void)stopIndoorTracking;
 - (void)updateTracking;
+- (void)updateTrackingFromInitialize;
 - (void)logOpenedAppConversion;
 
 - (NSArray<NSString *> * _Nullable)geofenceIds;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -20,6 +20,8 @@
 - (void)flushReplays;
 - (void)flushReplaysRequest:(NSArray<NSDictionary *> * _Nonnull)replays
           completionHandler:(void (^_Nullable)(RadarStatus status, NSDictionary * _Nullable res))completionHandler;
+- (void)stopIndoorTracking;
+- (void)updateTracking;
 - (void)logOpenedAppConversion;
 
 - (NSArray<NSString *> * _Nullable)geofenceIds;

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -16,12 +16,21 @@
 #import "RadarUtils.h"
 #import "RadarDelegateHolder.h"
 #import "RadarAPIClient.h"
+#import "RadarIndoors.h"
 #import "RadarLocationManager.h"
 
 @implementation RadarSwiftBridge
 
 - (void)flushReplays {
     [[RadarReplayBuffer sharedInstance] flushReplaysWithCompletionHandler:nil completionHandler:nil];
+}
+
+- (void)stopIndoorTracking {
+    [[RadarIndoors shared] stopWithCompletionHandler:^{}];
+}
+
+- (void)updateTracking {
+    [[RadarLocationManager sharedInstance] updateTracking];
 }
 
 - (void)logOpenedAppConversion {

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -33,6 +33,10 @@
     [[RadarLocationManager sharedInstance] updateTracking];
 }
 
+- (void)updateTrackingFromInitialize {
+    [[RadarLocationManager sharedInstance] updateTrackingFromInitialize];
+}
+
 - (void)logOpenedAppConversion {
     [Radar logOpenedAppConversion];
 }

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -100,10 +100,6 @@
     [[RadarLocationManager sharedInstance] handleLocation:location source:source];
 }
 
-- (void)updateTracking {
-    [[RadarLocationManager sharedInstance] updateTracking];
-}
-
 - (RadarUser * _Nullable)radarUser {
     return [RadarState radarUser];
 }

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -16,6 +16,7 @@ protocol RadarSwiftBridgeProtocol {
     func flushReplaysRequest(_ replays: [[AnyHashable: Any]], completionHandler: ((RadarStatus, [AnyHashable: Any]?) -> Void)?)
     func stopIndoorTracking()
     func updateTracking()
+    func updateTrackingFromInitialize()
     func logOpenedAppConversion()
     func geofenceIds() -> [String]?
     func beaconIds() -> [String]?

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -14,6 +14,8 @@ import Foundation
 protocol RadarSwiftBridgeProtocol {
     func flushReplays()
     func flushReplaysRequest(_ replays: [[AnyHashable: Any]], completionHandler: ((RadarStatus, [AnyHashable: Any]?) -> Void)?)
+    func stopIndoorTracking()
+    func updateTracking()
     func logOpenedAppConversion()
     func geofenceIds() -> [String]?
     func beaconIds() -> [String]?

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -15,7 +15,6 @@ protocol RadarSwiftBridgeProtocol {
     func flushReplays()
     func flushReplaysRequest(_ replays: [[AnyHashable: Any]], completionHandler: ((RadarStatus, [AnyHashable: Any]?) -> Void)?)
     func stopIndoorTracking()
-    func updateTracking()
     func updateTrackingFromInitialize()
     func logOpenedAppConversion()
     func geofenceIds() -> [String]?

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -14,6 +14,10 @@ import UserNotifications
 final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked Sendable {
     var flushStatus: RadarStatus = .success
     private(set) var lastFlushedReplays: [[AnyHashable: Any]]?
+    private(set) var flushReplaysCallCount = 0
+    private(set) var stopIndoorTrackingCallCount = 0
+    private(set) var updateTrackingCallCount = 0
+    private(set) var callOrder: [String] = []
 
     func flushReplaysRequest(
         _ replays: [[AnyHashable: Any]],
@@ -23,7 +27,21 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
         completionHandler?(flushStatus, nil)
     }
 
-    func flushReplays() {}
+    func flushReplays() {
+        flushReplaysCallCount += 1
+        callOrder.append("flushReplays")
+    }
+
+    func stopIndoorTracking() {
+        stopIndoorTrackingCallCount += 1
+        callOrder.append("stopIndoorTracking")
+    }
+
+    func updateTracking() {
+        updateTrackingCallCount += 1
+        callOrder.append("updateTracking")
+    }
+
     func logOpenedAppConversion() {}
     func geofenceIds() -> [String]? { nil }
     func beaconIds() -> [String]? { nil }

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -75,8 +75,6 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
         lastHandledLocation = location
         lastHandledSource = source
     }
-    private(set) var updateTrackingCallCount = 0
-    func updateTracking() { updateTrackingCallCount += 1 }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?
     func didFail(status: RadarStatus) { lastFailStatus = status }

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -17,6 +17,7 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     private(set) var flushReplaysCallCount = 0
     private(set) var stopIndoorTrackingCallCount = 0
     private(set) var updateTrackingCallCount = 0
+    private(set) var updateTrackingFromInitializeCallCount = 0
     private(set) var callOrder: [String] = []
 
     func flushReplaysRequest(
@@ -40,6 +41,11 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     func updateTracking() {
         updateTrackingCallCount += 1
         callOrder.append("updateTracking")
+    }
+
+    func updateTrackingFromInitialize() {
+        updateTrackingFromInitializeCallCount += 1
+        callOrder.append("updateTrackingFromInitialize")
     }
 
     func logOpenedAppConversion() {}

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -11,9 +11,140 @@ import Testing
 
 @testable import RadarSDK
 
+final class TrackingRadarActivityManager: RadarActivityManager, @unchecked Sendable {
+    private(set) var stopActivityUpdatesCallCount = 0
+    private(set) var stopRelativeAltitudeUpdatesCallCount = 0
+    private(set) var stopAbsoluteAltitudeUpdatesCallCount = 0
+
+    override func stopActivityUpdates() {
+        stopActivityUpdatesCallCount += 1
+    }
+
+    override func stopRelativeAltitudeUpdates() {
+        stopRelativeAltitudeUpdatesCallCount += 1
+    }
+
+    override func stopAbsoluteAltitudeUpdates() {
+        stopAbsoluteAltitudeUpdatesCallCount += 1
+    }
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftLifecycleTests {
+
+        // MARK: - stopTracking
+
+        @Test("stopTracking clears tracking state without stopping motion services when disabled")
+        func stopTrackingClearsStateWithoutMotionServices() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.tracking = true
+            let options = RadarTrackingOptions.presetEfficient
+            options.startTrackingAfter = Date()
+            options.stopTrackingAfter = Date()
+            RadarSettings.trackingOptions = options
+
+            let locationManager = TrackingCLLocationManager()
+            let activityManager = TrackingRadarActivityManager()
+            RadarLocationManagerSwift.stopTracking(
+                locationManager: locationManager,
+                activityManager: activityManager
+            )
+
+            #expect(RadarSettings.tracking == false)
+            #expect(RadarSettings.trackingOptions.startTrackingAfter == nil)
+            #expect(RadarSettings.trackingOptions.stopTrackingAfter == nil)
+            #expect(locationManager.stopUpdatingHeadingCallCount == 0)
+            #expect(activityManager.stopActivityUpdatesCallCount == 0)
+            #expect(activityManager.stopRelativeAltitudeUpdatesCallCount == 0)
+            #expect(activityManager.stopAbsoluteAltitudeUpdatesCallCount == 0)
+            #expect(bridge.callOrder == ["stopIndoorTracking", "updateTracking"])
+        }
+
+        @Test("stopTracking stops activity and heading updates when motion is enabled")
+        func stopTrackingStopsMotionUpdates() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let options = RadarTrackingOptions.presetEfficient
+            options.useMotion = true
+            RadarSettings.trackingOptions = options
+            let locationManager = TrackingCLLocationManager()
+            let activityManager = TrackingRadarActivityManager()
+
+            RadarLocationManagerSwift.stopTracking(
+                locationManager: locationManager,
+                activityManager: activityManager
+            )
+
+            #expect(locationManager.stopUpdatingHeadingCallCount == 1)
+            #expect(activityManager.stopActivityUpdatesCallCount == 1)
+            #expect(activityManager.stopRelativeAltitudeUpdatesCallCount == 0)
+            #expect(activityManager.stopAbsoluteAltitudeUpdatesCallCount == 0)
+        }
+
+        @Test("stopTracking stops altitude and heading updates when pressure is enabled")
+        func stopTrackingStopsPressureUpdates() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let options = RadarTrackingOptions.presetEfficient
+            options.usePressure = true
+            RadarSettings.trackingOptions = options
+            let locationManager = TrackingCLLocationManager()
+            let activityManager = TrackingRadarActivityManager()
+
+            RadarLocationManagerSwift.stopTracking(
+                locationManager: locationManager,
+                activityManager: activityManager
+            )
+
+            #expect(locationManager.stopUpdatingHeadingCallCount == 1)
+            #expect(activityManager.stopActivityUpdatesCallCount == 0)
+            #expect(activityManager.stopRelativeAltitudeUpdatesCallCount == 1)
+            #expect(activityManager.stopAbsoluteAltitudeUpdatesCallCount == 1)
+        }
+
+        @Test("stopTracking flushes replays before updating tracking when configured")
+        func stopTrackingFlushesReplaysBeforeUpdatingTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["extendFlushReplays": true])
+            RadarLocationManagerSwift.stopTracking(
+                locationManager: TrackingCLLocationManager(),
+                activityManager: nil
+            )
+
+            #expect(bridge.flushReplaysCallCount == 1)
+            #expect(bridge.callOrder == ["stopIndoorTracking", "flushReplays", "updateTracking"])
+        }
 
         // MARK: - shutDown
 

--- a/RadarSDKTests/RadarLocationManagerSwiftRTOTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftRTOTests.swift
@@ -14,6 +14,70 @@ extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftRTOTests {
 
+        // MARK: - updateTrackingFromMeta
+
+        @Test("updateTrackingFromMeta stores remote options and updates initialization tracking")
+        func updateTrackingFromMetaStoresOptionsAndUpdatesInitializationTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let options = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+            let meta = RadarMeta.from(dictionary: ["trackingOptions": options.dictionaryValue()])
+
+            RadarLocationManagerSwift.updateTrackingFromMeta(meta)
+
+            #expect(RadarSettings.remoteTrackingOptions == options)
+            #expect(bridge.updateTrackingFromInitializeCallCount == 1)
+            #expect(bridge.callOrder == ["updateTrackingFromInitialize"])
+        }
+
+        @Test("updateTrackingFromMeta clears remote options when metadata has none")
+        func updateTrackingFromMetaClearsOptionsAndUpdatesInitializationTracking() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.remoteTrackingOptions = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+
+            RadarLocationManagerSwift.updateTrackingFromMeta(RadarMeta.from(dictionary: [:]))
+
+            #expect(RadarSettings.remoteTrackingOptions == nil)
+            #expect(bridge.updateTrackingFromInitializeCallCount == 1)
+            #expect(bridge.callOrder == ["updateTrackingFromInitialize"])
+        }
+
+        @Test("updateTrackingFromMeta leaves remote options unchanged for nil metadata")
+        func updateTrackingFromMetaLeavesOptionsUnchangedForNilMetadata() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let options = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+            RadarSettings.remoteTrackingOptions = options
+
+            RadarLocationManagerSwift.updateTrackingFromMeta(nil)
+
+            #expect(RadarSettings.remoteTrackingOptions == options)
+            #expect(bridge.updateTrackingFromInitializeCallCount == 1)
+            #expect(bridge.callOrder == ["updateTrackingFromInitialize"])
+        }
+
         // MARK: - applyRemoteTrackingOptions
 
         @Test("Stores the remote tracking options carried by a meta with trackingOptions set")

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -62,6 +62,54 @@ extension RadarSerializedTests {
                 #expect(bridge.updateTrackingCallCount == 0)
                 #expect(RadarSettings.tracking == false)
             }
+        // MARK: - stopTracking — public method routing
+
+        @Test("Public stopTracking routes to the Swift twin when useSwiftLocationManager is enabled")
+        func publicStopTrackingRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            let originalLocationManager = manager.locationManager
+            let originalActivityManager = manager.activityManager
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                manager.locationManager = originalLocationManager
+                manager.activityManager = originalActivityManager
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+            RadarSettings.tracking = true
+            manager.locationManager = TrackingCLLocationManager()
+            manager.activityManager = TrackingRadarActivityManager()
+
+            manager.stopTracking()
+
+            #expect(RadarSettings.tracking == false)
+            #expect(bridge.callOrder == ["stopIndoorTracking", "updateTracking"])
+        }
+
+        @Test("Public stopTracking keeps the Objective-C body when useSwiftLocationManager is disabled")
+        func publicStopTrackingUsesObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+            RadarSettings.tracking = true
+
+            manager.stopTracking()
+
+            #expect(RadarSettings.tracking == false)
+            #expect(bridge.callOrder.isEmpty)
         }
 
         // MARK: - restartPreviousTrackingOptions — Swift twin

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -62,6 +62,57 @@ extension RadarSerializedTests {
                 #expect(bridge.updateTrackingCallCount == 0)
                 #expect(RadarSettings.tracking == false)
             }
+        // MARK: - updateTrackingFromMeta — public method routing
+
+        @Test("Public updateTrackingFromMeta routes to the Swift twin when useSwiftLocationManager is enabled")
+        func publicUpdateTrackingFromMetaRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+            let options = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+            let meta = RadarMeta.from(dictionary: ["trackingOptions": options.dictionaryValue()])!
+
+            RadarLocationManager.sharedInstance().perform(
+                #selector(RadarLocationManagerSwift.updateTrackingFromMeta(_:)),
+                with: meta
+            )
+
+            #expect(RadarSettings.remoteTrackingOptions == options)
+            #expect(bridge.updateTrackingFromInitializeCallCount == 1)
+            #expect(bridge.callOrder == ["updateTrackingFromInitialize"])
+        }
+
+        @Test("Public updateTrackingFromMeta keeps the Objective-C body when useSwiftLocationManager is disabled")
+        func publicUpdateTrackingFromMetaUsesObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+            let options = RadarLocationManagerSwiftTestHelpers.trackingOptions(beacons: true)
+            let meta = RadarMeta.from(dictionary: ["trackingOptions": options.dictionaryValue()])!
+
+            RadarLocationManager.sharedInstance().perform(
+                #selector(RadarLocationManagerSwift.updateTrackingFromMeta(_:)),
+                with: meta
+            )
+
+            #expect(RadarSettings.remoteTrackingOptions == options)
+            #expect(bridge.callOrder.isEmpty)
+        }
+
         // MARK: - stopTracking — public method routing
 
         @Test("Public stopTracking routes to the Swift twin when useSwiftLocationManager is enabled")

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -62,6 +62,8 @@ extension RadarSerializedTests {
                 #expect(bridge.updateTrackingCallCount == 0)
                 #expect(RadarSettings.tracking == false)
             }
+        }
+
         // MARK: - updateTrackingFromMeta — public method routing
 
         @Test("Public updateTrackingFromMeta routes to the Swift twin when useSwiftLocationManager is enabled")

--- a/RadarSDKTests/TrackingCLLocationManager.swift
+++ b/RadarSDKTests/TrackingCLLocationManager.swift
@@ -18,6 +18,7 @@ final class TrackingCLLocationManager: CLLocationManager, @unchecked Sendable {
     private(set) var trackedRegions = Set<CLRegion>()
     private(set) var requestStateRegions: [CLRegion] = []
     private(set) var stopUpdatingLocationCallCount = 0
+    private(set) var stopUpdatingHeadingCallCount = 0
     private(set) var requestLocationCallCount = 0
     var mockLocation: CLLocation?
 
@@ -38,6 +39,10 @@ final class TrackingCLLocationManager: CLLocationManager, @unchecked Sendable {
 
     override func stopUpdatingLocation() {
         stopUpdatingLocationCallCount += 1
+    }
+
+    override func stopUpdatingHeading() {
+        stopUpdatingHeadingCallCount += 1
     }
 
     override func requestLocation() {


### PR DESCRIPTION
## Summary

- Add a behavior-preserving Swift twin for `RadarLocationManager.stopTracking()`.
- Add a behavior-preserving Swift twin for `updateTrackingFromMeta:` that preserves the initialization-specific tracking update path.
- Route to Swift when `useSwiftLocationManager` is enabled while retaining the Objective-C fallback.
- Add bridge seams for indoor shutdown, initialization tracking updates, and regular `updateTracking`, plus lifecycle and routing coverage.

## Test Plan

1. Initialize the SDK with `useSwiftLocationManager` enabled and motion and pressure disabled.
2. Start tracking, configure delayed tracking dates, call `Radar.stopTracking()`, and confirm tracking is disabled and the delayed dates are cleared.
3. Enable motion tracking, call `Radar.stopTracking()`, and confirm heading and activity updates stop.
4. Enable pressure tracking, call `Radar.stopTracking()`, and confirm heading and relative and absolute altitude updates stop.
5. Enable replay flushing and confirm stopping tracking flushes pending replays.
6. Enable indoor tracking, stop tracking, and confirm indoor scanning stops.
7. Enable `useSwiftLocationManager`, load configuration metadata with tracking options, and confirm the remote tracking options are applied and tracking refreshes.
8. Load configuration metadata without tracking options and confirm previously stored remote options are cleared while tracking still refreshes.
9. Repeat the metadata flow with nil metadata and confirm existing remote options remain unchanged.
10. Disable `useSwiftLocationManager`, repeat the stop-tracking and metadata flows, and confirm the existing Objective-C behavior remains unchanged.
