### PR TITLE
FENCE-2804: Port region entry and exit delegates to Swift

### DIFF
--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -157,19 +157,31 @@ extension RadarLocationManagerSwift {
                 beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
             }
 
-            if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
-                if isEntry {
-                    beaconManager.handleBeaconUUIDEntry(for: beaconRegion, completionHandler: completionHandler)
-                } else {
-                    beaconManager.handleBeaconUUIDExit(for: beaconRegion, completionHandler: completionHandler)
-                }
+            handleBeacon(
+                region: beaconRegion,
+                isEntry: isEntry,
+                completionHandler: completionHandler
+            )
+        }
+    }
+
+    @MainActor
+    private static func handleBeacon(
+        region: CLBeaconRegion,
+        isEntry: Bool,
+        completionHandler: @escaping RadarBeaconCompletionHandler
+    ) {
+        let beaconManager = RadarBeaconManagerSwift.shared
+        if region.identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+            if isEntry {
+                beaconManager.handleBeaconUUIDEntry(for: region, completionHandler: completionHandler)
             } else {
-                if isEntry {
-                    beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
-                } else {
-                    beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
-                }
+                beaconManager.handleBeaconUUIDExit(for: region, completionHandler: completionHandler)
             }
+        } else if isEntry {
+            beaconManager.handleBeaconEntry(for: region, completionHandler: completionHandler)
+        } else {
+            beaconManager.handleBeaconExit(for: region, completionHandler: completionHandler)
         }
     }
 
@@ -190,18 +202,11 @@ extension RadarLocationManagerSwift {
         let isInside = state == .inside
         RadarLogger.shared.debug("🦅 \(isInside ? "Inside" : "Outside") beacon region | identifier = \(identifier)")
 
-        let beaconManager = RadarBeaconManagerSwift.shared
-        if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
-            if isInside {
-                beaconManager.handleBeaconUUIDEntry(for: beaconRegion, completionHandler: completionHandler)
-            } else {
-                beaconManager.handleBeaconUUIDExit(for: beaconRegion, completionHandler: completionHandler)
-            }
-        } else if isInside {
-            beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
-        } else {
-            beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
-        }
+        handleBeacon(
+            region: beaconRegion,
+            isEntry: isInside,
+            completionHandler: completionHandler
+        )
     }
 
     @objc(didUpdateHeading:)

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -66,6 +66,74 @@ extension RadarLocationManagerSwift {
         RadarSwift.bridge?.handleLocation(location, source: source)
     }
 
