### PR TITLE
FENCE-2804: Port region entry and exit delegates to Swift

### DIFF
--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -106,31 +106,70 @@ extension RadarLocationManagerSwift {
                 return
             }
 
-            let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
-            runOnMainThread { [stateBox] in
-                let beaconManager = RadarBeaconManagerSwift.shared
-                let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
-                    RadarSwift.bridge?.handleLocation(
-                        stateBox.location,
-                        source: beaconSource,
-                        beacons: nearbyBeacons
-                    )
-                }
-
-                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
-                    if isEntry {
-                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
-                    } else {
-                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
-                    }
-                } else if isEntry {
-                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
-                } else {
-                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
-                }
-            }
+            handleBeaconRegion(
+                location: location,
+                identifier: identifier,
+                region: beaconRegion,
+                source: beaconSource,
+                isEntry: isEntry
+            )
         } else if let location = locationManager.location {
             RadarSwift.bridge?.handleLocation(location, source: geofenceSource)
+        }
+    }
+
+    private static func handleBeaconRegion(
+        location: CLLocation,
+        identifier: String,
+        region: CLBeaconRegion,
+        source: RadarLocationSource,
+        isEntry: Bool
+    ) {
+        let beaconUUID = region.uuid
+        let beaconMajor = region.major?.uint16Value
+        let beaconMinor = region.minor?.uint16Value
+
+        Task { @MainActor in
+            let beaconManager = RadarBeaconManagerSwift.shared
+            let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
+                RadarSwift.bridge?.handleLocation(
+                    location,
+                    source: source,
+                    beacons: nearbyBeacons
+                )
+            }
+
+            if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                if isEntry {
+                    beaconManager.handleBeaconUUIDEntry(completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconUUIDExit(completionHandler: completionHandler)
+                }
+            } else {
+                let beaconRegion: CLBeaconRegion
+                if let beaconMajor, let beaconMinor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        minor: beaconMinor,
+                        identifier: identifier
+                    )
+                } else if let beaconMajor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        identifier: identifier
+                    )
+                } else {
+                    beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
+                }
+
+                if isEntry {
+                    beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
+                }
+            }
         }
     }
 

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -66,6 +66,74 @@ extension RadarLocationManagerSwift {
         RadarSwift.bridge?.handleLocation(location, source: source)
     }
 
+    @objc(didEnterRegionOnLocationManager:region:)
+    static func didEnterRegion(locationManager: CLLocationManager, region: CLRegion) {
+        handleRegion(
+            locationManager: locationManager,
+            region: region,
+            action: "entry",
+            isEntry: true
+        )
+    }
+
+    @objc(didExitRegionOnLocationManager:region:)
+    static func didExitRegion(locationManager: CLLocationManager, region: CLRegion) {
+        handleRegion(
+            locationManager: locationManager,
+            region: region,
+            action: "exit",
+            isEntry: false
+        )
+    }
+
+    private static func handleRegion(
+        locationManager: CLLocationManager,
+        region: CLRegion,
+        action: String,
+        isEntry: Bool
+    ) {
+        guard shouldHandleRegion(identifier: region.identifier, action: action) else {
+            return
+        }
+
+        let identifier = region.identifier
+        let location = effectiveLocation(for: locationManager)
+        let beaconSource: RadarLocationSource = isEntry ? .beaconEnter : .beaconExit
+        let geofenceSource: RadarLocationSource = isEntry ? .geofenceEnter : .geofenceExit
+
+        if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) || identifier.hasPrefix(syncBeaconIdentifierPrefix) {
+            guard let location, let beaconRegion = region as? CLBeaconRegion else {
+                return
+            }
+
+            let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
+            runOnMainThread { [stateBox] in
+                let beaconManager = RadarBeaconManagerSwift.shared
+                let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
+                    RadarSwift.bridge?.handleLocation(
+                        stateBox.location,
+                        source: beaconSource,
+                        beacons: nearbyBeacons
+                    )
+                }
+
+                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                    if isEntry {
+                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
+                    } else {
+                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
+                    }
+                } else if isEntry {
+                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
+                }
+            }
+        } else if let location = locationManager.location {
+            RadarSwift.bridge?.handleLocation(location, source: geofenceSource)
+        }
+    }
+
     @objc(didDetermineStateOnLocationManager:state:region:)
     static func didDetermineState(locationManager: CLLocationManager, state: CLRegionState, region: CLRegion) {
         let identifier = region.identifier

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1394,6 +1394,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
 - (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
     if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didEnterRegionOnLocationManager:manager region:region];
+        return;
+    }
+
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
         if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"entry"]) {
             return;
         }
@@ -1440,6 +1445,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didExitRegionOnLocationManager:manager region:region];
+        return;
+    }
+
     if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
         if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"exit"]) {
             return;

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -76,6 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)didUpdateLocations:(nullable NSArray<CLLocation *> *)updates completionHandlerCount:(NSUInteger)completionHandlerCount;
 + (void)didVisitOnLocationManager:(CLLocationManager *)locationManager visit:(CLVisit *)visit;
++ (void)didEnterRegionOnLocationManager:(CLLocationManager *)locationManager
+                                 region:(CLRegion *)region;
++ (void)didExitRegionOnLocationManager:(CLLocationManager *)locationManager
+                                region:(CLRegion *)region;
 + (void)didDetermineStateOnLocationManager:(CLLocationManager *)locationManager
                                      state:(CLRegionState)state
                                     region:(CLRegion *)region;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -39,6 +39,9 @@
 - (void)didReceiveEvents:(NSArray<RadarEvent *> * _Nonnull)events user:(RadarUser * _Nonnull)user;
 - (void)didUpdateClientLocation:(CLLocation * _Nonnull)location stopped:(BOOL)stopped source:(RadarLocationSource)source;
 - (void)handleLocation:(CLLocation * _Nonnull)location source:(RadarLocationSource)source;
