### PR TITLE
FENCE-2804: Port one-shot location requests to Swift

### DIFF
--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -21,10 +21,10 @@ import Foundation
 // auto-synthesized Swift module, so we cannot extend `RadarLocationManager` from Swift.
 // Static methods on this class are called from `RadarLocationManager.m` via
 // `RadarSDK-Swift.h`. Methods that need access to the manager's CLLocationManager
-// receive it as an explicit argument. Timer methods use the host protocol below because
-// they also need private timer state and shutdown scheduling.
+// receive it as an explicit argument. Lifecycle methods use the host protocol below
+// because they also need private timer state, completion storage, and shutdown scheduling.
 // This protocol is a temporary migration seam. Remove it when RadarLocationManager is
-// fully ported to Swift and the timer state no longer needs an Objective-C host.
+// fully ported to Swift and the manager no longer needs an Objective-C host for that state.
 // `@objc public` keeps the seam visible to the generated Objective-C header; it is not a new SDK API.
 @objc public protocol RadarLocationManagerSwiftHost: AnyObject {
     func started() -> Bool
@@ -38,6 +38,9 @@ import Foundation
     func cancelPendingShutdown()
     func requestLocation()
     func scheduleShutdown(after delay: TimeInterval)
+
+    // Keep completion storage in Objective-C until the location callback and timeout paths move together.
+    func addCompletionHandler(_ completionHandler: RadarLocationCompletionHandler?)
 }
 
 private final class RadarLocationManagerSwiftHostBox: @unchecked Sendable {
@@ -182,6 +185,44 @@ final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this typ
             RadarLogger.shared.debug("🦅 Scheduling shutdown")
             host.scheduleShutdown(after: delay)
         }
+    }
+
+    @objc(getLocationWithHost:authorizationStatus:locationManager:completionHandler:)
+    static func getLocation(
+        host: RadarLocationManagerSwiftHost,
+        authorizationStatus: CLAuthorizationStatus,
+        locationManager: CLLocationManager,
+        completionHandler: RadarLocationCompletionHandler?
+    ) {
+        getLocation(
+            host: host,
+            authorizationStatus: authorizationStatus,
+            locationManager: locationManager,
+            desiredAccuracy: .medium,
+            completionHandler: completionHandler
+        )
+    }
+
+    @objc(getLocationWithDesiredAccuracyOnHost:authorizationStatus:locationManager:desiredAccuracy:completionHandler:)
+    static func getLocation(
+        host: RadarLocationManagerSwiftHost,
+        authorizationStatus: CLAuthorizationStatus,
+        locationManager: CLLocationManager,
+        desiredAccuracy: RadarTrackingOptionsDesiredAccuracy,
+        completionHandler: RadarLocationCompletionHandler?
+    ) {
+        guard authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways else {
+            RadarSwift.bridge?.didFail(status: .errorPermissions)
+            completionHandler?(.errorPermissions, nil, false)
+            return
+        }
+
+        if let completionHandler {
+            host.addCompletionHandler(completionHandler)
+        }
+
+        locationManager.desiredAccuracy = clLocationAccuracy(for: desiredAccuracy)
+        requestLocation(locationManager: locationManager)
     }
 
     @objc(matchBeaconIdsWithRanged:synced:)

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -35,8 +35,8 @@
 #import "RadarSDK-Swift.h"
 #endif
 
-// Temporary migration seam for the Swift timer twins. The manager keeps ownership of its
-// private state while Swift runs the timer logic. Remove this conformance when the manager
+// Temporary migration seam for the Swift lifecycle twins. The manager keeps ownership of its
+// private state while Swift runs the lifecycle logic. Remove this conformance when the manager
 // is fully ported.
 @interface RadarLocationManager () <RadarLocationManagerSwiftHost>
 
