### PR TITLE
Simplify nightly Obj-C migration workflow

### DIFF
--- a/.github/workflows/objc-to-swift-nightly.yml
+++ b/.github/workflows/objc-to-swift-nightly.yml
@@ -1,10 +1,10 @@
 name: Nightly ObjC to Swift migration
 
-# Converts ONE deterministic, eligible Objective-C implementation to Swift per run
-# and opens a PR for human review. Approval happens at PR review (see AGENTS.md
-# "Language Policy"). The skill replaces the selected implementation while preserving
-# its Objective-C contract. This job runs the same macOS validation as PR CI before
-# publication; PR CI remains the independent verifier.
+# Converts ONE eligible Objective-C implementation to Swift per run and opens a PR
+# for human review. The migration skill chooses the simplest candidate using explicit
+# candidacy rules, then replaces it while preserving its Objective-C contract. Approval
+# happens at PR review (see AGENTS.md "Language Policy"). This job runs the same macOS
+# validation as PR CI before publication; PR CI remains the independent verifier.
 
 on:
   schedule:
@@ -80,33 +80,17 @@ jobs:
           cp -R clankers-skill/skills/objc-to-swift .claude/skills/objc-to-swift
           rm -rf clankers-skill
 
-      - name: Select deterministic migration target
-        id: candidate
-        if: steps.guard.outputs.open == '0'
-        run: |
-          TARGET="$(bash .claude/skills/objc-to-swift/scripts/find-next-candidate.sh "$GITHUB_WORKSPACE")"
-          if [ -z "$TARGET" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No eligible Objective-C implementation remains; skipping migration."
-            exit 0
-          fi
-
-          echo "available=true" >> "$GITHUB_OUTPUT"
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "MIGRATION_TARGET=$TARGET" >> "$GITHUB_ENV"
-          echo "Selected $TARGET"
-
       - name: Use the PR CI Xcode version
-        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
+        if: steps.guard.outputs.open == '0'
         run: |
           sudo xcode-select -switch /Applications/Xcode_26.3.app
 
       - name: Install Swift validation tools
-        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
+        if: steps.guard.outputs.open == '0'
         run: brew install swift-format swiftlint
 
       - name: Pick an available iPhone simulator
-        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
+        if: steps.guard.outputs.open == '0'
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices --json \
             | jq -r '
@@ -127,19 +111,22 @@ jobs:
           echo "MIGRATION_DESTINATION=platform=iOS Simulator,id=$SIMULATOR_ID" >> "$GITHUB_ENV"
 
       - name: Run the migration agent
-        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
+        if: steps.guard.outputs.open == '0'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          MIGRATION_TARGET: ${{ steps.candidate.outputs.target }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             /objc-to-swift batch
 
-            Convert exactly the preselected file at
-            ${{ steps.candidate.outputs.target }}. Do not select another file or leave
-            the Objective-C implementation beside the Swift replacement. The workflow
-            provides MIGRATION_TARGET, GH_TOKEN, and MIGRATION_DESTINATION.
+            Inspect the full RadarSDK Objective-C backlog and choose exactly one eligible
+            implementation. Prefer the smallest implementation, then the least coupled,
+            then the filename. Exclude managers, partial migrations, and models already
+            represented elsewhere. State the selected file and rationale before editing.
+            Replace it with a same-basename Swift implementation, preserve Objective-C
+            compatibility, delete the old .m and project references, and do not select
+            another file or leave the old implementation beside Swift. The workflow
+            provides GH_TOKEN and MIGRATION_DESTINATION.
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep" --max-turns 80'

--- a/.github/workflows/objc-to-swift-nightly.yml
+++ b/.github/workflows/objc-to-swift-nightly.yml
@@ -1,10 +1,10 @@
 name: Nightly ObjC to Swift migration
 
-# Converts ONE safe Objective-C file to Swift per run and opens a PR for human
-# review. Approval happens at PR review (see AGENTS.md "Language Policy") — the
-# agent only picks conservative leaf files, and skips the run entirely while a
-# previous migration PR is still open. This job runs the same macOS validation
-# as PR CI before publication; PR CI remains the independent verifier.
+# Converts ONE deterministic, eligible Objective-C implementation to Swift per run
+# and opens a PR for human review. Approval happens at PR review (see AGENTS.md
+# "Language Policy"). The skill replaces the selected implementation while preserving
+# its Objective-C contract. This job runs the same macOS validation as PR CI before
+# publication; PR CI remains the independent verifier.
 
 on:
   schedule:
@@ -80,17 +80,33 @@ jobs:
           cp -R clankers-skill/skills/objc-to-swift .claude/skills/objc-to-swift
           rm -rf clankers-skill
 
-      - name: Use the PR CI Xcode version
+      - name: Select deterministic migration target
+        id: candidate
         if: steps.guard.outputs.open == '0'
+        run: |
+          TARGET="$(bash .claude/skills/objc-to-swift/scripts/find-next-candidate.sh "$GITHUB_WORKSPACE")"
+          if [ -z "$TARGET" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No eligible Objective-C implementation remains; skipping migration."
+            exit 0
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "MIGRATION_TARGET=$TARGET" >> "$GITHUB_ENV"
+          echo "Selected $TARGET"
+
+      - name: Use the PR CI Xcode version
+        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
         run: |
           sudo xcode-select -switch /Applications/Xcode_26.3.app
 
       - name: Install Swift validation tools
-        if: steps.guard.outputs.open == '0'
+        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
         run: brew install swift-format swiftlint
 
       - name: Pick an available iPhone simulator
-        if: steps.guard.outputs.open == '0'
+        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices --json \
             | jq -r '
@@ -111,17 +127,19 @@ jobs:
           echo "MIGRATION_DESTINATION=platform=iOS Simulator,id=$SIMULATOR_ID" >> "$GITHUB_ENV"
 
       - name: Run the migration agent
-        if: steps.guard.outputs.open == '0'
+        if: steps.guard.outputs.open == '0' && steps.candidate.outputs.available == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MIGRATION_TARGET: ${{ steps.candidate.outputs.target }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             /objc-to-swift batch
 
-            This is the unattended nightly migration run. Follow the skill's
-            "Batch mode (unattended CI runs)" section exactly. The workflow
-            provides GH_TOKEN and MIGRATION_DESTINATION for that procedure.
+            Convert exactly the preselected file at
+            ${{ steps.candidate.outputs.target }}. Do not select another file or leave
+            the Objective-C implementation beside the Swift replacement. The workflow
+            provides MIGRATION_TARGET, GH_TOKEN, and MIGRATION_DESTINATION.
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep" --max-turns 80'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,17 @@ When working in an existing Objective-C file, consider migrating the file to Swi
 
 **Sanctioned exception — the nightly batch migration.** The scheduled workflow
 `.github/workflows/objc-to-swift-nightly.yml` runs the `objc-to-swift` skill (from
-`radarlabs/clankers`) in its unattended batch mode: each run picks the most trivial
-remaining leaf file (smallest, least-coupled, no risky flags), converts that one file, and
-opens a PR labeled `swift-migration`. In that context the
+`radarlabs/clankers`) in its unattended batch mode: each run selects one deterministic,
+eligible implementation, replaces it with a same-basename Swift implementation while
+preserving compatibility, deletes the old `.m` from the project, and opens a PR labeled
+`swift-migration`. In that context the
 "ask the user" requirement is satisfied by human review of that PR — nothing merges without
 an explicit approval — and at most one such PR may be open at a time. Interactive sessions
 must still ask before migrating.
+
+Large stateful managers may use a temporary Swift seam only when a user explicitly approves
+that staged migration. The nightly workflow does not select managers or leave parallel
+implementations for ordinary files.
 
 ## Build & Test
 
@@ -74,7 +79,11 @@ Run `git submodule update --init --recursive` to initialize submodules.
 
 ## Xcode Project
 
-The Xcode project is `RadarSDK.xcodeproj`. When adding new Swift files, add them to the project file (`project.pbxproj`) so they are compiled. Remove the corresponding `.m` and `.h` files from the project when migrating a class.
+The Xcode project is `RadarSDK.xcodeproj`. When adding new Swift files, add them to the
+project file (`project.pbxproj`) so they are compiled. Remove the corresponding `.m` file
+and project references when migrating a class. Keep the `.h` file and its Headers entry
+while Objective-C consumers still import the compatibility surface; remove it only after
+confirming it is unused.
 
 ## Debugging CI Failures
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ When working in an existing Objective-C file, consider migrating the file to Swi
 
 **Sanctioned exception — the nightly batch migration.** The scheduled workflow
 `.github/workflows/objc-to-swift-nightly.yml` runs the `objc-to-swift` skill (from
-`radarlabs/clankers`) in its unattended batch mode: each run selects one deterministic,
-eligible implementation, replaces it with a same-basename Swift implementation while
-preserving compatibility, deletes the old `.m` from the project, and opens a PR labeled
-`swift-migration`. In that context the
+`radarlabs/clankers`) in its unattended batch mode: each run asks the skill to choose one
+eligible implementation using its candidacy rules, replaces it with a same-basename Swift
+implementation while preserving compatibility, deletes the old `.m` from the project, and
+opens a PR labeled `swift-migration`. In that context the
 "ask the user" requirement is satisfied by human review of that PR — nothing merges without
 an explicit approval — and at most one such PR may be open at a time. Interactive sessions
 must still ask before migrating.


### PR DESCRIPTION
## Motivation

Basically, the skill/workflow was not doing a great job and I think it just had too much in it. I wanted to simplify it focusing on removing simple Obj-C classes and replacing them with Swift.

## Summary

- Removes workflow-side candidate preselection and lets the migration agent choose exactly one eligible Objective-C implementation using explicit candidacy rules.
- Directs the agent to prefer the smallest, least-coupled eligible file, preserve Objective-C compatibility, delete the old `.m` and project references, and stop on blockers instead of switching files.
- Preserves the existing GitHub App, one-open-PR guard, macOS validation setup, simulator selection, and runtime skill staging while updating repository policy for compatibility-first deletion.

Related skill change: [radarlabs/clankers#22](https://github.com/radarlabs/clankers/pull/22)