+- (void)handleLocation:(CLLocation * _Nonnull)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> * _Nullable)beacons;
 - (void)updateTracking;
 - (void)didFailWithStatus:(RadarStatus)status;
 - (RadarBeacon * _Nonnull)createBeaconWithUuid:(NSString * _Nonnull)uuid major:(NSString * _Nonnull)major minor:(NSString * _Nonnull)minor rssi:(NSInteger)rssi;

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -19,6 +19,12 @@
 #import "RadarIndoors.h"
 #import "RadarLocationManager.h"
 
+@interface RadarLocationManager (SwiftBeaconLocation)
+- (void)handleLocation:(CLLocation *)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> *)beacons;
+@end
+
 @implementation RadarSwiftBridge
 
 - (void)flushReplays {
@@ -98,6 +104,10 @@
 
 - (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
     [[RadarLocationManager sharedInstance] handleLocation:location source:source];
+}
+
+- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source beacons:(NSArray<RadarBeacon *> *)beacons {
+    [[RadarLocationManager sharedInstance] handleLocation:location source:source beacons:beacons];
 }
 
 - (RadarUser * _Nullable)radarUser {

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -31,6 +31,7 @@ protocol RadarSwiftBridgeProtocol {
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser)
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource)
     func handleLocation(_ location: CLLocation, source: RadarLocationSource)
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?)
     func updateTracking()
     func radarUser() -> RadarUser?
     func didFail(status: RadarStatus)

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -71,9 +71,15 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     }
     private(set) var lastHandledLocation: CLLocation?
     private(set) var lastHandledSource: RadarLocationSource?
+    private(set) var lastHandledBeacons: [RadarBeacon]?
     func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
         lastHandledLocation = location
         lastHandledSource = source
+    }
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?) {
+        lastHandledLocation = location
+        lastHandledSource = source
+        lastHandledBeacons = beacons
     }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -600,3 +600,152 @@ extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
         #expect(bridge.lastHandledSource == .beaconEnter)
     }
 }
+
+extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
+    // MARK: - didEnterRegion and didExitRegion
+
+    @Test("region callbacks handle synced beacon entry and exit with nearby beacons")
+    @MainActor
+    func regionCallbacksHandleSyncedBeaconEntryAndExit() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useRadarModifiedBeacon": false
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLBeaconRegion(
+            uuid: UUID(),
+            identifier: "radar_beacon_\(UUID().uuidString)"
+        )
+
+        RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconEnter)
+        #expect(bridge.lastHandledBeacons?.isEmpty == false)
+
+        RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconExit)
+    }
+
+    @Test("region callbacks use the current location for geofence entry and exit")
+    @MainActor
+    func regionCallbacksHandleGeofenceEntryAndExit() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceEnter)
+
+        RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceExit)
+    }
+}
+
+extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
+    @Test("Public region callbacks route to the Swift twins when enabled")
+    @MainActor
+    func publicRegionCallbacksRouteToSwiftTwinsWhenFlagEnabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalLocationManager = manager.locationManager
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.locationManager = originalLocationManager
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": true
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        manager.locationManager = locationManager
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        manager.locationManager(locationManager, didEnterRegion: region)
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceEnter)
+
+        manager.locationManager(locationManager, didExitRegion: region)
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceExit)
+    }
+
+    @Test("Public region callbacks keep the Objective-C body when disabled")
+    @MainActor
+    func publicRegionCallbacksUseObjCBodyWhenFlagDisabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalLocationManager = manager.locationManager
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.locationManager = originalLocationManager
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": false
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        manager.locationManager = locationManager
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        manager.locationManager(locationManager, didEnterRegion: region)
+        manager.locationManager(locationManager, didExitRegion: region)
+
+        #expect(bridge.lastHandledLocation == nil)
+        #expect(bridge.lastHandledSource == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Port `locationManager:didEnterRegion:` and `locationManager:didExitRegion:` to Swift.
- Preserve synced-beacon nearby-beacon handling and geofence location handling.
- Keep the Objective-C implementations as the fallback when `useSwiftLocationManager` is disabled.

## Test Plan

1. In the Radar dashboard, open the **Beacons** page for the project and environment used by the Example app.
2. Create or verify an enabled iBeacon with the physical beacon UUID, major, minor, and a location near the test device.
3. In the dashboard remote SDK configuration, enable the `beacons` tracking option and disable `useRadarModifiedBeacon` for this test, then save the configuration.
4. Build and launch the Example app on a physical iPhone with the matching project key. Grant location access and Bluetooth access when prompted.
5. Start tracking in the Example app and confirm the Debug tab or monitored-region information shows a synced region with a `radar_beacon_` identifier.
6. Move the phone into range of the physical beacon, or restart tracking while already in range, and confirm the Debug tab records beacon-enter location handling.
7. Move the phone out of range and confirm the Debug tab records beacon-exit location handling.
8. Build and run again with `useSwiftLocationManager` disabled, repeat the enter and exit steps, and confirm the same behavior occurs through the Objective-C fallback.
9. Stop tracking, switch the remote tracking override back to the project default, and confirm the Example app returns to its normal tracking behavior.

## Validation

- `make lint-swift` passed with zero violations.
- Strict `swift-format` passed on touched Swift files.
- Focused region, lifecycle, and seam tests passed.
- SDK build-for-testing passed.