### PR TITLE
FENCE-2804: Port start and stop updates to Swift

### DIFF
--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -46,7 +46,7 @@ private final class RadarLocationManagerSwiftHostBox: @unchecked Sendable {
 }
 
 @objc(RadarLocationManagerSwift)
-final class RadarLocationManagerSwift: NSObject { // swiftlint:disable:this type_body_length
+final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this type_body_length
 
     // Mirror of the identifier prefix constants in RadarLocationManager.m. Kept in sync by
     // hand until that file is fully ported.

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -23,6 +23,9 @@ import Foundation
 // `RadarSDK-Swift.h`. Methods that need access to the manager's CLLocationManager
 // receive it as an explicit argument. Timer methods use the host protocol below because
 // they also need private timer state and shutdown scheduling.
+// This protocol is a temporary migration seam. Remove it when RadarLocationManager is
+// fully ported to Swift and the timer state no longer needs an Objective-C host.
+// `@objc public` keeps the seam visible to the generated Objective-C header; it is not a new SDK API.
 @objc public protocol RadarLocationManagerSwiftHost: AnyObject {
     func started() -> Bool
     func setStarted(_ started: Bool)

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -8,6 +8,9 @@
 import CoreLocation
 import Foundation
 
+// Keep the ObjC-facing twins together while the location manager migration is in progress.
+// swiftlint:disable file_length
+
 // Swift port of `RadarLocationManager` methods, added one at a time as the class
 // migrates from Objective-C. Each method here has a twin in `RadarLocationManager.m`
 // that dispatches to it when `useSwiftLocationManager` is enabled. When a method's
@@ -18,10 +21,32 @@ import Foundation
 // auto-synthesized Swift module, so we cannot extend `RadarLocationManager` from Swift.
 // Static methods on this class are called from `RadarLocationManager.m` via
 // `RadarSDK-Swift.h`. Methods that need access to the manager's CLLocationManager
-// receive it as an explicit argument — once the porting cluster grows enough to share
-// more instance state (timer, completion handlers), we can introduce a host protocol.
+// receive it as an explicit argument. Timer methods use the host protocol below because
+// they also need private timer state and shutdown scheduling.
+@objc public protocol RadarLocationManagerSwiftHost: AnyObject {
+    func started() -> Bool
+    func setStarted(_ started: Bool)
+    func startedInterval() -> Int32
+    func setStartedInterval(_ interval: Int32)
+    func sending() -> Bool
+    func timer() -> Timer?
+    func setTimer(_ timer: Timer?)
+
+    func cancelPendingShutdown()
+    func requestLocation()
+    func scheduleShutdown(after delay: TimeInterval)
+}
+
+private final class RadarLocationManagerSwiftHostBox: @unchecked Sendable {
+    let host: RadarLocationManagerSwiftHost
+
+    init(host: RadarLocationManagerSwiftHost) {
+        self.host = host
+    }
+}
+
 @objc(RadarLocationManagerSwift)
-final class RadarLocationManagerSwift: NSObject {
+final class RadarLocationManagerSwift: NSObject { // swiftlint:disable:this type_body_length
 
     // Mirror of the identifier prefix constants in RadarLocationManager.m. Kept in sync by
     // hand until that file is fully ported.
@@ -95,6 +120,63 @@ final class RadarLocationManagerSwift: NSObject {
         RadarSettings.trackingOptions = trackingOptions
 
         RadarSwift.bridge?.updateTracking()
+    }
+
+    @objc(startUpdatesWithHost:locationManager:lowPowerLocationManager:interval:blueBar:)
+    static func startUpdates(
+        host: RadarLocationManagerSwiftHost,
+        locationManager: CLLocationManager,
+        lowPowerLocationManager: CLLocationManager,
+        interval: Int32,
+        blueBar: Bool
+    ) {
+        if !host.started() || interval != host.startedInterval() {
+            RadarLogger.shared.debug("🦅 Starting timer | interval = \(interval)")
+
+            host.cancelPendingShutdown()
+            host.timer()?.invalidate()
+
+            let hostBox = RadarLocationManagerSwiftHostBox(host: host)
+            host.setTimer(
+                Timer.scheduledTimer(withTimeInterval: TimeInterval(interval), repeats: true) { [hostBox] _ in
+                    RadarLogger.shared.debug("🦅 Timer fired")
+                    hostBox.host.requestLocation()
+                })
+
+            lowPowerLocationManager.startUpdatingLocation()
+            if blueBar && interval <= 5 {
+                locationManager.startUpdatingLocation()
+            } else {
+                locationManager.stopUpdatingLocation()
+            }
+
+            host.setStarted(true)
+            host.setStartedInterval(interval)
+        } else {
+            RadarLogger.shared.debug("🦅 Already started timer")
+        }
+    }
+
+    @objc(stopUpdatesWithHost:locationManager:)
+    static func stopUpdates(host: RadarLocationManagerSwiftHost, locationManager: CLLocationManager) {
+        guard host.timer() != nil else {
+            return
+        }
+
+        RadarLogger.shared.debug("🦅 Stopping timer")
+
+        host.timer()?.invalidate()
+        locationManager.stopUpdatingLocation()
+
+        host.setStarted(false)
+        host.setStartedInterval(0)
+
+        if !host.sending() {
+            let delay: TimeInterval = RadarSettings.tracking ? 10 : 0
+
+            RadarLogger.shared.debug("🦅 Scheduling shutdown")
+            host.scheduleShutdown(after: delay)
+        }
     }
 
     @objc(matchBeaconIdsWithRanged:synced:)

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -58,6 +58,8 @@ final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this typ
     private static let syncGeofenceIdentifierPrefix = "radar_geofence_"
     private static let syncBeaconIdentifierPrefix = "radar_beacon_"
     private static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
+    private static let trackingShutdownDelay: TimeInterval = 10
+    private static let immediateShutdownDelay: TimeInterval = 0
     nonisolated(unsafe) static var permissionsHelper: RadarPermissionsHelping = RadarPermissionsHelperSwift()
 
     @objc(startTrackingWithOptions:)
@@ -162,20 +164,20 @@ final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this typ
 
     @objc(stopUpdatesWithHost:locationManager:)
     static func stopUpdates(host: RadarLocationManagerSwiftHost, locationManager: CLLocationManager) {
-        guard host.timer() != nil else {
+        guard let timer = host.timer() else {
             return
         }
 
         RadarLogger.shared.debug("🦅 Stopping timer")
 
-        host.timer()?.invalidate()
+        timer.invalidate()
         locationManager.stopUpdatingLocation()
 
         host.setStarted(false)
         host.setStartedInterval(0)
 
         if !host.sending() {
-            let delay: TimeInterval = RadarSettings.tracking ? 10 : 0
+            let delay = RadarSettings.tracking ? Self.trackingShutdownDelay : Self.immediateShutdownDelay
 
             RadarLogger.shared.debug("🦅 Scheduling shutdown")
             host.scheduleShutdown(after: delay)

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -35,7 +35,7 @@
 #import "RadarSDK-Swift.h"
 #endif
 
-@interface RadarLocationManager ()
+@interface RadarLocationManager () <RadarLocationManagerSwiftHost>
 
 /**
  `YES` if `startUpdates()` has started the `timer` for location updates.
@@ -260,6 +260,15 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)startUpdates:(int)interval blueBar:(BOOL)blueBar {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift startUpdatesWithHost:self
+                                       locationManager:self.locationManager
+                                lowPowerLocationManager:self.lowPowerLocationManager
+                                               interval:interval
+                                                blueBar:blueBar];
+        return;
+    }
+
     if (!self.started || interval != self.startedInterval) {
         [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:[NSString stringWithFormat:@"Starting timer | interval = %d", interval]];
 
@@ -292,6 +301,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)stopUpdates {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift stopUpdatesWithHost:self locationManager:self.locationManager];
+        return;
+    }
+
     if (!self.timer) {
         return;
     }
@@ -312,6 +326,14 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
         [self performSelector:@selector(shutDown) withObject:nil afterDelay:delay];
     }
+}
+
+- (void)cancelPendingShutdown {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(shutDown) object:nil];
+}
+
+- (void)scheduleShutdownAfter:(NSTimeInterval)delay {
+    [self performSelector:@selector(shutDown) withObject:nil afterDelay:delay];
 }
 
 - (void)shutDown {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -35,6 +35,9 @@
 #import "RadarSDK-Swift.h"
 #endif
 
+// Temporary migration seam for the Swift timer twins. The manager keeps ownership of its
+// private state while Swift runs the timer logic. Remove this conformance when the manager
+// is fully ported.
 @interface RadarLocationManager () <RadarLocationManagerSwiftHost>
 
 /**
@@ -328,6 +331,8 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
     }
 }
 
+// Temporary callbacks used by the Swift timer twin. They keep shutdown scheduling in the
+// existing Objective-C manager until the manager is fully ported.
 - (void)cancelPendingShutdown {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(shutDown) object:nil];
 }

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -18,6 +18,8 @@
 #import "RadarMeta.h"
 #import "RadarTrackingOptions.h"
 
+@protocol RadarLocationManagerSwiftHost;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RadarLocationManagerSwift : NSObject
@@ -30,6 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)restartPreviousTrackingOptions;
 + (void)stopTrackingOnLocationManager:(CLLocationManager *)locationManager
                       activityManager:(nullable id)activityManager;
++ (void)startUpdatesWithHost:(id<RadarLocationManagerSwiftHost>)host
+              locationManager:(CLLocationManager *)locationManager
+       lowPowerLocationManager:(CLLocationManager *)lowPowerLocationManager
+                      interval:(int)interval
+                       blueBar:(BOOL)blueBar;
++ (void)stopUpdatesWithHost:(id<RadarLocationManagerSwiftHost>)host
+             locationManager:(CLLocationManager *)locationManager;
 
 + (NSArray<NSString *> *)matchBeaconIdsWithRanged:(NSArray<RadarBeacon *> *)rangedBeacons
                                            synced:(NSArray<RadarBeacon *> *)syncedBeacons;

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -70,7 +70,7 @@ final class TrackingRadarLocationManagerHost: NSObject, RadarLocationManagerSwif
 
 extension RadarSerializedTests {
     @Suite(.serialized)
-    actor RadarLocationManagerSwiftLifecycleTests { // swiftlint:disable:this type_body_length
+    actor RadarLocationManagerSwiftLifecycleTests {  // swiftlint:disable:this type_body_length
 
         // MARK: - startUpdates
 

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -11,6 +11,9 @@ import Testing
 
 @testable import RadarSDK
 
+// Keep lifecycle seam tests together so the direct twins and their shared host stay easy to compare.
+// swiftlint:disable file_length
+
 final class TrackingRadarActivityManager: RadarActivityManager, @unchecked Sendable {
     private(set) var stopActivityUpdatesCallCount = 0
     private(set) var stopRelativeAltitudeUpdatesCallCount = 0
@@ -29,9 +32,238 @@ final class TrackingRadarActivityManager: RadarActivityManager, @unchecked Senda
     }
 }
 
+final class TrackingRadarLocationManagerHost: NSObject, RadarLocationManagerSwiftHost, @unchecked Sendable {
+    private var startedValue = false
+    private var startedIntervalValue: Int32 = 0
+    var sendingValue = false
+    private var timerValue: Timer?
+    private(set) var cancelPendingShutdownCallCount = 0
+    private(set) var scheduledShutdownDelays: [TimeInterval] = []
+    private(set) var requestLocationCallCount = 0
+
+    func started() -> Bool { startedValue }
+
+    func setStarted(_ started: Bool) { startedValue = started }
+
+    func startedInterval() -> Int32 { startedIntervalValue }
+
+    func setStartedInterval(_ interval: Int32) { startedIntervalValue = interval }
+
+    func sending() -> Bool { sendingValue }
+
+    func timer() -> Timer? { timerValue }
+
+    func setTimer(_ timer: Timer?) { timerValue = timer }
+
+    func cancelPendingShutdown() {
+        cancelPendingShutdownCallCount += 1
+    }
+
+    func requestLocation() {
+        requestLocationCallCount += 1
+    }
+
+    func scheduleShutdown(after delay: TimeInterval) {
+        scheduledShutdownDelays.append(delay)
+    }
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
-    actor RadarLocationManagerSwiftLifecycleTests {
+    actor RadarLocationManagerSwiftLifecycleTests { // swiftlint:disable:this type_body_length
+
+        // MARK: - startUpdates
+
+        @Test("startUpdates starts low-power updates and stops primary updates without the blue bar")
+        func startUpdatesUsesLowPowerManagerWithoutBlueBar() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+            defer { host.timer()?.invalidate() }
+
+            #expect(host.started())
+            #expect(host.startedInterval() == 10)
+            #expect(host.timer() != nil)
+            #expect(host.cancelPendingShutdownCallCount == 1)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 1)
+            #expect(locationManager.startUpdatingLocationCallCount == 0)
+            #expect(locationManager.stopUpdatingLocationCallCount == 1)
+
+            host.timer()?.fire()
+            #expect(host.requestLocationCallCount == 1)
+        }
+
+        @Test("startUpdates starts primary updates for a short blue-bar interval")
+        func startUpdatesStartsPrimaryManagerForShortBlueBarInterval() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 5,
+                blueBar: true
+            )
+            defer { host.timer()?.invalidate() }
+
+            #expect(locationManager.startUpdatingLocationCallCount == 1)
+            #expect(locationManager.stopUpdatingLocationCallCount == 0)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 1)
+        }
+
+        @Test("startUpdates stops primary updates for a long blue-bar interval")
+        func startUpdatesStopsPrimaryManagerForLongBlueBarInterval() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 6,
+                blueBar: true
+            )
+            defer { host.timer()?.invalidate() }
+
+            #expect(locationManager.startUpdatingLocationCallCount == 0)
+            #expect(locationManager.stopUpdatingLocationCallCount == 1)
+        }
+
+        @Test("startUpdates does not replace a timer when the interval is unchanged")
+        func startUpdatesSkipsUnchangedInterval() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+            let originalTimer = host.timer()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+            defer { host.timer()?.invalidate() }
+
+            #expect(host.timer() === originalTimer)
+            #expect(host.cancelPendingShutdownCallCount == 1)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 1)
+        }
+
+        @Test("startUpdates replaces the timer when the interval changes")
+        func startUpdatesReplacesChangedInterval() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+            let originalTimer = host.timer()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 20,
+                blueBar: false
+            )
+            defer { host.timer()?.invalidate() }
+
+            #expect(originalTimer?.isValid == false)
+            #expect(host.timer() !== originalTimer)
+            #expect(host.startedInterval() == 20)
+            #expect(host.cancelPendingShutdownCallCount == 2)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 2)
+        }
+
+        // MARK: - stopUpdates
+
+        @Test("stopUpdates is a no-op when no timer exists")
+        func stopUpdatesDoesNothingWithoutTimer() {
+            let host = TrackingRadarLocationManagerHost()
+            host.setStarted(true)
+            host.setStartedInterval(10)
+            let locationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.stopUpdates(host: host, locationManager: locationManager)
+
+            #expect(host.started())
+            #expect(host.startedInterval() == 10)
+            #expect(locationManager.stopUpdatingLocationCallCount == 0)
+            #expect(host.scheduledShutdownDelays.isEmpty)
+        }
+
+        @Test("stopUpdates invalidates the timer, clears state, and schedules a tracked shutdown")
+        func stopUpdatesSchedulesTrackedShutdown() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+            RadarSettings.tracking = true
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+            let timer = host.timer()
+
+            RadarLocationManagerSwift.stopUpdates(host: host, locationManager: locationManager)
+            defer { host.timer()?.invalidate() }
+
+            #expect(timer?.isValid == false)
+            #expect(host.timer() === timer)
+            #expect(host.started() == false)
+            #expect(host.startedInterval() == 0)
+            #expect(locationManager.stopUpdatingLocationCallCount == 2)
+            #expect(host.scheduledShutdownDelays == [10])
+        }
+
+        @Test("stopUpdates does not schedule shutdown while a location is sending")
+        func stopUpdatesSkipsShutdownWhileSending() {
+            let host = TrackingRadarLocationManagerHost()
+            host.sendingValue = true
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.startUpdates(
+                host: host,
+                locationManager: locationManager,
+                lowPowerLocationManager: lowPowerLocationManager,
+                interval: 10,
+                blueBar: false
+            )
+
+            RadarLocationManagerSwift.stopUpdates(host: host, locationManager: locationManager)
+            defer { host.timer()?.invalidate() }
+
+            #expect(host.scheduledShutdownDelays.isEmpty)
+        }
 
         // MARK: - stopTracking
 

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -332,48 +332,50 @@ extension RadarSerializedTests {
 
             RadarLocationManager.sharedInstance().replaceSyncedBeacons([])
         }
+    }
+}
 
-        @Test("ObjC startTrackingWithOptions: does not require the main thread")
-        func publicStartTrackingSurvivesBackgroundThread() async {
-            await withCheckedContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
-                    RadarLocationManagerSwiftTestHelpers.withMockedSwiftTrackingDependencies { bridge in
-                        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-                            "useSwiftLocationManager": true
-                        ])
-                        #expect(!Thread.isMainThread)
+extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
+    @Test("ObjC startTrackingWithOptions: does not require the main thread")
+    func publicStartTrackingSurvivesBackgroundThread() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                RadarLocationManagerSwiftTestHelpers.withMockedSwiftTrackingDependencies { bridge in
+                    RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                        "useSwiftLocationManager": true
+                    ])
+                    #expect(!Thread.isMainThread)
 
-                        RadarLocationManager.sharedInstance().startTracking(with: .presetResponsive)
+                    RadarLocationManager.sharedInstance().startTracking(with: .presetResponsive)
 
-                        #expect(bridge.updateTrackingCallCount == 1)
-                        #expect(RadarSettings.tracking == true)
-                    }
-                    continuation.resume()
+                    #expect(bridge.updateTrackingCallCount == 1)
+                    #expect(RadarSettings.tracking == true)
                 }
+                continuation.resume()
             }
         }
+    }
 
-        @Test("restartPreviousTrackingOptions round-trips through ObjC off the main thread")
-        func restartPreviousTrackingOptionsSurvivesBackgroundThread() async {
-            await withCheckedContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
-                    RadarLocationManagerSwiftTestHelpers.withMockedSwiftTrackingDependencies { bridge in
-                        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-                            "useSwiftLocationManager": true
-                        ])
-                        let previousOptions = RadarTrackingOptions.presetResponsive
-                        RadarSettings.previousTrackingOptions = previousOptions
-                        #expect(!Thread.isMainThread)
+    @Test("restartPreviousTrackingOptions round-trips through ObjC off the main thread")
+    func restartPreviousTrackingOptionsSurvivesBackgroundThread() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                RadarLocationManagerSwiftTestHelpers.withMockedSwiftTrackingDependencies { bridge in
+                    RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                        "useSwiftLocationManager": true
+                    ])
+                    let previousOptions = RadarTrackingOptions.presetResponsive
+                    RadarSettings.previousTrackingOptions = previousOptions
+                    #expect(!Thread.isMainThread)
 
-                        RadarLocationManagerSwift.restartPreviousTrackingOptions()
+                    RadarLocationManagerSwift.restartPreviousTrackingOptions()
 
-                        #expect(RadarSettings.previousTrackingOptions == nil)
-                        #expect(RadarSettings.tracking == true)
-                        #expect(RadarSettings.trackingOptions == previousOptions)
-                        #expect(bridge.updateTrackingCallCount == 1)
-                    }
-                    continuation.resume()
+                    #expect(RadarSettings.previousTrackingOptions == nil)
+                    #expect(RadarSettings.tracking == true)
+                    #expect(RadarSettings.trackingOptions == previousOptions)
+                    #expect(bridge.updateTrackingCallCount == 1)
                 }
+                continuation.resume()
             }
         }
     }

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -11,6 +11,21 @@ import Testing
 
 @testable import RadarSDK
 
+private func invokeStartUpdates(on manager: RadarLocationManager, interval: Int32, blueBar: Bool) {
+    typealias StartUpdatesFunction = @convention(c) (AnyObject, Selector, Int32, Bool) -> Void
+
+    let selector = NSSelectorFromString("startUpdates:blueBar:")
+    guard let implementation = manager.method(for: selector) else {
+        preconditionFailure("RadarLocationManager does not respond to startUpdates:blueBar:")
+    }
+
+    unsafeBitCast(implementation, to: StartUpdatesFunction.self)(manager, selector, interval, blueBar)
+}
+
+private func invokeStopUpdates(on manager: RadarLocationManager) {
+    manager.perform(NSSelectorFromString("stopUpdates"))
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -113,6 +128,66 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
+        }
+
+        // MARK: - startUpdates and stopUpdates — public method routing
+
+        @Test("Public timer methods route to Swift when useSwiftLocationManager is enabled")
+        func publicTimerMethodsRouteToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let manager = RadarLocationManager.sharedInstance()
+            let originalLocationManager = manager.locationManager
+            let originalLowPowerLocationManager = manager.lowPowerLocationManager
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+            defer {
+                invokeStopUpdates(on: manager)
+                manager.perform(NSSelectorFromString("cancelPendingShutdown"))
+                manager.locationManager = originalLocationManager
+                manager.lowPowerLocationManager = originalLowPowerLocationManager
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+            RadarSettings.tracking = true
+            manager.locationManager = locationManager
+            manager.lowPowerLocationManager = lowPowerLocationManager
+
+            invokeStartUpdates(on: manager, interval: 5, blueBar: true)
+            invokeStopUpdates(on: manager)
+
+            #expect(locationManager.startUpdatingLocationCallCount == 1)
+            #expect(locationManager.stopUpdatingLocationCallCount == 1)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 1)
+        }
+
+        @Test("Public timer methods keep the Objective-C body when useSwiftLocationManager is disabled")
+        func publicTimerMethodsUseObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let manager = RadarLocationManager.sharedInstance()
+            let originalLocationManager = manager.locationManager
+            let originalLowPowerLocationManager = manager.lowPowerLocationManager
+            let locationManager = TrackingCLLocationManager()
+            let lowPowerLocationManager = TrackingCLLocationManager()
+            defer {
+                invokeStopUpdates(on: manager)
+                manager.perform(NSSelectorFromString("cancelPendingShutdown"))
+                manager.locationManager = originalLocationManager
+                manager.lowPowerLocationManager = originalLowPowerLocationManager
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+            RadarSettings.tracking = true
+            manager.locationManager = locationManager
+            manager.lowPowerLocationManager = lowPowerLocationManager
+
+            invokeStartUpdates(on: manager, interval: 5, blueBar: true)
+            invokeStopUpdates(on: manager)
+
+            #expect(locationManager.startUpdatingLocationCallCount == 1)
+            #expect(locationManager.stopUpdatingLocationCallCount == 1)
+            #expect(lowPowerLocationManager.startUpdatingLocationCallCount == 1)
         }
 
         // MARK: - stopTracking — public method routing

--- a/RadarSDKTests/TrackingCLLocationManager.swift
+++ b/RadarSDKTests/TrackingCLLocationManager.swift
@@ -17,6 +17,7 @@ import Foundation
 final class TrackingCLLocationManager: CLLocationManager, @unchecked Sendable {
     private(set) var trackedRegions = Set<CLRegion>()
     private(set) var requestStateRegions: [CLRegion] = []
+    private(set) var startUpdatingLocationCallCount = 0
     private(set) var stopUpdatingLocationCallCount = 0
     private(set) var stopUpdatingHeadingCallCount = 0
     private(set) var requestLocationCallCount = 0
@@ -39,6 +40,10 @@ final class TrackingCLLocationManager: CLLocationManager, @unchecked Sendable {
 
     override func stopUpdatingLocation() {
         stopUpdatingLocationCallCount += 1
+    }
+
+    override func startUpdatingLocation() {
+        startUpdatingLocationCallCount += 1
     }
 
     override func stopUpdatingHeading() {


### PR DESCRIPTION
## Summary

- Add Swift twins for `startUpdates:blueBar:` and `stopUpdates`.
- Preserve Objective-C fallback behavior behind `useSwiftLocationManager`.
- Add the internal timer-state host seam and lifecycle coverage.

## Test Plan

1. Build and launch the `Example` app on an iOS device, grant it Always location access, and open the Tests tab.
2. Tap the gear icon, tap Refresh in the Tracking section, and confirm that Source is `Local`. If it shows `Remote (server)`, disable the remote tracking override for the project, relaunch the app, and refresh again.
3. Return to the Tests tab and tap `startTracking (responsive)` in the Tracking panel.
4. Open the gear settings, expand Active tracking options, and confirm that `showBlueBar` is `false`; return to the Tests tab and background the app.
5. Confirm that the iOS location-use blue bar or pill is not displayed.
6. Bring the app to the foreground, tap `stopTracking`, open the gear settings, tap Refresh, and confirm that Tracking Status is `Off`.
7. Return to the Tests tab, tap `startTracking (continuous)`, and confirm in Active tracking options that `showBlueBar` is `true` and `desiredMovingUpdateInterval` is `30s`.
8. Background the app and confirm that the iOS location-use blue bar or pill is displayed.
9. Bring the app to the foreground, tap `stopTracking`, refresh the Tracking section, and confirm that Tracking Status is `Off`.