+    @objc(didEnterRegionOnLocationManager:region:)
+    static func didEnterRegion(locationManager: CLLocationManager, region: CLRegion) {
+        handleRegion(
+            locationManager: locationManager,
+            region: region,
+            action: "entry",
+            isEntry: true
+        )
+    }
+
+    @objc(didExitRegionOnLocationManager:region:)
+    static func didExitRegion(locationManager: CLLocationManager, region: CLRegion) {
+        handleRegion(
+            locationManager: locationManager,
+            region: region,
+            action: "exit",
+            isEntry: false
+        )
+    }
+
+    private static func handleRegion(
+        locationManager: CLLocationManager,
+        region: CLRegion,
+        action: String,
+        isEntry: Bool
+    ) {
+        guard shouldHandleRegion(identifier: region.identifier, action: action) else {
+            return
+        }
+
+        let identifier = region.identifier
+        let location = effectiveLocation(for: locationManager)
+        let beaconSource: RadarLocationSource = isEntry ? .beaconEnter : .beaconExit
+        let geofenceSource: RadarLocationSource = isEntry ? .geofenceEnter : .geofenceExit
+
+        if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) || identifier.hasPrefix(syncBeaconIdentifierPrefix) {
+            guard let location, let beaconRegion = region as? CLBeaconRegion else {
+                return
+            }
+
+            let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
+            runOnMainThread { [stateBox] in
+                let beaconManager = RadarBeaconManagerSwift.shared
+                let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
+                    RadarSwift.bridge?.handleLocation(
+                        stateBox.location,
+                        source: beaconSource,
+                        beacons: nearbyBeacons
+                    )
+                }
+
+                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                    if isEntry {
+                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
+                    } else {
+                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
+                    }
+                } else if isEntry {
+                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
+                }
+            }
+        } else if let location = locationManager.location {
+            RadarSwift.bridge?.handleLocation(location, source: geofenceSource)
+        }
+    }
+
     @MainActor
     @objc(didDetermineState:region:completionHandler:)
     static func didDetermineState(

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -106,31 +106,70 @@ extension RadarLocationManagerSwift {
                 return
             }
 
-            let stateBox = RadarBeaconRegionStateBox(location: location, region: beaconRegion)
-            runOnMainThread { [stateBox] in
-                let beaconManager = RadarBeaconManagerSwift.shared
-                let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
-                    RadarSwift.bridge?.handleLocation(
-                        stateBox.location,
-                        source: beaconSource,
-                        beacons: nearbyBeacons
-                    )
-                }
-
-                if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
-                    if isEntry {
-                        beaconManager.handleBeaconUUIDEntry(for: stateBox.region, completionHandler: completionHandler)
-                    } else {
-                        beaconManager.handleBeaconUUIDExit(for: stateBox.region, completionHandler: completionHandler)
-                    }
-                } else if isEntry {
-                    beaconManager.handleBeaconEntry(for: stateBox.region, completionHandler: completionHandler)
-                } else {
-                    beaconManager.handleBeaconExit(for: stateBox.region, completionHandler: completionHandler)
-                }
-            }
+            handleBeaconRegion(
+                location: location,
+                identifier: identifier,
+                region: beaconRegion,
+                source: beaconSource,
+                isEntry: isEntry
+            )
         } else if let location = locationManager.location {
             RadarSwift.bridge?.handleLocation(location, source: geofenceSource)
+        }
+    }
+
+    private static func handleBeaconRegion(
+        location: CLLocation,
+        identifier: String,
+        region: CLBeaconRegion,
+        source: RadarLocationSource,
+        isEntry: Bool
+    ) {
+        let beaconUUID = region.uuid
+        let beaconMajor = region.major?.uint16Value
+        let beaconMinor = region.minor?.uint16Value
+
+        Task { @MainActor in
+            let beaconManager = RadarBeaconManagerSwift.shared
+            let completionHandler: RadarBeaconCompletionHandler = { _, nearbyBeacons in
+                RadarSwift.bridge?.handleLocation(
+                    location,
+                    source: source,
+                    beacons: nearbyBeacons
+                )
+            }
+
+            if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
+                if isEntry {
+                    beaconManager.handleBeaconUUIDEntry(completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconUUIDExit(completionHandler: completionHandler)
+                }
+            } else {
+                let beaconRegion: CLBeaconRegion
+                if let beaconMajor, let beaconMinor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        minor: beaconMinor,
+                        identifier: identifier
+                    )
+                } else if let beaconMajor {
+                    beaconRegion = CLBeaconRegion(
+                        uuid: beaconUUID,
+                        major: beaconMajor,
+                        identifier: identifier
+                    )
+                } else {
+                    beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
+                }
+
+                if isEntry {
+                    beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
+                } else {
+                    beaconManager.handleBeaconExit(for: beaconRegion, completionHandler: completionHandler)
+                }
+            }
         }
     }
 

--- a/RadarSDK/RadarLocationManager+SwiftDelegate.swift
+++ b/RadarSDK/RadarLocationManager+SwiftDelegate.swift
@@ -139,31 +139,31 @@ extension RadarLocationManagerSwift {
                 )
             }
 
