### PR TITLE
FENCE-2804: Simplify `didDetermineState` Swift port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ Large stateful managers may use a temporary Swift seam only when a user explicit
 that staged migration. The nightly workflow does not select managers or leave parallel
 implementations for ordinary files.
 
+## Concurrency
+
+When Swift starts work that can run later on the main actor, prefer `Task { @MainActor in ... }`
+over `DispatchQueue.main.async`. Objective-C cannot enforce Swift actor isolation, so it may use
+`runOnMainThread` before calling Swift code that owns main-actor state.
+
 ## Build & Test
 
 ```bash

--- a/RadarSDK.xcodeproj/project.pbxproj
+++ b/RadarSDK.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		B0A0F0322FBC000100111111 /* MockRadarSwiftBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0332FBC000100111111 /* MockRadarSwiftBridge.swift */; };
 		B0A0F0342FBC000100111111 /* RadarLocationManagerSwiftRTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0352FBC000100111111 /* RadarLocationManagerSwiftRTOTests.swift */; };
 		B0A0F0382FBC000100111111 /* RadarLocationManager+SwiftDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F0392FBC000100111111 /* RadarLocationManager+SwiftDelegate.swift */; };
+		B0A0F03A2FBC000100111111 /* RadarLocationManagerSwiftBeaconStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0F03B2FBC000100111111 /* RadarLocationManagerSwiftBeaconStateTests.swift */; };
 		B7E6CE0E6EFBA25C635EC1C1 /* CLLocation+Radar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171F6F711363E4AC60E02B28 /* CLLocation+Radar.swift */; };
 		BA264CFB2FF3158B000EDFE6 /* RadarReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA264CFA2FF31582000EDFE6 /* RadarReplay.swift */; };
 		BA264CFD2FF31BD9000EDFE6 /* RadarReplay.h in Headers */ = {isa = PBXBuildFile; fileRef = BA264CFC2FF31BD5000EDFE6 /* RadarReplay.h */; };
@@ -407,6 +408,7 @@
 		B0A0F0332FBC000100111111 /* MockRadarSwiftBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRadarSwiftBridge.swift; sourceTree = "<group>"; };
 		B0A0F0352FBC000100111111 /* RadarLocationManagerSwiftRTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftRTOTests.swift; sourceTree = "<group>"; };
 		B0A0F0392FBC000100111111 /* RadarLocationManager+SwiftDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RadarLocationManager+SwiftDelegate.swift"; sourceTree = "<group>"; };
+		B0A0F03B2FBC000100111111 /* RadarLocationManagerSwiftBeaconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarLocationManagerSwiftBeaconStateTests.swift; sourceTree = "<group>"; };
 		BA264CFA2FF31582000EDFE6 /* RadarReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarReplay.swift; sourceTree = "<group>"; };
 		BA264CFC2FF31BD5000EDFE6 /* RadarReplay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RadarReplay.h; sourceTree = "<group>"; };
 		BA264CFE2FF31FAF000EDFE6 /* RadarReplayBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarReplayBuffer.swift; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 				B0A0F0172FBC000100111111 /* TrackingCLLocationManager.swift */,
 				B0A0F0192FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift */,
 				B0A0F0212FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift */,
+				B0A0F03B2FBC000100111111 /* RadarLocationManagerSwiftBeaconStateTests.swift */,
 				B0A0F0232FBC000100111111 /* StubCLHeading.swift */,
 				B0A0F0252FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift */,
 				B0A0F0292FBC000100111111 /* RadarLocationManagerSwiftAuthTests.swift */,
@@ -1349,6 +1352,7 @@
 				B0A0F0162FBC000100111111 /* TrackingCLLocationManager.swift in Sources */,
 				B0A0F0182FBC000100111111 /* RadarLocationManagerSwiftBeaconSyncTests.swift in Sources */,
 				B0A0F0202FBC000100111111 /* RadarLocationManagerSwiftRegionTests.swift in Sources */,
+				B0A0F03A2FBC000100111111 /* RadarLocationManagerSwiftBeaconStateTests.swift in Sources */,
 				B0A0F0222FBC000100111111 /* StubCLHeading.swift in Sources */,
 				B0A0F0242FBC000100111111 /* RadarLocationManagerSwiftHeadingTests.swift in Sources */,
 				B0A0F0282FBC000100111111 /* RadarLocationManagerSwiftAuthTests.swift in Sources */,

--- a/RadarSDK/RadarLocationManager+Swift.swift
+++ b/RadarSDK/RadarLocationManager+Swift.swift
@@ -59,8 +59,8 @@ final class RadarLocationManagerSwift: NSObject {  // swiftlint:disable:this typ
     static let identifierPrefix = "radar_"
     private static let bubbleGeofenceIdentifierPrefix = "radar_bubble_"
     private static let syncGeofenceIdentifierPrefix = "radar_geofence_"
-    private static let syncBeaconIdentifierPrefix = "radar_beacon_"
-    private static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
+    static let syncBeaconIdentifierPrefix = "radar_beacon_"
+    static let syncBeaconUUIDIdentifierPrefix = "radar_uuid_"
     private static let trackingShutdownDelay: TimeInterval = 10
     private static let immediateShutdownDelay: TimeInterval = 0
     nonisolated(unsafe) static var permissionsHelper: RadarPermissionsHelping = RadarPermissionsHelperSwift()

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -66,6 +66,37 @@ extension RadarLocationManagerSwift {
         RadarSwift.bridge?.handleLocation(location, source: source)
     }
 
+    @MainActor
+    @objc(didDetermineState:region:completionHandler:)
+    static func didDetermineState(
+        _ state: CLRegionState,
+        region: CLRegion,
+        completionHandler: @escaping RadarBeaconCompletionHandler
+    ) {
+        let identifier = region.identifier
+        guard identifier.hasPrefix(syncBeaconIdentifierPrefix) || identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix),
+            let beaconRegion = region as? CLBeaconRegion
+        else {
+            return
+        }
+
+        let isInside = state == .inside
+        RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
+
+        let beaconManager = RadarBeaconManagerSwift.shared
+        if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+            if isInside {
+                beaconManager.handleBeaconUUIDEntry(for: beaconRegion, completionHandler: completionHandler)
+            } else {
+                beaconManager.handleBeaconUUIDExit(for: beaconRegion, completionHandler: completionHandler)
+            }
+        } else if isInside {
+            beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
+        } else {
+            beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
+        }
+    }
+
     @objc(didUpdateHeading:)
     static func didUpdateHeading(_ heading: CLHeading) {
         RadarState().lastHeadingData = [

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1489,6 +1489,24 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        CLLocation *location = [RadarLocationManagerSwift effectiveLocationForLocationManager:manager];
+        if (!location) {
+            return;
+        }
+
+        RadarLocationSource source = state == CLRegionStateInside ? RadarLocationSourceBeaconEnter : RadarLocationSourceBeaconExit;
+        RadarBeaconCompletionHandler completionHandler = ^(RadarStatus status, NSArray<RadarBeacon *> *_Nullable nearbyBeacons) {
+            [self handleLocation:location source:source beacons:nearbyBeacons];
+        };
+
+        // Swift owns beacon state on the main actor, so Objective-C must move there before calling it.
+        [RadarUtilsDeprecated runOnMainThread:^{
+            [RadarLocationManagerSwift didDetermineState:state region:region completionHandler:completionHandler];
+        }];
+        return;
+    }
+
     if (!([region.identifier hasPrefix:kSyncBeaconIdentifierPrefix] || [region.identifier hasPrefix:kSyncBeaconUUIDIdentifierPrefix])) {
         return;
     }

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -76,6 +76,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)didUpdateLocations:(nullable NSArray<CLLocation *> *)updates completionHandlerCount:(NSUInteger)completionHandlerCount;
 + (void)didVisitOnLocationManager:(CLLocationManager *)locationManager visit:(CLVisit *)visit;
++ (void)didDetermineState:(CLRegionState)state
+                   region:(CLRegion *)region
+        completionHandler:(RadarBeaconCompletionHandler)completionHandler;
 
 + (void)didUpdateHeading:(CLHeading *)newHeading;
 + (void)didChangeAuthorizationStatus:(CLAuthorizationStatus)status;

--- a/RadarSDKTests/RadarLocationManagerSwiftBeaconStateTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftBeaconStateTests.swift
@@ -1,0 +1,200 @@
+//
+//  RadarLocationManagerSwiftBeaconStateTests.swift
+//  RadarSDKTests
+//
+//  Copyright © 2026 Radar Labs, Inc. All rights reserved.
+//
+
+import CoreLocation
+import Testing
+
+@testable import RadarSDK
+
+extension RadarSerializedTests {
+    @Suite(.serialized)
+    @MainActor
+    struct RadarLocationManagerBeaconStateTests {
+        private let beaconManager = RadarBeaconManagerSwift.shared
+
+        private func withBeaconDependencies(_ body: () -> Void) {
+            let originalBridge = RadarSwift.bridge
+            let originalPermissionsHelper = beaconManager.permissionsHelper
+            let originalBeaconUUIDs = RadarSettings.beaconUUIDs
+
+            RadarLocationManagerSwiftTestHelpers.clearState()
+            RadarSwift.bridge = MockRadarSwiftBridge()
+            beaconManager.permissionsHelper = MockRadarPermissionsHelper()
+            RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                "useRadarModifiedBeacon": false
+            ])
+            RadarSettings.beaconUUIDs = []
+            RadarSettings.tracking = false
+            let trackingOptions = RadarTrackingOptions.presetResponsive
+            trackingOptions.syncLocations = .events
+            RadarSettings.trackingOptions = trackingOptions
+            beaconManager.stopRanging()
+
+            defer {
+                beaconManager.stopRanging()
+                RadarSwift.bridge = originalBridge
+                beaconManager.permissionsHelper = originalPermissionsHelper
+                RadarSettings.beaconUUIDs = originalBeaconUUIDs
+                RadarLocationManagerSwiftTestHelpers.clearState()
+            }
+
+            body()
+        }
+
+        private func makeRegion(identifier: String) -> CLBeaconRegion {
+            CLBeaconRegion(
+                uuid: UUID(),
+                major: 1,
+                minor: 2,
+                identifier: identifier
+            )
+        }
+
+        private func makeLocation() -> CLLocation {
+            CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 40.7, longitude: -74),
+                altitude: 0,
+                horizontalAccuracy: 5,
+                verticalAccuracy: 5,
+                timestamp: Date()
+            )
+        }
+
+        @Test("didDetermineState ignores non-beacon regions")
+        func ignoresNonBeaconRegion() {
+            withBeaconDependencies {
+                let region = CLCircularRegion(
+                    center: CLLocationCoordinate2D(latitude: 40.7, longitude: -74),
+                    radius: 100,
+                    identifier: "radar_geofence_test"
+                )
+                var called = false
+
+                RadarLocationManagerSwift.didDetermineState(.inside, region: region) { _, _ in
+                    called = true
+                }
+
+                #expect(!called)
+            }
+        }
+
+        @Test("didDetermineState forwards the normal beacon entry payload")
+        func forwardsNormalBeaconEntryPayload() {
+            withBeaconDependencies {
+                let region = makeRegion(identifier: "radar_beacon_test")
+                var entryBeacons: [RadarBeacon]?
+
+                RadarLocationManagerSwift.didDetermineState(.inside, region: region) { _, beacons in
+                    entryBeacons = beacons
+                }
+
+                #expect(entryBeacons?.count == 1)
+                #expect(beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+
+        @Test("didDetermineState forwards the normal beacon exit payload")
+        func forwardsNormalBeaconExitPayload() {
+            withBeaconDependencies {
+                let region = makeRegion(identifier: "radar_beacon_test")
+                var exitBeacons: [RadarBeacon]?
+                beaconManager.nearbyBeaconIdentifiers.insert(region.identifier)
+
+                RadarLocationManagerSwift.didDetermineState(.outside, region: region) { _, beacons in
+                    exitBeacons = beacons
+                }
+
+                #expect(exitBeacons?.isEmpty == true)
+                #expect(!beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+
+        @Test("didDetermineState handles UUID beacon entry and exit")
+        func handlesUUIDBeaconStates() {
+            withBeaconDependencies {
+                let region = makeRegion(identifier: "radar_uuid_test")
+                var entryStatus: RadarStatus?
+                var exitStatus: RadarStatus?
+
+                RadarLocationManagerSwift.didDetermineState(.inside, region: region) { status, beacons in
+                    entryStatus = status
+                    #expect(beacons?.isEmpty == true)
+                }
+                RadarLocationManagerSwift.didDetermineState(.outside, region: region) { status, beacons in
+                    exitStatus = status
+                    #expect(beacons?.isEmpty == true)
+                }
+
+                #expect(entryStatus == .success)
+                #expect(exitStatus == .success)
+            }
+        }
+
+        @Test("Public didDetermineState uses the Swift path when enabled")
+        func publicMethodUsesSwiftPath() {
+            withBeaconDependencies {
+                RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                    "useRadarModifiedBeacon": false,
+                    "useSwiftLocationManager": true,
+                ])
+                let locationManager = TrackingCLLocationManager()
+                locationManager.mockLocation = makeLocation()
+                let region = makeRegion(identifier: "radar_beacon_swift")
+
+                RadarLocationManager.sharedInstance().locationManager(
+                    locationManager,
+                    didDetermineState: .inside,
+                    for: region
+                )
+
+                #expect(beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+
+        @Test("Public didDetermineState keeps the Objective-C fallback when disabled")
+        func publicMethodUsesObjectiveCFallback() {
+            withBeaconDependencies {
+                RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                    "useRadarModifiedBeacon": false,
+                    "useSwiftLocationManager": false,
+                ])
+                let locationManager = TrackingCLLocationManager()
+                locationManager.mockLocation = makeLocation()
+                let region = makeRegion(identifier: "radar_beacon_objc")
+
+                RadarLocationManager.sharedInstance().locationManager(
+                    locationManager,
+                    didDetermineState: .inside,
+                    for: region
+                )
+
+                #expect(beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+
+        @Test("Public Swift path ignores beacon state without an effective location")
+        func publicSwiftPathRequiresLocation() {
+            withBeaconDependencies {
+                RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+                    "useRadarModifiedBeacon": false,
+                    "useSwiftLocationManager": true,
+                ])
+                let locationManager = TrackingCLLocationManager()
+                let region = makeRegion(identifier: "radar_beacon_no_location")
+                RadarSwift.bridge = MockRadarSwiftBridge()
+
+                RadarLocationManager.sharedInstance().locationManager(
+                    locationManager,
+                    didDetermineState: .inside,
+                    for: region
+                )
+
+                #expect(!beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Port `locationManager:didDetermineState:forRegion:` to a synchronous main-actor Swift twin.
- Keep Objective-C responsible for final location processing and preserve its implementation as the feature-flag fallback.
- Use one explicit Objective-C-to-main-actor handoff without unstructured tasks, bridge capture, reconstructed beacon regions, or asynchronous test synchronization.
- Document the Objective-C-to-main-actor boundary in the repository concurrency guidance.

Basically #701 got out of hand with concurrency stuff and thread hopping so I think the right move here is to sort of "kick the can down the road" and when we have everything in Swift, we can reapproach the threading

## Test Plan

1. In the Radar dashboard, configure an enabled iBeacon whose UUID, major, and minor match a physical test beacon, and enable beacon tracking for the Example app's project.
2. Build and launch the Example app on a physical iPhone, then grant location and Bluetooth permissions.
3. Start tracking and confirm the synced beacon region appears in the app's monitored-region or Debug information.
4. Move the phone into range of the beacon and confirm the Debug tab records beacon-enter location handling.
5. Move the phone out of range and confirm the Debug tab records beacon-exit location handling.
6. Repeat the previous steps with `useSwiftLocationManager` disabled and confirm the Objective-C fallback produces the same behavior.
