### PR TITLE
Keep nightly migration skill out of commits

### DIFF
--- a/.github/workflows/objc-to-swift-nightly.yml
+++ b/.github/workflows/objc-to-swift-nightly.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Install the skill for this run
         if: steps.guard.outputs.open == '0'
         run: |
+          # The skill is runtime input from clankers, not a migration change.
+          # Keep other checked-in Claude skills visible to Git.
+          printf '%s\n' '.claude/skills/objc-to-swift/' >> .git/info/exclude
           mkdir -p .claude/skills
           cp -R clankers-skill/skills/objc-to-swift .claude/skills/objc-to-swift
           rm -rf clankers-skill


### PR DESCRIPTION
## Summary

- Keep the runtime-installed `objc-to-swift` skill available to the nightly Claude action without allowing it into migration commits.
- Use the checkout-local Git exclude so other checked-in Claude skills remain unaffected.

Claude randomly committed and pushed the skill from our skills repo that it checks out to run this workflow. This happened once in the last run of the workflow, usually Claude remembers not to commit it, but this should prevent it entirely (I hope)

## Test Plan

1. Trigger the nightly ObjC-to-Swift migration workflow from GitHub Actions.
2. Open the generated migration branch and confirm the migration commit does not contain `.claude/skills/objc-to-swift`.
3. In a local checkout, place a separate test skill under `.claude/skills/another-skill/` and confirm it remains visible to Git while the runtime `objc-to-swift` path remains ignored.