+            let beaconRegion: CLBeaconRegion
+            if let beaconMajor, let beaconMinor {
+                beaconRegion = CLBeaconRegion(
+                    uuid: beaconUUID,
+                    major: beaconMajor,
+                    minor: beaconMinor,
+                    identifier: identifier
+                )
+            } else if let beaconMajor {
+                beaconRegion = CLBeaconRegion(
+                    uuid: beaconUUID,
+                    major: beaconMajor,
+                    identifier: identifier
+                )
+            } else {
+                beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
+            }
+
             if identifier.hasPrefix(syncBeaconUUIDIdentifierPrefix) {
                 if isEntry {
-                    beaconManager.handleBeaconUUIDEntry(completionHandler: completionHandler)
+                    beaconManager.handleBeaconUUIDEntry(for: beaconRegion, completionHandler: completionHandler)
                 } else {
-                    beaconManager.handleBeaconUUIDExit(completionHandler: completionHandler)
+                    beaconManager.handleBeaconUUIDExit(for: beaconRegion, completionHandler: completionHandler)
                 }
             } else {
-                let beaconRegion: CLBeaconRegion
-                if let beaconMajor, let beaconMinor {
-                    beaconRegion = CLBeaconRegion(
-                        uuid: beaconUUID,
-                        major: beaconMajor,
-                        minor: beaconMinor,
-                        identifier: identifier
-                    )
-                } else if let beaconMajor {
-                    beaconRegion = CLBeaconRegion(
-                        uuid: beaconUUID,
-                        major: beaconMajor,
-                        identifier: identifier
-                    )
-                } else {
-                    beaconRegion = CLBeaconRegion(uuid: beaconUUID, identifier: identifier)
-                }
-
                 if isEntry {
                     beaconManager.handleBeaconEntry(for: beaconRegion, completionHandler: completionHandler)
                 } else {

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1394,6 +1394,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 
 - (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
     if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didEnterRegionOnLocationManager:manager region:region];
+        return;
+    }
+
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
         if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"entry"]) {
             return;
         }
@@ -1441,6 +1446,11 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
+        [RadarLocationManagerSwift didExitRegionOnLocationManager:manager region:region];
+        return;
+    }
+
     if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
         if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"exit"]) {
             return;

--- a/RadarSDK/RadarLocationManager.m
+++ b/RadarSDK/RadarLocationManager.m
@@ -1398,29 +1398,21 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         return;
     }
 
-    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"entry"]) {
-            return;
-        }
-    } else {
-        if (![region.identifier hasPrefix:kIdentifierPrefix]) {
-            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region entry: wrong prefix"];
+    if (![region.identifier hasPrefix:kIdentifierPrefix]) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region entry: wrong prefix"];
 
-            return;
-        }
+        return;
+    }
 
-        BOOL tracking = [RadarSettings tracking];
-        if (!tracking) {
-            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region entry: not tracking"];
+    BOOL tracking = [RadarSettings tracking];
+    if (!tracking) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region entry: not tracking"];
 
-            return;
-        }
+        return;
     }
 
     CLLocation *location;
-    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        location = [RadarLocationManagerSwift effectiveLocationForLocationManager:manager];
-    } else if (manager.location.isValid) {
+    if (manager.location.isValid) {
         location = manager.location;
     } else {
         location = [RadarState lastLocation];
@@ -1451,29 +1443,21 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
         return;
     }
 
-    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        if (![RadarLocationManagerSwift shouldHandleRegionWithIdentifier:region.identifier action:@"exit"]) {
-            return;
-        }
-    } else {
-        if (![region.identifier hasPrefix:kIdentifierPrefix]) {
-            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region exit: wrong prefix"];
+    if (![region.identifier hasPrefix:kIdentifierPrefix]) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region exit: wrong prefix"];
 
-            return;
-        }
+        return;
+    }
 
