### PR TITLE
FENCE-2804: Port `didDetermineState` to Swift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ Large stateful managers may use a temporary Swift seam only when a user explicit
 that staged migration. The nightly workflow does not select managers or leave parallel
 implementations for ordinary files.
 
+## Concurrency
+
+For work that can happen asynchronously on the main actor, prefer `Task { @MainActor in ... }` over `DispatchQueue.main.async` or a `runOnMainThread` helper. Use synchronous main-thread dispatch only when the caller must complete that work before returning.
+
 ## Build & Test
 
 ```bash

--- a/RadarSDK/RadarBeaconManager+Delegate.swift
+++ b/RadarSDK/RadarBeaconManager+Delegate.swift
@@ -158,9 +158,8 @@ extension RadarBeaconManagerSwift {
         }
     }
 
-    @objc(handleBeaconUUIDEntryForRegion:completionHandler:)
+    @objc(handleBeaconUUIDEntryWithCompletionHandler:)
     func handleBeaconUUIDEntry(
-        for region: CLBeaconRegion,
         completionHandler: @escaping RadarBeaconCompletionHandler
     ) {
         if RadarSettings.useRadarModifiedBeacon { return }
@@ -169,9 +168,8 @@ extension RadarBeaconManagerSwift {
         rangeBeaconUUIDs(uuids, completionHandler: completionHandler)
     }
 
-    @objc(handleBeaconUUIDExitForRegion:completionHandler:)
+    @objc(handleBeaconUUIDExitWithCompletionHandler:)
     func handleBeaconUUIDExit(
-        for region: CLBeaconRegion,
         completionHandler: @escaping RadarBeaconCompletionHandler
     ) {
         if RadarSettings.useRadarModifiedBeacon { return }

--- a/RadarSDK/RadarBeaconManagerSwift.h
+++ b/RadarSDK/RadarBeaconManagerSwift.h
@@ -32,11 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleBeaconExitForRegion:(CLBeaconRegion *)region
                 completionHandler:(RadarBeaconCompletionHandler)completionHandler;
 
-- (void)handleBeaconUUIDEntryForRegion:(CLBeaconRegion *)region
-                     completionHandler:(RadarBeaconCompletionHandler)completionHandler;
+- (void)handleBeaconUUIDEntryWithCompletionHandler:(RadarBeaconCompletionHandler)completionHandler;
 
-- (void)handleBeaconUUIDExitForRegion:(CLBeaconRegion *)region
-                    completionHandler:(RadarBeaconCompletionHandler)completionHandler;
+- (void)handleBeaconUUIDExitWithCompletionHandler:(RadarBeaconCompletionHandler)completionHandler;
 
 - (void)registerBeaconRegionNotificationsFromArray:(NSArray<NSDictionary<NSString *, id> *> *)beaconArray;
 

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -57,10 +57,10 @@ final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this typ
     // Mirror of the identifier prefix constants in RadarLocationManager.m. Kept in sync by
     // hand until that file is fully ported.
     static let identifierPrefix = "radar_"
-    private static let bubbleGeofenceIdentifierPrefix = "radar_bubble_"
-    private static let syncGeofenceIdentifierPrefix = "radar_geofence_"
-    private static let syncBeaconIdentifierPrefix = "radar_beacon_"
-    private static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
+    static let bubbleGeofenceIdentifierPrefix = "radar_bubble_"
+    static let syncGeofenceIdentifierPrefix = "radar_geofence_"
+    static let syncBeaconIdentifierPrefix = "radar_beacon_"
+    static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
     private static let trackingShutdownDelay: TimeInterval = 10
     private static let immediateShutdownDelay: TimeInterval = 0
     nonisolated(unsafe) static var permissionsHelper: RadarPermissionsHelping = RadarPermissionsHelperSwift()

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -8,16 +8,6 @@
 import CoreLocation
 import Foundation
 
-private final class RadarBeaconRegionStateBox: @unchecked Sendable {
-    let location: CLLocation
-    let region: CLBeaconRegion
-
-    init(location: CLLocation, region: CLBeaconRegion) {
-        self.location = location
-        self.region = region
-    }
-}
-
 // The `CLLocationManagerDelegate` half of `RadarLocationManager`
 extension RadarLocationManagerSwift {
 
@@ -89,25 +79,47 @@ extension RadarLocationManagerSwift {
 
         let isInside = state == .inside
         let source: RadarLocationSource = isInside ? .beaconEnter : .beaconExit
-        let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
+        let beaconUUID = beaconRegion.uuid
+        let beaconMajor = beaconRegion.major?.uint16Value
+        let beaconMinor = beaconRegion.minor?.uint16Value
         RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
 
-        Task { @MainActor [stateBox] in
+        Task { @MainActor in
             let beaconManager = RadarBeaconManagerSwift.shared
             let completionHandler: RadarBeaconCompletionHandler = { _, _ in
-                RadarSwift.bridge?.handleLocation(stateBox.location, source: source)
+                RadarSwift.bridge?.handleLocation(location, source: source)
             }
 
             if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
                 if isInside {
-                    beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
+                    beaconManager.handleBeaconUUIDEntry(completionHandler: completionHandler)
                 } else {
-                    beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
+                    beaconManager.handleBeaconUUIDExit(completionHandler: completionHandler)
                 }
-            } else if isInside {
-                beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
             } else {
-                beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
+                let beaconRegion: CLBeaconRegion
+                if let beaconMajor, let beaconMinor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        minor: beaconMinor,
+                        identifier: identifier
+                    )
+                } else if let beaconMajor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        identifier: identifier
+                    )
+                } else {
+                    beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
+                }
+
+                if isInside {
+                    beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
+                }
             }
         }
     }

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -92,7 +92,7 @@ extension RadarLocationManagerSwift {
         let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
         RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
 
-        runOnMainThread { [stateBox] in
+        Task { @MainActor [stateBox] in
             let beaconManager = RadarBeaconManagerSwift.shared
             let completionHandler: RadarBeaconCompletionHandler = { _, _ in
                 RadarSwift.bridge?.handleLocation(stateBox.location, source: source)
@@ -108,21 +108,6 @@ extension RadarLocationManagerSwift {
                 beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
             } else {
                 beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
-            }
-        }
-    }
-
-    // Core Location may call this delegate off the main thread, while beacon state is main-actor owned.
-    private static func runOnMainThread(_ work: @escaping @MainActor @Sendable () -> Void) {
-        if Thread.isMainThread {
-            MainActor.assumeIsolated {
-                work()
-            }
-        } else {
-            DispatchQueue.main.async {
-                MainActor.assumeIsolated {
-                    work()
-                }
             }
         }
     }

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -8,6 +8,16 @@
 import CoreLocation
 import Foundation
 
+private final class RadarBeaconRegionStateBox: @unchecked Sendable {
+    let location: CLLocation
+    let region: CLBeaconRegion
+
+    init(location: CLLocation, region: CLBeaconRegion) {
+        self.location = location
+        self.region = region
+    }
+}
+
 // The `CLLocationManagerDelegate` half of `RadarLocationManager`
 extension RadarLocationManagerSwift {
 
@@ -64,6 +74,59 @@ extension RadarLocationManagerSwift {
             ? .visitArrival
             : .visitDeparture
         RadarSwift.bridge?.handleLocation(location, source: source)
+    }
+
+    @objc(didDetermineStateOnLocationManager:state:region:)
+    static func didDetermineState(locationManager: CLLocationManager, state: CLRegionState, region: CLRegion) {
+        let identifier = region.identifier
+        guard identifier.hasPrefix(syncBeaconIdentifierPrefix) || identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) else {
+            return
+        }
+
+        guard let location = effectiveLocation(for: locationManager), let beaconRegion = region as? CLBeaconRegion else {
+            return
+        }
+
+        let isInside = state == .inside
+        let source: RadarLocationSource = isInside ? .beaconEnter : .beaconExit
+        let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
+        RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
+
+        runOnMainThread { [stateBox] in
+            MainActor.assumeIsolated {
+                let beaconManager = RadarBeaconManagerSwift.shared
+                let completionHandler: RadarBeaconCompletionHandler = { _, _ in
+                    RadarSwift.bridge?.handleLocation(stateBox.location, source: source)
+                }
+
+                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                    if isInside {
+                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
+                    } else {
+                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
+                    }
+                } else if isInside {
+                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
+                }
+            }
+        }
+    }
+
+    // Core Location may call this delegate off the main thread, while beacon state is main-actor owned.
+    private static func runOnMainThread(_ work: @escaping @MainActor @Sendable () -> Void) {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                work()
+            }
+        } else {
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    work()
+                }
+            }
+        }
     }
 
     @objc(didUpdateHeading:)

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -93,23 +93,21 @@ extension RadarLocationManagerSwift {
         RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
 
         runOnMainThread { [stateBox] in
-            MainActor.assumeIsolated {
-                let beaconManager = RadarBeaconManagerSwift.shared
-                let completionHandler: RadarBeaconCompletionHandler = { _, _ in
-                    RadarSwift.bridge?.handleLocation(stateBox.location, source: source)
-                }
+            let beaconManager = RadarBeaconManagerSwift.shared
+            let completionHandler: RadarBeaconCompletionHandler = { _, _ in
+                RadarSwift.bridge?.handleLocation(stateBox.location, source: source)
+            }
 
-                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
-                    if isInside {
-                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
-                    } else {
-                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
-                    }
-                } else if isInside {
-                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
+            if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                if isInside {
+                    beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
                 } else {
-                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
+                    beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
                 }
+            } else if isInside {
+                beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
+            } else {
+                beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
             }
         }
     }

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -82,13 +82,15 @@ extension RadarLocationManagerSwift {
         let beaconUUID = beaconRegion.uuid
         let beaconMajor = beaconRegion.major?.uint16Value
         let beaconMinor = beaconRegion.minor?.uint16Value
+        // Capture the bridge with the event so delayed work cannot deliver it to a different bridge.
+        let bridge = RadarSwift.bridge
+        let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
+            bridge?.handleLocation(location, source: source, beacons: nearbyBeacons)
+        }
         RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
 
         Task { @MainActor in
             let beaconManager = RadarBeaconManagerSwift.shared
-            let completionHandler: RadarBeaconCompletionHandler = { _, _ in
-                RadarSwift.bridge?.handleLocation(location, source: source)
-            }
 
             if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
                 if isInside {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1423,8 +1423,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
     if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
         [RadarUtilsDeprecated runOnMainThread:^{
-            [[RadarBeaconManagerSwift shared] handleBeaconUUIDEntryForRegion:(CLBeaconRegion *)region
-                                                           completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
+            [[RadarBeaconManagerSwift shared] handleBeaconUUIDEntryWithCompletionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
                 [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
             }];
         }];
@@ -1471,8 +1470,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
     if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
         [RadarUtilsDeprecated runOnMainThread:^{
-            [[RadarBeaconManagerSwift shared] handleBeaconUUIDExitForRegion:(CLBeaconRegion *)region
-                                                          completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
+            [[RadarBeaconManagerSwift shared] handleBeaconUUIDExitWithCompletionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
                 [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
             }];
         }];
@@ -1512,8 +1510,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
         if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
             [RadarUtilsDeprecated runOnMainThread:^{
-                [[RadarBeaconManagerSwift shared] handleBeaconUUIDEntryForRegion:(CLBeaconRegion *)region
-                                                               completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
+                [[RadarBeaconManagerSwift shared] handleBeaconUUIDEntryWithCompletionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
                     [self handleLocation:location source:RadarLocationSourceBeaconEnter beacons:nearbyBeacons];
                 }];
             }];
@@ -1530,8 +1527,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
         if ([region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix]) {
             [RadarUtilsDeprecated runOnMainThread:^{
-                [[RadarBeaconManagerSwift shared] handleBeaconUUIDExitForRegion:(CLBeaconRegion *)region
-                                                              completionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
+                [[RadarBeaconManagerSwift shared] handleBeaconUUIDExitWithCompletionHandler:^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
                     [self handleLocation:location source:RadarLocationSourceBeaconExit beacons:nearbyBeacons];
                 }];
             }];

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1489,6 +1489,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didDetermineStateOnLocationManager:manager state:state region:region];
+        return;
+    }
+
     if (!([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix] || [region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix])) {
         return;
     }

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -76,6 +76,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)didUpdateLocations:(nullable NSArray<CLLocation *> *)updates completionHandlerCount:(NSUInteger)completionHandlerCount;
 + (void)didVisitOnLocationManager:(CLLocationManager *)locationManager visit:(CLVisit *)visit;
++ (void)didDetermineStateOnLocationManager:(CLLocationManager *)locationManager
+                                     state:(CLRegionState)state
+                                    region:(CLRegion *)region;
 
 + (void)didUpdateHeading:(CLHeading *)newHeading;
 + (void)didChangeAuthorizationStatus:(CLAuthorizationStatus)status;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -39,6 +39,7 @@
 - (void)didReceiveEvents:(NSArray<RadarEvent *> * _Nonnull)events user:(RadarUser * _Nonnull)user;
 - (void)didUpdateClientLocation:(CLLocation * _Nonnull)location stopped:(BOOL)stopped source:(RadarLocationSource)source;
 - (void)handleLocation:(CLLocation * _Nonnull)location source:(RadarLocationSource)source;
+- (void)handleLocation:(CLLocation * _Nonnull)location source:(RadarLocationSource)source beacons:(NSArray<RadarBeacon *> * _Nullable)beacons;
 - (void)updateTracking;
 - (void)didFailWithStatus:(RadarStatus)status;
 - (RadarBeacon * _Nonnull)createBeaconWithUuid:(NSString * _Nonnull)uuid major:(NSString * _Nonnull)major minor:(NSString * _Nonnull)minor rssi:(NSInteger)rssi;

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -19,6 +19,12 @@
 #import "RadarIndoors.h"
 #import "RadarLocationManager.h"
 
+@interface RadarLocationManager (RadarSwiftBridgeInternal)
+- (void)handleLocation:(CLLocation *)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> * _Nullable)beacons;
+@end
+
 @implementation RadarSwiftBridge
 
 - (void)flushReplays {
@@ -98,6 +104,12 @@
 
 - (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
     [[RadarLocationManager sharedInstance] handleLocation:location source:source];
+}
+
+- (void)handleLocation:(CLLocation *)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> * _Nullable)beacons {
+    [[RadarLocationManager sharedInstance] handleLocation:location source:source beacons:beacons];
 }
 
 - (RadarUser * _Nullable)radarUser {

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -31,6 +31,7 @@ protocol RadarSwiftBridgeProtocol {
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser)
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource)
     func handleLocation(_ location: CLLocation, source: RadarLocationSource)
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?)
     func updateTracking()
     func radarUser() -> RadarUser?
     func didFail(status: RadarStatus)

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -71,9 +71,40 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     }
     private(set) var lastHandledLocation: CLLocation?
     private(set) var lastHandledSource: RadarLocationSource?
-    func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
+    private(set) var lastHandledBeacons: [RadarBeacon]?
+    private let handledLocationLock = NSLock()
+    private var handledLocationContinuations: [AsyncStream<Void>.Continuation] = []
+
+    // Delegate callbacks are asynchronous, so tests wait for the callback instead of guessing a delay.
+    func handledLocationEvents() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            handledLocationLock.lock()
+            handledLocationContinuations.append(continuation)
+            handledLocationLock.unlock()
+        }
+    }
+
+    private func recordHandledLocation(
+        _ location: CLLocation,
+        source: RadarLocationSource,
+        beacons: [RadarBeacon]?
+    ) {
         lastHandledLocation = location
         lastHandledSource = source
+        lastHandledBeacons = beacons
+
+        handledLocationLock.lock()
+        let continuations = handledLocationContinuations
+        handledLocationLock.unlock()
+        continuations.forEach { _ = $0.yield(()) }
+    }
+
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
+        recordHandledLocation(location, source: source, beacons: nil)
+    }
+
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?) {
+        recordHandledLocation(location, source: source, beacons: beacons)
     }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?

--- a/RadarSDKTests/RadarBeaconManagerTests.swift
+++ b/RadarSDKTests/RadarBeaconManagerTests.swift
@@ -308,10 +308,9 @@ extension RadarSerializedTests {
         func handleBeaconUUIDEntry_useRadarModifiedBeacon_earlyReturn() {
             setUseRadarModifiedBeacon(true)
 
-            let region = Self.makeRegion()
             var called = false
 
-            beaconManager.handleBeaconUUIDEntry(for: region) { _, _ in
+            beaconManager.handleBeaconUUIDEntry { _, _ in
                 called = true
             }
 
@@ -322,10 +321,9 @@ extension RadarSerializedTests {
         func handleBeaconUUIDExit_useRadarModifiedBeacon_earlyReturn() {
             setUseRadarModifiedBeacon(true)
 
-            let region = Self.makeRegion()
             var called = false
 
-            beaconManager.handleBeaconUUIDExit(for: region) { _, _ in
+            beaconManager.handleBeaconUUIDExit { _, _ in
                 called = true
             }
 

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -567,11 +567,12 @@ extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
 
     @Test("Public didDetermineState routes to the Swift twin when useSwiftLocationManager is enabled")
     @MainActor
-    func publicDidDetermineStateRoutesToSwiftTwinWhenFlagEnabled() {
+    func publicDidDetermineStateRoutesToSwiftTwinWhenFlagEnabled() async {
         RadarLocationManagerSwiftTestHelpers.clearState()
         let bridge = MockRadarSwiftBridge()
         let originalBridge = RadarSwift.bridge
         RadarSwift.bridge = bridge
+        let replacementBridge = MockRadarSwiftBridge()
         defer {
             RadarSwift.bridge = originalBridge
             RadarLocationManagerSwiftTestHelpers.clearState()
@@ -588,6 +589,47 @@ extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
             uuid: UUID(),
             identifier: "radar_beacon_\(UUID().uuidString)"
         )
+        let handledLocationEvents = bridge.handledLocationEvents()
+
+        invokeDidDetermineState(
+            on: RadarLocationManager.sharedInstance(),
+            locationManager: locationManager,
+            state: .inside,
+            region: region
+        )
+        RadarSwift.bridge = replacementBridge
+        #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconEnter)
+        #expect(bridge.lastHandledBeacons?.count == 1)
+        #expect(replacementBridge.lastHandledLocation == nil)
+    }
+
+    @Test("Public didDetermineState keeps the Objective-C body when useSwiftLocationManager is disabled")
+    @MainActor
+    func publicDidDetermineStateUsesObjCBodyWhenFlagDisabled() async {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": false,
+            "useRadarModifiedBeacon": false,
+        ])
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLBeaconRegion(
+            uuid: UUID(),
+            identifier: "radar_beacon_\(UUID().uuidString)"
+        )
+        let handledLocationEvents = bridge.handledLocationEvents()
 
         invokeDidDetermineState(
             on: RadarLocationManager.sharedInstance(),
@@ -596,7 +638,9 @@ extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
             region: region
         )
 
+        #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
         #expect(bridge.lastHandledLocation === location)
         #expect(bridge.lastHandledSource == .beaconEnter)
+        #expect(bridge.lastHandledBeacons?.count == 1)
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -15,6 +15,15 @@ private func invokeGetLocation(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
 }
 
+private func invokeDidDetermineState(
+    on manager: RadarLocationManager,
+    locationManager: CLLocationManager,
+    state: CLRegionState,
+    region: CLRegion
+) {
+    manager.locationManager(locationManager, didDetermineState: state, for: region)
+}
+
 // Keep lifecycle seam tests together so the direct twins and their shared host stay easy to compare.
 // swiftlint:disable file_length
 
@@ -550,5 +559,44 @@ extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
         invokeGetLocation(on: manager)
 
         #expect(bridge.lastFailStatus == nil)
+    }
+}
+
+extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
+    // MARK: - didDetermineState — public method routing
+
+    @Test("Public didDetermineState routes to the Swift twin when useSwiftLocationManager is enabled")
+    @MainActor
+    func publicDidDetermineStateRoutesToSwiftTwinWhenFlagEnabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": true,
+            "useRadarModifiedBeacon": false,
+        ])
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLBeaconRegion(
+            uuid: UUID(),
+            identifier: "radar_beacon_\(UUID().uuidString)"
+        )
+
+        invokeDidDetermineState(
+            on: RadarLocationManager.sharedInstance(),
+            locationManager: locationManager,
+            state: .inside,
+            region: region
+        )
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconEnter)
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
@@ -302,7 +302,7 @@ extension RadarSerializedTests {
 
         @Test("didDetermineState handles synced beacon entry and exit")
         @MainActor
-        func didDetermineStateHandlesSyncedBeaconEntryAndExit() {
+        func didDetermineStateHandlesSyncedBeaconEntryAndExit() async {
             RadarLocationManagerSwiftTestHelpers.clearState()
             let bridge = MockRadarSwiftBridge()
             let originalBridge = RadarSwift.bridge
@@ -328,6 +328,7 @@ extension RadarSerializedTests {
                 state: .inside,
                 region: region
             )
+            await Task.yield()
 
             #expect(bridge.lastHandledLocation === location)
             #expect(bridge.lastHandledSource == .beaconEnter)
@@ -337,6 +338,7 @@ extension RadarSerializedTests {
                 state: .outside,
                 region: region
             )
+            await Task.yield()
 
             #expect(bridge.lastHandledLocation === location)
             #expect(bridge.lastHandledSource == .beaconExit)

--- a/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
@@ -11,6 +11,9 @@ import Testing
 
 @testable import RadarSDK
 
+// Keep direct region handling and UUID coverage together while this migration is in progress.
+// swiftlint:disable file_length
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftRegionTests {
@@ -322,26 +325,86 @@ extension RadarSerializedTests {
                 uuid: UUID(),
                 identifier: "radar_beacon_\(UUID().uuidString)"
             )
+            let handledLocationEvents = bridge.handledLocationEvents()
 
             RadarLocationManagerSwift.didDetermineState(
                 locationManager: locationManager,
                 state: .inside,
                 region: region
             )
-            await Task.yield()
+            #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
 
             #expect(bridge.lastHandledLocation === location)
             #expect(bridge.lastHandledSource == .beaconEnter)
+            #expect(bridge.lastHandledBeacons?.count == 1)
 
             RadarLocationManagerSwift.didDetermineState(
                 locationManager: locationManager,
                 state: .outside,
                 region: region
             )
-            await Task.yield()
+            #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
 
             #expect(bridge.lastHandledLocation === location)
             #expect(bridge.lastHandledSource == .beaconExit)
+            #expect(bridge.lastHandledBeacons?.isEmpty == true)
+        }
+
+    }
+}
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    actor RadarLocationManagerSwiftUUIDRegionTests {
+
+        @Test("didDetermineState forwards UUID beacon entry and exit events")
+        @MainActor
+        func didDetermineStateHandlesSyncedBeaconUUIDEntryAndExit() async {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let beaconManager = RadarBeaconManagerSwift.shared
+            let originalPermissionsHelper = beaconManager.permissionsHelper
+            let originalBeaconUUIDs = RadarSettings.beaconUUIDs
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                beaconManager.permissionsHelper = originalPermissionsHelper
+                RadarSettings.beaconUUIDs = originalBeaconUUIDs
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            beaconManager.permissionsHelper = MockRadarPermissionsHelper()
+            RadarSettings.beaconUUIDs = []
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": false
+            ])
+            let locationManager = TrackingCLLocationManager()
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+            locationManager.mockLocation = location
+            let region = CLBeaconRegion(
+                uuid: UUID(),
+                identifier: "radar_uuid_\(UUID().uuidString)"
+            )
+            let handledLocationEvents = bridge.handledLocationEvents()
+
+            RadarLocationManagerSwift.didDetermineState(
+                locationManager: locationManager,
+                state: .inside,
+                region: region
+            )
+            #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
+            #expect(bridge.lastHandledSource == .beaconEnter)
+            #expect(bridge.lastHandledBeacons?.isEmpty == true)
+
+            RadarLocationManagerSwift.didDetermineState(
+                locationManager: locationManager,
+                state: .outside,
+                region: region
+            )
+            #expect(await RadarLocationManagerSwiftTestHelpers.waitForHandledLocation(handledLocationEvents))
+            #expect(bridge.lastHandledSource == .beaconExit)
+            #expect(bridge.lastHandledBeacons?.isEmpty == true)
         }
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftRegionTests.swift
@@ -268,5 +268,78 @@ extension RadarSerializedTests {
                 #expect(RadarLocationManagerSwift.shouldHandleRegion(identifier: identifier, action: "entry"))
             }
         }
+
+        // MARK: - didDetermineState
+
+        @Test("didDetermineState ignores non-beacon regions")
+        @MainActor
+        func didDetermineStateIgnoresNonBeaconRegions() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let locationManager = TrackingCLLocationManager()
+            locationManager.mockLocation = CLLocation(latitude: 40.7, longitude: -74.0)
+            let region = CLCircularRegion(
+                center: locationManager.mockLocation!.coordinate,
+                radius: 100,
+                identifier: "radar_geofence_not_a_beacon"
+            )
+
+            RadarLocationManagerSwift.didDetermineState(
+                locationManager: locationManager,
+                state: .inside,
+                region: region
+            )
+
+            #expect(bridge.lastHandledLocation == nil)
+        }
+
+        @Test("didDetermineState handles synced beacon entry and exit")
+        @MainActor
+        func didDetermineStateHandlesSyncedBeaconEntryAndExit() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": false
+            ])
+            let locationManager = TrackingCLLocationManager()
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+            locationManager.mockLocation = location
+            let region = CLBeaconRegion(
+                uuid: UUID(),
+                identifier: "radar_beacon_\(UUID().uuidString)"
+            )
+
+            RadarLocationManagerSwift.didDetermineState(
+                locationManager: locationManager,
+                state: .inside,
+                region: region
+            )
+
+            #expect(bridge.lastHandledLocation === location)
+            #expect(bridge.lastHandledSource == .beaconEnter)
+
+            RadarLocationManagerSwift.didDetermineState(
+                locationManager: locationManager,
+                state: .outside,
+                region: region
+            )
+
+            #expect(bridge.lastHandledLocation === location)
+            #expect(bridge.lastHandledSource == .beaconExit)
+        }
     }
 }

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,15 +26,6 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
-private func invokeDidDetermineState(
-    on manager: RadarLocationManager,
-    locationManager: CLLocationManager,
-    state: CLRegionState,
-    region: CLRegion
-) {
-    manager.locationManager(locationManager, didDetermineState: state, for: region)
-}
-
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -137,43 +128,6 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
-        }
-
-        // MARK: - didDetermineState — public method routing
-
-        @Test("Public didDetermineState routes to the Swift twin when useSwiftLocationManager is enabled")
-        @MainActor
-        func publicDidDetermineStateRoutesToSwiftTwinWhenFlagEnabled() {
-            RadarLocationManagerSwiftTestHelpers.clearState()
-            let bridge = MockRadarSwiftBridge()
-            let originalBridge = RadarSwift.bridge
-            RadarSwift.bridge = bridge
-            defer {
-                RadarSwift.bridge = originalBridge
-                RadarLocationManagerSwiftTestHelpers.clearState()
-            }
-
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
-                "useSwiftLocationManager": true,
-                "useRadarModifiedBeacon": false,
-            ])
-            let locationManager = TrackingCLLocationManager()
-            let location = CLLocation(latitude: 40.7, longitude: -74.0)
-            locationManager.mockLocation = location
-            let region = CLBeaconRegion(
-                uuid: UUID(),
-                identifier: "radar_beacon_\(UUID().uuidString)"
-            )
-
-            invokeDidDetermineState(
-                on: RadarLocationManager.sharedInstance(),
-                locationManager: locationManager,
-                state: .inside,
-                region: region
-            )
-
-            #expect(bridge.lastHandledLocation === location)
-            #expect(bridge.lastHandledSource == .beaconEnter)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,10 +26,6 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
-private func invokeGetLocation(on manager: RadarLocationManager) {
-    manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
-}
-
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -132,56 +128,6 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
-        }
-
-        // MARK: - getLocation — public method routing
-
-        @Test("Public getLocation routes to the Swift twin when useSwiftLocationManager is enabled")
-        func publicGetLocationRoutesToSwiftTwinWhenFlagEnabled() {
-            RadarLocationManagerSwiftTestHelpers.clearState()
-            let bridge = MockRadarSwiftBridge()
-            let originalBridge = RadarSwift.bridge
-            let manager = RadarLocationManager.sharedInstance()
-            let originalPermissionsHelper = manager.permissionsHelper
-            RadarSwift.bridge = bridge
-            defer {
-                RadarSwift.bridge = originalBridge
-                manager.permissionsHelper = originalPermissionsHelper
-                RadarLocationManagerSwiftTestHelpers.clearState()
-            }
-
-            let permissionsHelper = RadarPermissionsHelperMock()
-            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
-            manager.permissionsHelper = permissionsHelper
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
-
-            invokeGetLocation(on: manager)
-
-            #expect(bridge.lastFailStatus == .errorPermissions)
-        }
-
-        @Test("Public getLocation keeps the Objective-C body when useSwiftLocationManager is disabled")
-        func publicGetLocationUsesObjCBodyWhenFlagDisabled() {
-            RadarLocationManagerSwiftTestHelpers.clearState()
-            let bridge = MockRadarSwiftBridge()
-            let originalBridge = RadarSwift.bridge
-            let manager = RadarLocationManager.sharedInstance()
-            let originalPermissionsHelper = manager.permissionsHelper
-            RadarSwift.bridge = bridge
-            defer {
-                RadarSwift.bridge = originalBridge
-                manager.permissionsHelper = originalPermissionsHelper
-                RadarLocationManagerSwiftTestHelpers.clearState()
-            }
-
-            let permissionsHelper = RadarPermissionsHelperMock()
-            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
-            manager.permissionsHelper = permissionsHelper
-            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
-
-            invokeGetLocation(on: manager)
-
-            #expect(bridge.lastFailStatus == nil)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,6 +26,15 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
+private func invokeDidDetermineState(
+    on manager: RadarLocationManager,
+    locationManager: CLLocationManager,
+    state: CLRegionState,
+    region: CLRegion
+) {
+    manager.locationManager(locationManager, didDetermineState: state, for: region)
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -128,6 +137,43 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
+        }
+
+        // MARK: - didDetermineState — public method routing
+
+        @Test("Public didDetermineState routes to the Swift twin when useSwiftLocationManager is enabled")
+        @MainActor
+        func publicDidDetermineStateRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useSwiftLocationManager": true,
+                "useRadarModifiedBeacon": false,
+            ])
+            let locationManager = TrackingCLLocationManager()
+            let location = CLLocation(latitude: 40.7, longitude: -74.0)
+            locationManager.mockLocation = location
+            let region = CLBeaconRegion(
+                uuid: UUID(),
+                identifier: "radar_beacon_\(UUID().uuidString)"
+            )
+
+            invokeDidDetermineState(
+                on: RadarLocationManager.sharedInstance(),
+                locationManager: locationManager,
+                state: .inside,
+                region: region
+            )
+
+            #expect(bridge.lastHandledLocation === location)
+            #expect(bridge.lastHandledSource == .beaconEnter)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing

--- a/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftSeamTests.swift
@@ -26,6 +26,10 @@ private func invokeStopUpdates(on manager: RadarLocationManager) {
     manager.perform(NSSelectorFromString("stopUpdates"))
 }
 
+private func invokeGetLocation(on manager: RadarLocationManager) {
+    manager.perform(NSSelectorFromString("getLocationWithCompletionHandler:"), with: nil)
+}
+
 extension RadarSerializedTests {
     @Suite(.serialized)
     actor RadarLocationManagerSwiftSeamTests {
@@ -128,6 +132,56 @@ extension RadarSerializedTests {
 
             #expect(RadarSettings.remoteTrackingOptions == options)
             #expect(bridge.callOrder.isEmpty)
+        }
+
+        // MARK: - getLocation — public method routing
+
+        @Test("Public getLocation routes to the Swift twin when useSwiftLocationManager is enabled")
+        func publicGetLocationRoutesToSwiftTwinWhenFlagEnabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            let originalPermissionsHelper = manager.permissionsHelper
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                manager.permissionsHelper = originalPermissionsHelper
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let permissionsHelper = RadarPermissionsHelperMock()
+            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+            manager.permissionsHelper = permissionsHelper
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": true])
+
+            invokeGetLocation(on: manager)
+
+            #expect(bridge.lastFailStatus == .errorPermissions)
+        }
+
+        @Test("Public getLocation keeps the Objective-C body when useSwiftLocationManager is disabled")
+        func publicGetLocationUsesObjCBodyWhenFlagDisabled() {
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            let bridge = MockRadarSwiftBridge()
+            let originalBridge = RadarSwift.bridge
+            let manager = RadarLocationManager.sharedInstance()
+            let originalPermissionsHelper = manager.permissionsHelper
+            RadarSwift.bridge = bridge
+            defer {
+                RadarSwift.bridge = originalBridge
+                manager.permissionsHelper = originalPermissionsHelper
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            let permissionsHelper = RadarPermissionsHelperMock()
+            permissionsHelper.mockLocationAuthorizationStatus = .notDetermined
+            manager.permissionsHelper = permissionsHelper
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: ["useSwiftLocationManager": false])
+
+            invokeGetLocation(on: manager)
+
+            #expect(bridge.lastFailStatus == nil)
         }
 
         // MARK: - startUpdates and stopUpdates — public method routing

--- a/RadarSDKTests/RadarLocationManagerSwiftTestHelpers.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftTestHelpers.swift
@@ -17,6 +17,28 @@ import Foundation
 
 enum RadarLocationManagerSwiftTestHelpers {
 
+    /// Wait for an asynchronous delegate callback without making the test depend on a scheduling delay.
+    static func waitForHandledLocation(_ events: AsyncStream<Void>) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                var iterator = events.makeAsyncIterator()
+                return await iterator.next() != nil
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                    return false
+                } catch {
+                    return false
+                }
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
     /// Swift tracking crosses both injection seams; keeping their lifetime scoped together
     /// prevents a test's bridge or authorization state from leaking into the next test.
     static func withMockedSwiftTrackingDependencies(


### PR DESCRIPTION
## Summary

- Port `locationManager:didDetermineState:forRegion:` to Swift.
- Preserve the Objective-C implementation as the fallback when `useSwiftLocationManager` is disabled.
- Keep synced-beacon entry and exit handling on the main actor.

## Test Plan

1. In the Radar dashboard, open the **Beacons** page for the same project and environment used by the Example app. Create or verify an enabled iBeacon with the physical beacon's UUID, major, minor, and coordinates within about 1 kilometer of the test location.
2. In the dashboard's remote SDK configuration, enable the tracking option `beacons`. If the project uses Radar modified beacon mode, disable `useRadarModifiedBeacon` for this test, then save the configuration.
3. Build and launch the Example app on a physical iPhone using the matching project key. Grant location access, select **Always** when testing in the background, and grant Bluetooth access if prompted.
4. Open the Example app's Tracking section, tap **Refresh**, and confirm that **Active tracking options** shows `beacons: true`.
5. Build and run once with `useSwiftLocationManager` enabled in the test configuration. Start tracking from the Example app, then confirm the Debug tab or monitored-region information shows a synced region with a `radar_beacon_` identifier.
6. Move the phone into range of the physical beacon, or restart tracking while already in range, and confirm the Debug tab records beacon-enter location handling.
7. Move the phone out of range of the beacon and confirm the Debug tab records beacon-exit location handling.
8. Stop tracking, build and run again with `useSwiftLocationManager` disabled, and repeat the previous three steps. Confirm that beacon synchronization and enter/exit handling produce the same observable results through the Objective-C fallback.