@@ -165,10 +165,27 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)getLocationWithCompletionHandler:(RadarLocationCompletionHandler)completionHandler {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift getLocationWithHost:self
+                                      authorizationStatus:[self.permissionsHelper locationAuthorizationStatus]
+                                        locationManager:self.locationManager
+                                       completionHandler:completionHandler];
+        return;
+    }
+
     [self getLocationWithDesiredAccuracy:RadarTrackingOptionsDesiredAccuracyMedium completionHandler:completionHandler];
 }
 
 - (void)getLocationWithDesiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy completionHandler:(RadarLocationCompletionHandler)completionHandler {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift getLocationWithDesiredAccuracyOnHost:self
+                                                       authorizationStatus:[self.permissionsHelper locationAuthorizationStatus]
+                                                         locationManager:self.locationManager
+                                                        desiredAccuracy:desiredAccuracy
+                                                       completionHandler:completionHandler];
+        return;
+    }
+
     CLAuthorizationStatus authorizationStatus = [self.permissionsHelper locationAuthorizationStatus];
     if (!(authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse || authorizationStatus == kCLAuthorizationStatusAuthorizedAlways)) {
         [[RadarDelegateHolder sharedInstance] didFailWithStatus:RadarStatusErrorPermissions];

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -39,6 +39,15 @@ NS_ASSUME_NONNULL_BEGIN
                        blueBar:(BOOL)blueBar;
 + (void)stopUpdatesWithHost:(id<RadarLocationManagerSwiftHost>)host
              locationManager:(CLLocationManager *)locationManager;
++ (void)getLocationWithHost:(id<RadarLocationManagerSwiftHost>)host
+          authorizationStatus:(CLAuthorizationStatus)authorizationStatus
+              locationManager:(CLLocationManager *)locationManager
+             completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
++ (void)getLocationWithDesiredAccuracyOnHost:(id<RadarLocationManagerSwiftHost>)host
+                           authorizationStatus:(CLAuthorizationStatus)authorizationStatus
+                               locationManager:(CLLocationManager *)locationManager
+                              desiredAccuracy:(RadarTrackingOptionsDesiredAccuracy)desiredAccuracy
+                             completionHandler:(RadarLocationCompletionHandler _Nullable)completionHandler;
 
 + (NSArray<NSString *> *)matchBeaconIdsWithRanged:(NSArray<RadarBeacon *> *)rangedBeacons
                                            synced:(NSArray<RadarBeacon *> *)syncedBeacons;

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -11,6 +11,10 @@ import Testing
 
 @testable import RadarSDK
 
+private func invokeGetLocation(on manager: RadarLocationManager) {
+    manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
+}
+
 // Keep lifecycle seam tests together so the direct twins and their shared host stay easy to compare.
 // swiftlint:disable file_length
 
@@ -494,5 +498,57 @@ extension RadarSerializedTests {
             #expect(locationManager.desiredAccuracy == originalAccuracy)
             #expect(locationManager.requestLocationCallCount == 0)
         }
+    }
+}
+
+extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
+    // MARK: - getLocation — public method routing
+
+    @Test("Public getLocation routes to the Swift twin when useSwiftLocationManager is enabled")
+    func publicGetLocationRoutesToSwiftTwinWhenFlagEnabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalPermissionsHelper = manager.permissionsHelper
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.permissionsHelper = originalPermissionsHelper
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        let permissionsHelper = RadarPermissionsHelperMock()
+        permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+        manager.permissionsHelper = permissionsHelper
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+
+        invokeGetLocation(on: manager)
+
+        #expect(bridge.lastFailStatus == .errorPermissions)
+    }
+
+    @Test("Public getLocation keeps the Objective-C body when useSwiftLocationManager is disabled")
+    func publicGetLocationUsesObjCBodyWhenFlagDisabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalPermissionsHelper = manager.permissionsHelper
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.permissionsHelper = originalPermissionsHelper
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        let permissionsHelper = RadarPermissionsHelperMock()
+        permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+        manager.permissionsHelper = permissionsHelper
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+
+        invokeGetLocation(on: manager)
+
+        #expect(bridge.lastFailStatus == nil)
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -40,6 +40,7 @@ final class TrackingRadarLocationManagerHost: NSObject, RadarLocationManagerSwif
     private(set) var cancelPendingShutdownCallCount = 0
     private(set) var scheduledShutdownDelays: [TimeInterval] = []
     private(set) var requestLocationCallCount = 0