-        BOOL tracking = [RadarSettings tracking];
-        if (!tracking) {
-            [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region exit: not tracking"];
+    BOOL tracking = [RadarSettings tracking];
+    if (!tracking) {
+        [[RadarLogger sharedInstance] logWithLevel:RadarLogLevelDebug message:@"Ignoring region exit: not tracking"];
 
-            return;
-        }
+        return;
     }
 
     CLLocation *location;
-    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        location = [RadarLocationManagerSwift effectiveLocationForLocationManager:manager];
-    } else if (manager.location.isValid) {
+    if (manager.location.isValid) {
         location = manager.location;
     } else {
         location = [RadarState lastLocation];
@@ -1522,9 +1506,7 @@ static NSString *const kSyncBeaconUUIDIdentifierPrefix = @"radar_uuid_";
     }
 
     CLLocation *location;
-    if ([RadarSettings sdkConfiguration].useSwiftLocationManager) {
-        location = [RadarLocationManagerSwift effectiveLocationForLocationManager:manager];
-    } else if (manager.location.isValid) {
+    if (manager.location.isValid) {
         location = manager.location;
     } else {
         location = [RadarState lastLocation];

--- a/RadarSDK/RadarLocationManagerSwift.h
+++ b/RadarSDK/RadarLocationManagerSwift.h
@@ -76,6 +76,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)didUpdateLocations:(nullable NSArray<CLLocation *> *)updates completionHandlerCount:(NSUInteger)completionHandlerCount;
 + (void)didVisitOnLocationManager:(CLLocationManager *)locationManager visit:(CLVisit *)visit;
++ (void)didEnterRegionOnLocationManager:(CLLocationManager *)locationManager
+                                 region:(CLRegion *)region;
++ (void)didExitRegionOnLocationManager:(CLLocationManager *)locationManager
+                                region:(CLRegion *)region;
+
 + (void)didDetermineState:(CLRegionState)state
                    region:(CLRegion *)region
         completionHandler:(RadarBeaconCompletionHandler)completionHandler;

--- a/RadarSDK/RadarSwiftBridge.h
+++ b/RadarSDK/RadarSwiftBridge.h
@@ -39,6 +39,9 @@
 - (void)didReceiveEvents:(NSArray<RadarEvent *> * _Nonnull)events user:(RadarUser * _Nonnull)user;
 - (void)didUpdateClientLocation:(CLLocation * _Nonnull)location stopped:(BOOL)stopped source:(RadarLocationSource)source;
 - (void)handleLocation:(CLLocation * _Nonnull)location source:(RadarLocationSource)source;
+- (void)handleLocation:(CLLocation * _Nonnull)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> * _Nullable)beacons;
 - (void)updateTracking;
 - (void)didFailWithStatus:(RadarStatus)status;
 - (RadarBeacon * _Nonnull)createBeaconWithUuid:(NSString * _Nonnull)uuid major:(NSString * _Nonnull)major minor:(NSString * _Nonnull)minor rssi:(NSInteger)rssi;

--- a/RadarSDK/RadarSwiftBridge.m
+++ b/RadarSDK/RadarSwiftBridge.m
@@ -19,6 +19,12 @@
 #import "RadarIndoors.h"
 #import "RadarLocationManager.h"
 
+@interface RadarLocationManager (SwiftBeaconLocation)
+- (void)handleLocation:(CLLocation *)location
+                source:(RadarLocationSource)source
+               beacons:(NSArray<RadarBeacon *> *)beacons;
+@end
+
 @implementation RadarSwiftBridge
 
 - (void)flushReplays {
@@ -98,6 +104,10 @@
 
 - (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source {
     [[RadarLocationManager sharedInstance] handleLocation:location source:source];
+}
+
+- (void)handleLocation:(CLLocation *)location source:(RadarLocationSource)source beacons:(NSArray<RadarBeacon *> *)beacons {
+    [[RadarLocationManager sharedInstance] handleLocation:location source:source beacons:beacons];
 }
 
 - (RadarUser * _Nullable)radarUser {

--- a/RadarSDK/RadarSwiftBridge.swift
+++ b/RadarSDK/RadarSwiftBridge.swift
@@ -31,6 +31,7 @@ protocol RadarSwiftBridgeProtocol {
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser)
     func didUpdateClientLocation(_ location: CLLocation, stopped: Bool, source: RadarLocationSource)
     func handleLocation(_ location: CLLocation, source: RadarLocationSource)
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?)
     func updateTracking()
     func radarUser() -> RadarUser?
     func didFail(status: RadarStatus)

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -71,9 +71,15 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     }
     private(set) var lastHandledLocation: CLLocation?
     private(set) var lastHandledSource: RadarLocationSource?
+    private(set) var lastHandledBeacons: [RadarBeacon]?
     func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
         lastHandledLocation = location
         lastHandledSource = source
+    }
+    func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?) {
+        lastHandledLocation = location
+        lastHandledSource = source
+        lastHandledBeacons = beacons
     }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?

--- a/RadarSDKTests/MockRadarSwiftBridge.swift
+++ b/RadarSDKTests/MockRadarSwiftBridge.swift
@@ -72,14 +72,19 @@ final class MockRadarSwiftBridge: NSObject, RadarSwiftBridgeProtocol, @unchecked
     private(set) var lastHandledLocation: CLLocation?
     private(set) var lastHandledSource: RadarLocationSource?
     private(set) var lastHandledBeacons: [RadarBeacon]?
+    var onHandledLocation: (() -> Void)?
+
     func handleLocation(_ location: CLLocation, source: RadarLocationSource) {
         lastHandledLocation = location
         lastHandledSource = source
+        onHandledLocation?()
     }
+
     func handleLocation(_ location: CLLocation, source: RadarLocationSource, beacons: [RadarBeacon]?) {
         lastHandledLocation = location
         lastHandledSource = source
         lastHandledBeacons = beacons
+        onHandledLocation?()
     }
     func radarUser() -> RadarUser? { nil }
     private(set) var lastFailStatus: RadarStatus?

--- a/RadarSDKTests/RadarLocationManagerSwiftBeaconStateTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftBeaconStateTests.swift
@@ -134,6 +134,23 @@ extension RadarSerializedTests {
             }
         }
 
+        @Test("didDetermineState treats an unknown state as a beacon exit")
+        func treatsUnknownStateAsBeaconExit() {
+            withBeaconDependencies {
+                let region = makeRegion(identifier: "radar_beacon_unknown_state_test")
+                var exitStatus: RadarStatus?
+                beaconManager.nearbyBeaconIdentifiers.insert(region.identifier)
+
+                RadarLocationManagerSwift.didDetermineState(.unknown, region: region) { status, beacons in
+                    exitStatus = status
+                    #expect(beacons?.isEmpty == true)
+                }
+
+                #expect(exitStatus == .success)
+                #expect(!beaconManager.nearbyBeaconIdentifiers.contains(region.identifier))
+            }
+        }
+
         @Test("Public didDetermineState uses the Swift path when enabled")
         func publicMethodUsesSwiftPath() {
             withBeaconDependencies {

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -552,3 +552,152 @@ extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
         #expect(bridge.lastFailStatus == nil)
     }
 }
+
+extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
+    // MARK: - didEnterRegion and didExitRegion
+
+    @Test("region callbacks handle synced beacon entry and exit with nearby beacons")
+    @MainActor
+    func regionCallbacksHandleSyncedBeaconEntryAndExit() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useRadarModifiedBeacon": false
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLBeaconRegion(
+            uuid: UUID(),
+            identifier: "radar_beacon_\(UUID().uuidString)"
+        )
+
+        RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconEnter)
+        #expect(bridge.lastHandledBeacons?.isEmpty == false)
+
+        RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .beaconExit)
+    }
+
+    @Test("region callbacks use the current location for geofence entry and exit")
+    @MainActor
+    func regionCallbacksHandleGeofenceEntryAndExit() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceEnter)
+
+        RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceExit)
+    }
+}
+
+extension RadarSerializedTests.RadarLocationManagerSwiftSeamTests {
+    @Test("Public region callbacks route to the Swift twins when enabled")
+    @MainActor
+    func publicRegionCallbacksRouteToSwiftTwinsWhenFlagEnabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalLocationManager = manager.locationManager
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.locationManager = originalLocationManager
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": true
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        manager.locationManager = locationManager
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        manager.locationManager(locationManager, didEnterRegion: region)
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceEnter)
+
+        manager.locationManager(locationManager, didExitRegion: region)
+        #expect(bridge.lastHandledLocation === location)
+        #expect(bridge.lastHandledSource == .geofenceExit)
+    }
+
+    @Test("Public region callbacks keep the Objective-C body when disabled")
+    @MainActor
+    func publicRegionCallbacksUseObjCBodyWhenFlagDisabled() {
+        RadarLocationManagerSwiftTestHelpers.clearState()
+        let bridge = MockRadarSwiftBridge()
+        let originalBridge = RadarSwift.bridge
+        let manager = RadarLocationManager.sharedInstance()
+        let originalLocationManager = manager.locationManager
+        RadarSwift.bridge = bridge
+        defer {
+            RadarSwift.bridge = originalBridge
+            manager.locationManager = originalLocationManager
+            RadarLocationManagerSwiftTestHelpers.clearState()
+        }
+
+        RadarSettings.sdkConfiguration = RadarSdkConfiguration(dict: [
+            "useSwiftLocationManager": false
+        ])
+        RadarSettings.tracking = true
+        let locationManager = TrackingCLLocationManager()
+        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        locationManager.mockLocation = location
+        manager.locationManager = locationManager
+        let region = CLCircularRegion(
+            center: location.coordinate,
+            radius: 100,
+            identifier: "radar_geofence_\(UUID().uuidString)"
+        )
+
+        manager.locationManager(locationManager, didEnterRegion: region)
+        manager.locationManager(locationManager, didExitRegion: region)
+
+        #expect(bridge.lastHandledLocation == nil)
+        #expect(bridge.lastHandledSource == nil)
+    }
+}