+    private(set) var addCompletionHandlerCallCount = 0
 
     func started() -> Bool { startedValue }
 
@@ -65,6 +66,10 @@ final class TrackingRadarLocationManagerHost: NSObject, RadarLocationManagerSwif
 
     func scheduleShutdown(after delay: TimeInterval) {
         scheduledShutdownDelays.append(delay)
+    }
+
+    func addCompletionHandler(_ completionHandler: RadarLocationCompletionHandler?) {
+        addCompletionHandlerCallCount += 1
     }
 }
 
@@ -400,6 +405,94 @@ extension RadarSerializedTests {
             RadarLocationManagerSwift.requestLocation(locationManager: locationManager)
 
             #expect(locationManager.requestLocationCallCount == 1)
+        }
+
+        // MARK: - getLocation
+
+        @Test("getLocation uses high accuracy for authorized when-in-use requests")
+        func getLocationUsesHighAccuracyForAuthorizedWhenInUse() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.getLocation(
+                host: host,
+                authorizationStatus: .authorizedWhenInUse,
+                locationManager: locationManager,
+                desiredAccuracy: .high,
+                completionHandler: { _, _, _ in }
+            )
+
+            #expect(host.addCompletionHandlerCallCount == 1)
+            #expect(locationManager.desiredAccuracy == kCLLocationAccuracyBest)
+            #expect(locationManager.requestLocationCallCount == 1)
+        }
+
+        @Test("getLocation uses low accuracy for authorized-always requests")
+        func getLocationUsesLowAccuracyForAuthorizedAlways() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.getLocation(
+                host: host,
+                authorizationStatus: .authorizedAlways,
+                locationManager: locationManager,
+                desiredAccuracy: .low,
+                completionHandler: nil
+            )
+
+            #expect(host.addCompletionHandlerCallCount == 0)
+            #expect(locationManager.desiredAccuracy == kCLLocationAccuracyKilometer)
+            #expect(locationManager.requestLocationCallCount == 1)
+        }
+
+        @Test("getLocation uses medium accuracy in the default overload")
+        func getLocationUsesMediumAccuracyByDefault() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+
+            RadarLocationManagerSwift.getLocation(
+                host: host,
+                authorizationStatus: .authorizedAlways,
+                locationManager: locationManager,
+                completionHandler: nil
+            )
+
+            #expect(locationManager.desiredAccuracy == kCLLocationAccuracyHundredMeters)
+            #expect(locationManager.requestLocationCallCount == 1)
+        }
+
+        @Test("getLocation reports permissions errors before changing location state")
+        func getLocationReportsPermissionsErrorBeforeChangingLocationState() {
+            let host = TrackingRadarLocationManagerHost()
+            let locationManager = TrackingCLLocationManager()
+            let originalAccuracy = locationManager.desiredAccuracy
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer { RadarSwift.bridge = originalBridge }
+
+            var callbackStatus: RadarStatus?
+            var callbackLocation: CLLocation?
+            var callbackStopped: Bool?
+            RadarLocationManagerSwift.getLocation(
+                host: host,
+                authorizationStatus: .notDetermined,
+                locationManager: locationManager,
+                desiredAccuracy: .high,
+                completionHandler: { status, location, stopped in
+                    callbackStatus = status
+                    callbackLocation = location
+                    callbackStopped = stopped
+                }
+            )
+
+            #expect(bridge.lastFailStatus == .errorPermissions)
+            #expect(callbackStatus == .errorPermissions)
+            #expect(callbackLocation == nil)
+            #expect(callbackStopped == false)
+            #expect(host.addCompletionHandlerCallCount == 0)
+            #expect(locationManager.desiredAccuracy == originalAccuracy)
+            #expect(locationManager.requestLocationCallCount == 0)
         }
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,10 +26,6 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
-private func invokeGetLocation(on manager: RadarLocationManager) {
-    manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
-}
-
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -132,56 +128,6 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
-        }
-
-        // MARK: - getLocation — public method routing
-
-        @Test("Public getLocation routes to the Swift twin when useSwiftLocationManager is enabled")
-        func publicGetLocationRoutesToSwiftTwinWhenFlagEnabled() {
-            RadarLocationManagerSwiftTestHelpers.clearState()
-            let bridge = MockRadarSwiftBridge()
-            let originalBridge = RadarSwift.bridge
-            let manager = RadarLocationManager.sharedInstance()
-            let originalPermissionsHelper = manager.permissionsHelper
-            RadarSwift.bridge = bridge
-            defer {
-                RadarSwift.bridge = originalBridge
-                manager.permissionsHelper = originalPermissionsHelper
-                RadarLocationManagerSwiftTestHelpers.clearState()
-            }
-
-            let permissionsHelper = RadarPermissionsHelperMock()
-            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
-            manager.permissionsHelper = permissionsHelper
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
-
-            invokeGetLocation(on: manager)
-
-            #expect(bridge.lastFailStatus == .errorPermissions)
-        }
-
-        @Test("Public getLocation keeps the Objective-C body when useSwiftLocationManager is disabled")
-        func publicGetLocationUsesObjCBodyWhenFlagDisabled() {
-            RadarLocationManagerSwiftTestHelpers.clearState()
-            let bridge = MockRadarSwiftBridge()
-            let originalBridge = RadarSwift.bridge
-            let manager = RadarLocationManager.sharedInstance()
-            let originalPermissionsHelper = manager.permissionsHelper
-            RadarSwift.bridge = bridge
-            defer {
-                RadarSwift.bridge = originalBridge
-                manager.permissionsHelper = originalPermissionsHelper
-                RadarLocationManagerSwiftTestHelpers.clearState()
-            }
-
-            let permissionsHelper = RadarPermissionsHelperMock()
-            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
-            manager.permissionsHelper = permissionsHelper
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
-
-            invokeGetLocation(on: manager)
-
-            #expect(bridge.lastFailStatus == nil)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,6 +26,10 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
+private func invokeGetLocation(on manager: RadarLocationManager) {
+    manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -128,6 +132,56 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
+        }
+
+        // MARK: - getLocation — public method routing
+
+        @Test("Public getLocation routes to the Swift twin when useSwiftLocationManager is enabled")
+        func publicGetLocationRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            let originalPermissionsHelper = manager.permissionsHelper
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                manager.permissionsHelper = originalPermissionsHelper
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let permissionsHelper = RadarPermissionsHelperMock()
+            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+            manager.permissionsHelper = permissionsHelper
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+
+            invokeGetLocation(on: manager)
+
+            #expect(bridge.lastFailStatus == .errorPermissions)
+        }
+
+        @Test("Public getLocation keeps the Objective-C body when useSwiftLocationManager is disabled")
+        func publicGetLocationUsesObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            let originalPermissionsHelper = manager.permissionsHelper
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                manager.permissionsHelper = originalPermissionsHelper
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let permissionsHelper = RadarPermissionsHelperMock()
+            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+            manager.permissionsHelper = permissionsHelper
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+
+            invokeGetLocation(on: manager)
+
+            #expect(bridge.lastFailStatus == nil)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing


### PR DESCRIPTION
## Summary

- Port `getLocationWithCompletionHandler:` and `getLocationWithDesiredAccuracy:completionHandler:` to Swift.
- Preserve Objective-C completion storage and fallback behavior behind `useSwiftLocationManager`.
- Pass authorization status from the injected Objective-C permissions helper into the Swift twin.

## Test Plan

1. Build and launch the Example app on a device.
2. Grant the app location access and open the `CSGN` tab.
3. Tap `Refresh` and confirm that `Current location` shows coordinates instead of `unavailable`.
4. Open iOS Settings, disable location access for the Example app, return to the app, and tap `Refresh` again.
5. Confirm that `Current location` reports `unavailable` and the Debug tab records a permissions error.
6. Re-enable location access, return to the Example app, tap `Refresh`, and confirm that coordinates are shown again.
7. The Example app does not expose the desired-accuracy overload separately; the CSGN refresh exercises the shared one-shot request path.