--- a/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
+++ b/RadarSDKTests/RadarLocationManagerSwiftLifecycleTests.swift
@@ -558,7 +558,7 @@ extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
 
     @Test("region callbacks handle synced beacon entry and exit with nearby beacons")
     @MainActor
-    func regionCallbacksHandleSyncedBeaconEntryAndExit() {
+    func regionCallbacksHandleSyncedBeaconEntryAndExit() async {
         RadarLocationManagerSwiftTestHelpers.clearState()
         let bridge = MockRadarSwiftBridge()
         let originalBridge = RadarSwift.bridge
@@ -572,21 +572,37 @@ extension RadarSerializedTests.RadarLocationManagerSwiftLifecycleTests {
             "useRadarModifiedBeacon": false
         ])
         RadarSettings.tracking = true
+        let beaconManager = RadarBeaconManagerSwift.shared
+        beaconManager.stopRanging()
         let locationManager = TrackingCLLocationManager()
-        let location = CLLocation(latitude: 40.7, longitude: -74.0)
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0),
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            timestamp: Date()
+        )
         locationManager.mockLocation = location
         let region = CLBeaconRegion(
             uuid: UUID(),
             identifier: "radar_beacon_\(UUID().uuidString)"
         )
 
-        RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            bridge.onHandledLocation = { continuation.resume() }
+            RadarLocationManagerSwift.didEnterRegion(locationManager: locationManager, region: region)
+        }
+        bridge.onHandledLocation = nil
 
         #expect(bridge.lastHandledLocation === location)
         #expect(bridge.lastHandledSource == .beaconEnter)
         #expect(bridge.lastHandledBeacons?.isEmpty == false)
 
-        RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            bridge.onHandledLocation = { continuation.resume() }
+            RadarLocationManagerSwift.didExitRegion(locationManager: locationManager, region: region)
+        }
+        bridge.onHandledLocation = nil
 
         #expect(bridge.lastHandledLocation === location)
         #expect(bridge.lastHandledSource == .beaconExit)


### PR DESCRIPTION
## Summary

- Port the Core Location region-entry and region-exit delegate callbacks to Swift.
- Preserve geofence and beacon event sources, effective-location fallback behavior, and nearby-beacon payloads.
- Route through Swift only when `useSwiftLocationManager` is enabled and keep the Objective-C implementations as fallbacks.

## Test Plan

1. In the Radar dashboard, create a geofence around your physical test location and configure an enabled synced iBeacon that matches a physical beacon.
2. Build and launch the Example app on a physical iPhone, then grant location and Bluetooth permissions.
3. Start tracking and confirm the geofence and synced beacon region appear in the app's Debug information.
4. Move into and out of the configured geofence and confirm the Debug tab records geofence-enter and geofence-exit handling.
5. Move into and out of the beacon's range and confirm the Debug tab records beacon-enter and beacon-exit handling.
6. Repeat the previous steps with `useSwiftLocationManager` disabled and confirm the Objective-C fallback produces equivalent behavior.
